### PR TITLE
Limit Results to Selected Sources when Querying the "Cache" Source

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.hbs
@@ -18,11 +18,6 @@
     </div>
     <div class="resultSelector-menu-action menu-resultDisplay">
     </div>
-    <div class="resultSelector-menu-action">
-        <span class="fa fa-cog">
-
-        </span>
-    </div>
 </div>
 <div class="resultSelector-status">
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/CacheSourceSelector.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/CacheSourceSelector.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+define([
+        'js/cql',
+        'js/CQLUtils'
+
+], function (cql, CQLUtils) {
+
+    function buildCacheSourcesCql(sources){
+        return {
+            type: 'OR',
+            filters:
+                sources.filter(function(source) {
+                    return source !== 'cache'
+                })
+                .map(function(source) {
+                    return {
+                        property: '"metacard_source"',
+                        type: "=",
+                        value: source
+                    };
+                })
+        };
+    }
+
+    function limitCacheSources(cql, sources) {
+        return {
+            type: 'AND',
+            filters: [cql, buildCacheSourcesCql(sources)]
+        };
+    }
+
+    return {
+        trimCacheSources: function(cqlString, sources) {
+            return CQLUtils.sanitizeGeometryCql(
+                "(" +
+                 cql.write(
+                    limitCacheSources(
+                        cql.simplify(
+                            cql.read(
+                                cqlString
+                            )
+                        ),
+                        sources
+                    )
+                ) +
+                ")"
+            );
+        }
+    };
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -23,9 +23,10 @@ define([
         'usngs',
         'wreqr',
         'js/Common',
+        'js/CacheSourceSelector',
         'backboneassociations'
     ],
-    function (Backbone, _, properties, moment, cql, wellknown, Metacard, Sources, usngs, wreqr, Common) {
+    function (Backbone, _, properties, moment, cql, wellknown, Metacard, Sources, usngs, wreqr, Common, CacheSourceSelector) {
         "use strict";
         var Query = {};
 
@@ -620,9 +621,19 @@ define([
                 result.set('initiated', moment().format('lll'));
                 result.get('results').fullCollection.sort();
 
+                // the "cache" source is always added to the search
                 sources.unshift("cache");
+                   
+                var cqlString = data.cql;
                 this.currentSearches = sources.map(function (src) {
                     data.src = src;
+
+                    // since the "cache" source will return all cached results, need to
+                    // limit the cached results to only those from a selected source
+                    data.cql = (src === 'cache') ?
+                        CacheSourceSelector.trimCacheSources(cqlString, sources) :
+                        cqlString;
+
                     return result.fetch({
                         data: JSON.stringify(data),
                         remove: false,


### PR DESCRIPTION
#### What does this PR do?

Previous behavior was that results were being returned from the "cache" source for federated sources that are not selected in the query. This PR limits the "cache" query results to only those where `metacard_source` matches sources selected by the user. 

A special query is generated specifically for the "cache" source, where the CQL may look something like this: 
`"(("anyText" ILIKE '%') AND (("metacard_source" = 'CSW UK') OR ("metacard_source" = 'ddf.distribution') OR ("metacard_source" = 'GeoServer')))"`
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler @pklinef @bdeining 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef 
@jlcsmith 
#### How should this be tested?

Configure multiple sources. Ensure cached results from unselected sources are not returned.
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
