### PR TITLE
Removed filters in metacard details view, and added default hidden attributes

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -61,6 +61,16 @@
                 <value>86400</value>
             </list>
         </property>
+        <property name="hiddenAttributes">
+            <list>
+                <value>metacard.modified</value>
+                <value>metacard.created</value>
+                <value>metacard.owner</value>
+                <value>metacard-tags</value>
+                <value>validation-errors</value>
+                <value>validation-warnings</value>
+            </list>
+        </property>
     </bean>
 
     <service interface="ddf.catalog.data.MetacardType">

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -147,6 +147,7 @@
             description="List of attributes to be hidden in the UI."
             type="String"
             cardinality="10000"
+            default="metacard.modified,metacard.created,metacard-tags,metacard.owner,validation-errors,validation-warnings"
             required="false"/>
 
         <AD id="scheduleFrequencyList"

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
@@ -209,9 +209,6 @@ define([
             propertyIntersection = _.intersection.apply(_, propertyIntersection);
             propertyIntersection = propertyIntersection.filter(function(property) {
                 return (!properties.isHidden(property)
-                && property.indexOf('metacard') === -1
-                && property.indexOf('metadata') === -1
-                && property.indexOf('validation') === -1
                 && self.blacklist.indexOf(property) === -1
                 && self.hiddenTypes.indexOf(types[0][property].format) === -1
                 && self.bulkHiddenTypes.indexOf(types[0][property].format) === -1);


### PR DESCRIPTION
#### What does this PR do?

This PR removes the metadata filter from the metacard view
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler @lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
#### How should this be tested?

Build DDF, ingest content that has an attribute with `metadata` in the name, and observe it showing in the Metacard Details view.  The `metadata` attribute should still be excluded (as well as xml and object attributes).
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
