### PR TITLE
Fix polygon height so polygons are drawn at the same height as the corresponding billboards

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/view/cesium.metacard.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/view/cesium.metacard.js
@@ -429,7 +429,10 @@ define([
 
             getPolygonOutline: function(positions) {
                 return new Cesium.GeometryInstance({
-                    geometry: Cesium.PolygonOutlineGeometry.fromPositions({positions: positions}),
+                    geometry: Cesium.PolygonOutlineGeometry.fromPositions({
+                        positions: positions,
+                        perPositionHeight: true
+                    }),
                     attributes: {
                         color: Cesium.ColorGeometryInstanceAttribute.fromColor(this.outlineColor),
                         show : new Cesium.ShowGeometryInstanceAttribute(true)
@@ -442,7 +445,8 @@ define([
                 return new Cesium.GeometryInstance({
                     geometry: Cesium.PolygonGeometry.fromPositions({
                         positions: positions,
-                        vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT
+                        vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                        perPositionHeight: true
                     }),
                     attributes: {
                         color: Cesium.ColorGeometryInstanceAttribute.fromColor(this.polygonColor),


### PR DESCRIPTION
#### What does this PR do?

Fixes polygons' draw height in Cesium so polygons are drawn at the same height as the corresponding billboards.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@djblue 
@andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@jlcsmith 
#### How should this be tested?

Ingest some metacards/products with geospatial data, search for them on the 3d map, and verify that all polygons are drawn at the same height as their corresponding billboards.
#### Screenshots (if appropriate)

![screen shot 2016-07-19 at 3 48 33 pm](https://cloud.githubusercontent.com/assets/4495447/16969246/4d0804b2-4dc8-11e6-8532-b87a9b554a02.jpg)
#### Checklist:
- [] Documentation Updated
- [] Update / Add Unit Tests
- [] Update / Add Integration Tests
