### PR TITLE
Removed Result Preview Attributes when they are not set

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
@@ -121,11 +121,11 @@ define([
                                 }
                                 break;
                         }
+                        result.customDetail.push({
+                            label: additionProperty,
+                            value: value
+                        });
                     }
-                    result.customDetail.push({
-                        label: additionProperty,
-                        value: value ? value : 'NA'
-                    });
                 });
             }
             return result;


### PR DESCRIPTION
#### What does this PR do?
This PR removes preview attributes that are not set from the results view
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@andrewkfiedler  @rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith @kcwire 

#### How should this be tested?
Build / Install / Set an attribute in the config for preview results / Observe
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

