### PR TITLE
Updated workspace policy to allow metacard owners access permissions

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPlugin.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspaceSharingPolicyPlugin.java
@@ -130,7 +130,7 @@ public class WorkspaceSharingPolicyPlugin implements PolicyPlugin {
     @Override
     public PolicyResponse processPreDelete(List<Metacard> metacards,
             Map<String, Serializable> properties) throws StopProcessingException {
-        return new PolicyResponseImpl(Collections.emptyMap(), getPolicy(metacards));
+        return new PolicyResponseImpl(getPolicy(metacards), getPolicy(metacards));
     }
 
     @Override


### PR DESCRIPTION
#### What does this PR do?
Workspace owners are allowed CRUD permissions.  This is an override to the current policy.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler
@djblue
@pklinef
@rzwiefel
@bdeining 
@kcwire 

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

