### PR TITLE
Updated standing query to use metacard.created and metacard.modified dates

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/QueryPolling.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/QueryPolling.js
@@ -61,6 +61,36 @@ define([
                             value: then
                         }
                     ]
+                },
+                {
+                    type: 'AND',
+                    filters: [
+                        {
+                            property: '"metacard.created"',
+                            type: 'BEFORE',
+                            value: now
+                        },
+                        {
+                            property: '"metacard.created"',
+                            type: 'AFTER',
+                            value: then
+                        }
+                    ]
+                },
+                {
+                    type: 'AND',
+                    filters: [
+                        {
+                            property: '"metacard.modified"',
+                            type: 'BEFORE',
+                            value: now
+                        },
+                        {
+                            property: '"metacard.modified"',
+                            type: 'AFTER',
+                            value: then
+                        }
+                    ]
                 }
             ]
         };


### PR DESCRIPTION
#### What does this PR do?

The Catalog UI standing search capability adds a filter to the search when executed based on the `modified` and `created` dates on the metacard. The intention is to only find results that have been modified since the last run of the search. The filter has been updated to look for `metacard.created` and `metacard.modified` dates in addition to the `created` and `modified` dates. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining @andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith @andrewkfiedler 
#### How should this be tested?

Create a standing query. Ingest something that has an existing (old) `created` date. Verify the standing query results return the recently ingested item. 
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
