### PR TITLE
Fixed dropdowns not opening on Microsoft Edge

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/dropdown/dropdown.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/dropdown/dropdown.js
@@ -227,9 +227,10 @@ class Dropdown extends React.Component {
     }
   }
   getRect = () => {
-    const { x, y, width, height } =
-      this.ref !== undefined ? this.ref.getBoundingClientRect() : {}
-    return { rect: { x, y, width, height } }
+    const obj = this.ref !== undefined ? this.ref.getBoundingClientRect() : {}
+    return {
+      rect: { x: obj.left, y: obj.top, width: obj.width, height: obj.height },
+    }
   }
   componentDidMount() {
     document.addEventListener('mousedown', this.onMouseDown)


### PR DESCRIPTION
#### What does this PR do?
Fixes dropdowns on Microsoft Edge versions <= 44.18362.449.0
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@djblue 
#### How should this be tested?
Open the UI on an affected version of Microsoft Edge and verify that dropdowns open when you click them (i.e. pan/zoom dropdown on map, location mode selection on anyGeo search) 
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #63 
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
