### PR TITLE
Catalog UI bundle shutdown, startup cleanly. Resolved ConcurrentModificationException

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -392,10 +393,11 @@ public class ConfigurationApplication implements SparkApplication {
     }
 
     private void stopImageryEndpoints(List<String> imageryEndpointsToStop) {
-        for (String endpoint : imageryEndpointsToStop) {
+        for (Iterator<String> iterator = imageryEndpointsToStop.iterator(); iterator.hasNext(); ) {
+            String endpoint = iterator.next();
             try {
                 httpProxy.stop(endpoint);
-                imageryEndpoints.remove(endpoint);
+                iterator.remove();
             } catch (Exception e) {
                 LOGGER.error("Unable to stop proxy endpoint: {}", endpoint, e);
             }


### PR DESCRIPTION
#### What does this PR do?

When shutting down the Catalog UI bundle, the operation would fail with a ConcurrentModificationException due to attempting to remove an item from a collection while simultaneously iterating over the same collection. This PR safely removes the item from the collection while iterating. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining @rzwiefel @djblue 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith 
@stustison
#### How should this be tested?

Build and run DDF. Stop the Catalog UI application using the Admin Console. No ConcurrentModificationException errors should occur, and the application should stop successfully. Re-start the Catalog UI application. 
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
