### PR TITLE
Corrected blueprint to inject XmlInputTransformer

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/WorkspaceTransformer.java
@@ -189,7 +189,7 @@ public class WorkspaceTransformer {
                 }
             }
         } catch (Exception ex) {
-            // TODO (RCZ) - wat do here
+            // TODO (RCZ) - just throw?
             throw new RuntimeException(ex);
         }
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -86,7 +86,7 @@
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
     <reference id="inputTransformer" interface="ddf.catalog.transform.InputTransformer"
-               filter="(|(mime-type=application/xml)(mime-type=text/xml))"/>
+               filter="(id=xml)"/>
 
     <reference-list id="metacardActionProviders" interface="ddf.action.ActionProvider"
                     filter="(id=catalog.data.metacard.*)"/>


### PR DESCRIPTION
#### What does this PR do?

In cases where there are multiple InputTransformers registered as mime-type=text/xml, the wrong input transformer could get injected causing errors loading workspaces.  This change explicitly injects the XmlInputTransformer (id=xml). 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@rzwiefel @andrewkfiedler @bdeining 
#### How should this be tested?
- Install the catalog ui on top of the alliance distribution (which has its own InputTransformer with mime-type=xml).
- Save a workspace with a query
- re-load the Catalog UI and verify the workspace is properly loaded
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
