### PR TITLE
bump gt-cql version number

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-cql</artifactId>
-            <version>13.0</version>
+            <version>14.4</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jai_core</artifactId>


### PR DESCRIPTION
#### What does this PR do?

Bump the gt-cql version number from 13.0 to 14.4. This fixes a bug in the cql library that converts "-1" in query strings to a String instead of a Long.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@bdeining 
@pklinef 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[UI](https://github.com/orgs/codice/teams/ui)
@andrewkfiedler 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@kcwire
#### How should this be tested? (List steps with links to updated documentation)
* Build and install. 
* Add the following JSON to etc/definitions at the filename integer-inject.json:

```{
  "attributeTypes": {
    "integer1": {
      "type": "INTEGER_TYPE",
      "stored": true,
      "indexed": true,
      "tokenized": false,
      "multivalued": false
    }
  },
  "defaults": [
    {
      "attribute": "integer1",
      "value": 100
    }
  ],
  "inject": [
    {
      "attribute": "integer1"
    }
  ]
}
```
* Upload any content.
* In a new workspace, create the query "integer1 > -1".
* Run the query.
* Verify the query results lists the content previously uploaded.


#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
