### PR TITLE
DDF-5714 Add admin configurable icon definitions

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -82,6 +82,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private String format;
 
+  private Map<String, Map<String, String>> iconConfig = new HashMap<>();
+
   private List imageryProviders = new ArrayList<>();
 
   private List defaultLayout = new ArrayList<>();
@@ -547,6 +549,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("isExperimental", experimentalEnabled);
     config.put("autoMergeTime", autoMergeTime);
     config.put("webSocketsEnabled", webSocketsEnabled);
+    config.put("iconConfig", iconConfig);
     config.put("mapHome", mapHome);
     config.put("product", uiName);
     config.put("showRelevanceScores", relevanceScoresEnabled);
@@ -824,6 +827,24 @@ public class ConfigurationApplication implements SparkApplication {
     }
 
     return config;
+  }
+
+  public void setIconConfig(List<String> icons) {
+    Map<String, Map<String, String>> iconMap = new HashMap<>();
+
+    icons.forEach(
+        icon -> {
+          String key = icon.split("=")[0];
+          String[] config = icon.split("=")[1].split(",");
+          Map<String, String> tempMap = new HashMap<>();
+          tempMap.put("className", config[0]);
+          tempMap.put("code", config[1]);
+          tempMap.put("font", config[2]);
+          tempMap.put("size", config[3]);
+          iconMap.put(key, tempMap);
+        });
+
+    this.iconConfig = iconMap;
   }
 
   private Map<String, String> parseAttributeAndValuePairs(List<String> pairs) {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -836,12 +836,16 @@ public class ConfigurationApplication implements SparkApplication {
         icon -> {
           String key = icon.split("=")[0];
           String[] config = icon.split("=")[1].split(",");
-          Map<String, String> tempMap = new HashMap<>();
-          tempMap.put("className", config[0]);
-          tempMap.put("code", config[1]);
-          tempMap.put("font", config[2]);
-          tempMap.put("size", config[3]);
-          iconMap.put(key, tempMap);
+          if (config.length != 4) {
+            LOGGER.debug("Icon Configuration entry [{}] malformed, discarding.", icon);
+          } else {
+            Map<String, String> tempMap = new HashMap<>();
+            tempMap.put("className", config[0]);
+            tempMap.put("code", config[1]);
+            tempMap.put("font", config[2]);
+            tempMap.put("size", config[3]);
+            iconMap.put(key, tempMap);
+          }
         });
 
     this.iconConfig = iconMap;

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -266,6 +266,14 @@
             default="created,modified,thumbnail"
             required="false"/>
 
+        <AD id="iconConfig"
+            name="Icon Configuration"
+            description="List of icon configurations. Each entry is of the form [datatype]=[fa icon code],[unicode],[font],[size]"
+            type="String"
+            cardinality="10000"
+            default="default=fa fa-file\,f15b\,FontAwesome\,12px,interactive=fa fa-gamepad\,f11b\,FontAwesome\,12px,dataset=fa fa-database\,f1c0\,FontAwesome\,12px,video=fa fa-video-camera\,f03d\,FontAwesome\,12px,collection=fa fa-folder-open\,f1c0\,FontAwesome\,12px,event=fa fa-bolt\,f0e7\,FontAwesome\,12px,service=fa fa-globe\,f0ac\,FontAwesome\,12px,software=fa fa-terminal\,f120\,FontAwesome\,12px,sound=fa fa-music\,f001\,FontAwesome\,12px,text=fa fa-file-text\,f15c\,FontAwesome\,12px,document=fa fa-file\,f15b\,FontAwesome\,12px,image=fa fa-camera\,f030\,FontAwesome\,12px,track=fa fa-thumb-tack\,f08d\,FontAwesome\,12px"
+            required="false"/>
+
         <AD id="resultShow"
             name="Result Preview Metacard Attributes"
             description="List of metacard attributes to display in the result preview."

--- a/ui-backend/intrigue-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/ui-backend/intrigue-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -53,6 +53,21 @@ historicalSearchEnabled=B"true"
 archiveSearchEnabled=B"true"
 unknownErrorBoxEnabled=B"true"
 customTextNotationAttribute="title"
+iconConfig=[ \
+  "default\=fa\ fa-file,f15b,FontAwesome,12px", \
+  "interactive\=fa\ fa-gamepad,f11b,FontAwesome,12px", \
+  "dataset\=fa\ fa-database,f1c0,FontAwesome,12px", \
+  "video\=fa\ fa-video-camera,f03d,FontAwesome,12px", \
+  "collection\=fa\ fa-folder-open,f1c0,FontAwesome,12px", \
+  "event\=fa\ fa-bolt,f0e7,FontAwesome,12px", \
+  "service\=fa\ fa-globe,f0ac,FontAwesome,12px", \
+  "software\=fa\ fa-terminal,f120,FontAwesome,12px", \
+  "sound\=fa\ fa-music,f001,FontAwesome,12px", \
+  "text\=fa\ fa-file-text,f15c,FontAwesome,12px", \
+  "document\=fa\ fa-file,f15b,FontAwesome,12px", \
+  "image\=fa\ fa-camera,f030,FontAwesome,12px", \
+  "track\=fa\ fa-thumb-tack,f08d,FontAwesome,12px", \
+  ]
 basicSearchTemporalSelectionDefault=[ \
   "created", \
   "effective", \

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
@@ -13,112 +13,20 @@
  *
  **/
 const _get = require('lodash/get')
-const _map = {
-  default: {
-    class: 'fa fa-file',
-    style: {
-      code: 'f15b',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  interactive: {
-    class: 'fa fa-gamepad',
-    style: {
-      code: 'f11b',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  dataset: {
-    class: 'fa fa-database',
-    style: {
-      code: 'f1c0',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  video: {
-    class: 'fa fa-video-camera',
-    style: {
-      code: 'f03d',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  collection: {
-    class: 'fa fa-folder-open',
-    style: {
-      code: 'f07c',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  event: {
-    class: 'fa fa-bolt',
-    style: {
-      code: 'f0e7',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  service: {
-    class: 'fa fa-globe',
-    style: {
-      code: 'f0ac',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  software: {
-    class: 'fa fa-terminal',
-    style: {
-      code: 'f120',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  sound: {
-    class: 'fa fa-music',
-    style: {
-      code: 'f001',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  text: {
-    class: 'fa fa-file-text',
-    style: {
-      code: 'f15c',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  document: {
-    class: 'fa fa-file',
-    style: {
-      code: 'f15b',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  image: {
-    class: 'fa fa-camera',
-    style: {
-      code: 'f030',
-      font: 'FontAwesome',
-      size: '12px',
-    },
-  },
-  track: {
-    class: 'fa fa-thumb-tack',
-    style: {
-      code: 'f08d',
-      font: 'FontAwesome',
-      size: '15px',
-    },
-  },
-}
+const properties = require('../js/properties')
+
+const _map = Object.keys(properties.iconConfig).reduce(
+  (totalIconMap, iconConfigKey) => {
+    const iconProp = properties.iconConfig[iconConfigKey]
+    totalIconMap[iconConfigKey] = {
+      class: iconProp.className,
+      code: iconProp.code,
+      size: iconProp.size,
+      font: iconProp.font,
+    }
+    return totalIconMap
+  }
+, {})
 
 /* Maps top-level mime type category names to the closest icon. */
 const _mimeMap = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
@@ -25,8 +25,9 @@ const _map = Object.keys(properties.iconConfig).reduce(
       font: iconProp.font,
     }
     return totalIconMap
-  }
-, {})
+  },
+  {}
+)
 
 /* Maps top-level mime type category names to the closest icon. */
 const _mimeMap = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.js
@@ -20,9 +20,11 @@ const _map = Object.keys(properties.iconConfig).reduce(
     const iconProp = properties.iconConfig[iconConfigKey]
     totalIconMap[iconConfigKey] = {
       class: iconProp.className,
-      code: iconProp.code,
-      size: iconProp.size,
-      font: iconProp.font,
+      style: {
+        code: iconProp.code,
+        font: iconProp.font,
+        size: iconProp.size,
+      },
     }
     return totalIconMap
   },


### PR DESCRIPTION
DDF PR (4 Approvals) - https://github.com/codice/ddf/pull/5715

Example config for overriding:
```
iconConfig=[ \
  "default\=fa\ fa-file,f15b,FontAwesome,12px", \
  "interactive\=fa\ fa-gamepad,f11b,FontAwesome,12px", \
  "dataset\=fa\ fa-database,f1c0,FontAwesome,12px", \
  "video\=fa\ fa-video-camera,f03d,FontAwesome,12px", \
  "collection\=fa\ fa-folder-open,f1c0,FontAwesome,12px", \
  "event\=fa\ fa-bolt,f0e7,FontAwesome,12px", \
  "service\=fa\ fa-globe,f0ac,FontAwesome,12px", \
  "software\=fa\ fa-terminal,f120,FontAwesome,12px", \
  "sound\=fa\ fa-music,f001,FontAwesome,12px", \
  "text\=fa\ fa-file-text,f15c,FontAwesome,12px", \
  "document\=fa\ fa-file,f15b,FontAwesome,12px", \
  "image\=fa\ fa-camera,f030,FontAwesome,12px", \
  "track\=fa\ fa-thumb-tack,f08d,FontAwesome,12px", \
  ]
```