### PR TITLE
Fixed "Archive items(s)" typo

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-archive/metacard-archive.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/metacard-archive/metacard-archive.hbs
@@ -14,6 +14,6 @@
 <button class="is-negative" data-help="This will remove the item(s) from standard search results.
 To restore archived items, you can click on 'File' in the toolbar,
 and then click 'Restore Archived Items'.">
-    <span class="mainText">Archive items(s)</span>
+    <span class="mainText">Archive item(s)</span>
     <span class="subText">WARNING: This will remove the item(s) from standard search results.</span>
 </button>


### PR DESCRIPTION
#### What does this PR do?

Fixes a typo in the Archive button label.

<img width="1284" alt="screen shot 2016-10-13 at 9 52 32 pm" src="https://cloud.githubusercontent.com/assets/16792154/19375249/71bc433a-918f-11e6-92be-a415596d8c2a.png">
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler @bdeining 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@andrewkfiedler 
