### PR TITLE
Fixed catalog-search-ui shutdown

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,8 @@
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint" id="uiCamelContext"/>
 
-    <bean id="servlet" class="org.codice.proxy.http.HttpProxyCamelHttpTransportServlet">
+    <bean id="servlet" class="org.codice.proxy.http.HttpProxyCamelHttpTransportServlet"
+          init-method="init" destroy-method="destroy">
         <argument ref="uiCamelContext"/>
     </bean>
 


### PR DESCRIPTION
#### What does this PR do?
This PR correctly shuts down the HttpProxyCamelHttpTransportServlet and thus the Catalog UI
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@lcrosenbu 
@jlcsmith 
@andrewkfiedler
@rzwiefel

#### How should this be tested?
Build / Install / Shutdown Catalog UI / Observe Success
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

