### PR TITLE
DDF-5767 Fix 2D map labels disappearing in subsequent searches and clustering

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -282,7 +282,7 @@ module.exports = function CesiumMap(
       Only shows one label if there are multiple labels in the same location.
 
       Show the label in the following importance:
-        - it is selected
+        - it is selected and the existing label is not
         - there is no other label displayed at the same location
         - it is the label that was found by findOverlappingLabel
 
@@ -291,19 +291,43 @@ module.exports = function CesiumMap(
         - if the label is selected
         - if the search for overlapping label should include hidden selected labels
       */
-  function showHideLabel({
-    geometry,
-    isSelected = false,
-    findSelected = false,
-  }) {
+  function showHideLabel({ geometry, findSelected = false }) {
+    const isSelected = geometry.isSelected
     const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
-    if (isSelected && labelWithSamePosition) {
+    if (
+      isSelected &&
+      labelWithSamePosition &&
+      !labelWithSamePosition.isSelected
+    ) {
       labelWithSamePosition.show = false
     }
+    const otherLabelNotSelected = labelWithSamePosition
+      ? !labelWithSamePosition.isSelected
+      : true
     geometry.show =
-      isSelected ||
+      (isSelected && otherLabelNotSelected) ||
       !labelWithSamePosition ||
       geometry.id === labelWithSamePosition.id
+  }
+
+  /*
+      Shows a hidden label. Used when deleting a label that is shown.
+      */
+  function showHiddenLabel(geometry) {
+    if (!geometry.show) {
+      return
+    }
+    const hiddenLabel = _.find(
+      mapModel.get('labels'),
+      label =>
+        label.position.x === geometry.position.x &&
+        label.position.y === geometry.position.y &&
+        label.id !== geometry.id &&
+        !label.show
+    )
+    if (hiddenLabel) {
+      hiddenLabel.show = true
+    }
   }
 
   const exposedMethods = _.extend({}, Map, {
@@ -901,11 +925,10 @@ module.exports = function CesiumMap(
           options.isSelected ? -1 : 0
         )
       } else if (geometry.constructor === Cesium.Label) {
+        geometry.isSelected = options.isSelected
         showHideLabel({
           geometry,
-          isSelected: options.isSelected,
         })
-        geometry.isSelected = options.isSelected
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
           polyline.material = Cesium.Material.fromType('PolylineOutline', {
@@ -965,7 +988,8 @@ module.exports = function CesiumMap(
         map.entities.remove(geometry)
       }
       if (geometry.constructor === Cesium.Label) {
-        mapModel.clearLabels()
+        mapModel.removeLabel(geometry)
+        showHiddenLabel(geometry)
       }
       map.scene.requestRender()
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -297,9 +297,8 @@ module.exports = function CesiumMap(
     findSelected = false,
   }) {
     const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.show = false
-      labelWithSamePosition.isSelected = false
     }
     geometry.show =
       isSelected ||
@@ -964,6 +963,9 @@ module.exports = function CesiumMap(
       //unminified cesium chokes if you feed a geometry with id as an Array
       if (geometry.constructor === Cesium.Entity) {
         map.entities.remove(geometry)
+      }
+      if (geometry.constructor === Cesium.Label) {
+        mapModel.clearLabels()
       }
       map.scene.requestRender()
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -930,7 +930,7 @@ module.exports = function CesiumMap(
     showGeometry(geometry) {
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
-      } else if (showLabels && geometry.constructor === Cesium.Label) {
+      } else if (geometry.constructor === Cesium.Label) {
         // only show one label at one location
         const labelWithSamePosition = _.find(
           mapModel.get('labels'),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -264,6 +264,45 @@ module.exports = function CesiumMap(
     return labelCollection
   }
 
+  /*
+   * Returns a visible label that is in the same location as the provided label (geometryInstance) if one exists.
+   * If findSelected is true, the function will also check for hidden labels in the same location but are selected.
+   */
+  function findOverlappingLabel(findSelected, geometry) {
+    return _.find(
+      mapModel.get('labels'),
+      label =>
+        label.position.x === geometry.position.x &&
+        label.position.y === geometry.position.y &&
+        ((findSelected && label.isSelected) || label.show)
+    )
+  }
+
+  /*
+    * Only shows one label if there are multiple labels in the same location.
+    * If isSelected is true, hide the existing label at that location and show the given label (geometry).
+    * If findSelected is true, look for a selected label to display (set to false when setting isSelected for labels).
+    */
+  function showHideLabel(isSelected, findSelected, geometry) {
+    const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
+    if (isSelected) {
+      if (labelWithSamePosition !== undefined) {
+        labelWithSamePosition.show = false
+        labelWithSamePosition.isSelected = false
+      }
+      geometry.show = true
+    } else {
+      if (
+        labelWithSamePosition === undefined ||
+        geometry.id === labelWithSamePosition.id
+      ) {
+        geometry.show = true
+      } else if (!findSelected) {
+        geometry.show = false
+      }
+    }
+  }
+
   const exposedMethods = _.extend({}, Map, {
     drawLine(model) {
       drawingTools.line.draw(model)
@@ -859,39 +898,8 @@ module.exports = function CesiumMap(
           options.isSelected ? -1 : 0
         )
       } else if (geometry.constructor === Cesium.Label) {
+        showHideLabel(options.isSelected, false, geometry)
         geometry.isSelected = options.isSelected
-        if (options.isSelected) {
-          // if there is another label at that position, hide it
-          const labelWithSamePosition = _.find(
-            mapModel.get('labels'),
-            label =>
-              label.position.x === geometry.position.x &&
-              label.position.y === geometry.position.y &&
-              label.show
-          )
-          if (labelWithSamePosition !== undefined) {
-            labelWithSamePosition.show = false
-            labelWithSamePosition.isSelected = false
-          }
-          geometry.show = true
-        } else {
-          // display one label and hide all others
-          const labelWithSamePosition = _.find(
-            mapModel.get('labels'),
-            label =>
-              label.position.x === geometry.position.x &&
-              label.position.y === geometry.position.y &&
-              label.show
-          )
-          if (
-            labelWithSamePosition === undefined ||
-            geometry.id === labelWithSamePosition.id
-          ) {
-            geometry.show = true
-          } else {
-            geometry.show = false
-          }
-        }
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
           polyline.material = Cesium.Material.fromType('PolylineOutline', {
@@ -931,20 +939,7 @@ module.exports = function CesiumMap(
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
       } else if (geometry.constructor === Cesium.Label) {
-        // only show one label at one location
-        const labelWithSamePosition = _.find(
-          mapModel.get('labels'),
-          label =>
-            label.position.x === geometry.position.x &&
-            label.position.y === geometry.position.y &&
-            (label.isSelected || label.show)
-        )
-        if (
-          labelWithSamePosition === undefined ||
-          geometry.id === labelWithSamePosition.id
-        ) {
-          geometry.show = true
-        }
+        showHideLabel(false, true, geometry)
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
           polyline.show = true

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -641,8 +641,9 @@ module.exports = function CesiumMap(
       return billboardRef
     },
     /*
-     * Draws a label containing the text in the given options.
-     */
+          Adds a label utilizing the passed in point and options.
+          Options are a view to an id and text.
+        */
     addLabel(point, options) {
       const pointObject = convertPointCoordinate(point)
       const cartographicPosition = Cesium.Cartographic.fromDegrees(
@@ -866,7 +867,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (labelWithSamePosition !== undefined) {
             labelWithSamePosition.show = false
@@ -880,7 +881,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (
             labelWithSamePosition === undefined ||
@@ -936,11 +937,11 @@ module.exports = function CesiumMap(
           label =>
             label.position.x === geometry.position.x &&
             label.position.y === geometry.position.y &&
-            (label.isSelected === true || label.show === true)
+            (label.isSelected || label.show)
         )
         if (
           labelWithSamePosition === undefined ||
-          geometry.id == labelWithSamePosition.id
+          geometry.id === labelWithSamePosition.id
         ) {
           geometry.show = true
         }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -279,28 +279,32 @@ module.exports = function CesiumMap(
   }
 
   /*
-    * Only shows one label if there are multiple labels in the same location.
-    * If isSelected is true, hide the existing label at that location and show the given label (geometry).
-    * If findSelected is true, look for a selected label to display (set to false when setting isSelected for labels).
-    */
-  function showHideLabel(isSelected, findSelected, geometry) {
+      Only shows one label if there are multiple labels in the same location.
+
+      Show the label in the following importance:
+        - it is selected
+        - there is no other label displayed at the same location
+        - it is the label that was found by findOverlappingLabel
+
+      Arguments are:
+        - the label to show/hide
+        - if the label is selected
+        - if the search for overlapping label should include hidden selected labels
+      */
+  function showHideLabel({
+    geometry,
+    isSelected = false,
+    findSelected = false,
+  }) {
     const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
-    if (isSelected) {
-      if (labelWithSamePosition !== undefined) {
-        labelWithSamePosition.show = false
-        labelWithSamePosition.isSelected = false
-      }
-      geometry.show = true
-    } else {
-      if (
-        labelWithSamePosition === undefined ||
-        geometry.id === labelWithSamePosition.id
-      ) {
-        geometry.show = true
-      } else if (!findSelected) {
-        geometry.show = false
-      }
+    if (isSelected && labelWithSamePosition !== undefined) {
+      labelWithSamePosition.show = false
+      labelWithSamePosition.isSelected = false
     }
+    geometry.show =
+      isSelected ||
+      !labelWithSamePosition ||
+      geometry.id === labelWithSamePosition.id
   }
 
   const exposedMethods = _.extend({}, Map, {
@@ -898,7 +902,10 @@ module.exports = function CesiumMap(
           options.isSelected ? -1 : 0
         )
       } else if (geometry.constructor === Cesium.Label) {
-        showHideLabel(options.isSelected, false, geometry)
+        showHideLabel({
+          geometry,
+          isSelected: options.isSelected,
+        })
         geometry.isSelected = options.isSelected
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
@@ -939,7 +946,10 @@ module.exports = function CesiumMap(
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
       } else if (geometry.constructor === Cesium.Label) {
-        showHideLabel(false, true, geometry)
+        showHideLabel({
+          geometry,
+          findSelected: true,
+        })
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
           polyline.show = true

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -858,21 +858,38 @@ module.exports = function CesiumMap(
           options.isSelected ? -1 : 0
         )
       } else if (geometry.constructor === Cesium.Label) {
-        const geometryPosition = geometry.position
-        // finds an existing label that has the same position; returns undefined if none
-        const labelWithSamePosition = _.find(
-          mapModel.get('labels'),
-          label =>
-            label.position.x === geometryPosition.x &&
-            label.position.y === geometryPosition.y
-        )
-        // if there is an existing label with the same position, then this one
-        // should not be displayed
-        if (
-          labelWithSamePosition !== undefined &&
-          geometry.id !== labelWithSamePosition.id
-        ) {
-          geometry.show = false
+        geometry.isSelected = options.isSelected
+        if (options.isSelected) {
+          // if there is another label at that position, hide it
+          const labelWithSamePosition = _.find(
+            mapModel.get('labels'),
+            label =>
+              label.position.x === geometry.position.x &&
+              label.position.y === geometry.position.y &&
+              label.show === true
+          )
+          if (labelWithSamePosition !== undefined) {
+            labelWithSamePosition.show = false
+            labelWithSamePosition.isSelected = false
+          }
+          geometry.show = true
+        } else {
+          // display one label and hide all others
+          const labelWithSamePosition = _.find(
+            mapModel.get('labels'),
+            label =>
+              label.position.x === geometry.position.x &&
+              label.position.y === geometry.position.y &&
+              label.show === true
+          )
+          if (
+            labelWithSamePosition === undefined ||
+            geometry.id === labelWithSamePosition.id
+          ) {
+            geometry.show = true
+          } else {
+            geometry.show = false
+          }
         }
       } else if (geometry.constructor === Cesium.PolylineCollection) {
         geometry._polylines.forEach(polyline => {
@@ -912,19 +929,17 @@ module.exports = function CesiumMap(
     showGeometry(geometry) {
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
-      } else if (geometry.constructor === Cesium.Label) {
-        const geometryPosition = geometry.position
-        // finds an existing label that has the same position; returns undefined if none
+      } else if (showLabels && geometry.constructor === Cesium.Label) {
+        // only show one label at one location
         const labelWithSamePosition = _.find(
           mapModel.get('labels'),
           label =>
-            label.position.x === geometryPosition.x &&
-            label.position.y === geometryPosition.y
+            label.position.x === geometry.position.x &&
+            label.position.y === geometry.position.y &&
+            (label.isSelected === true || label.show === true)
         )
-        // only show one label at each location
-        // the first label also matches the top-most metacard
         if (
-          labelWithSamePosition !== undefined &&
+          labelWithSamePosition === undefined ||
           geometry.id == labelWithSamePosition.id
         ) {
           geometry.show = true

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -15,6 +15,7 @@
 
 import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
 
+const _ = require('underscore')
 const Backbone = require('backbone')
 const MetacardModel = require('../../../js/model/Metacard.js')
 const mtgeo = require('mt-geo')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -15,7 +15,7 @@
 
 import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
 
-const _ = require('underscore')
+const _ = require('lodash')
 const Backbone = require('backbone')
 const MetacardModel = require('../../../js/model/Metacard.js')
 const mtgeo = require('mt-geo')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -85,6 +85,11 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
+  clearLabels() {
+    this.set({
+      labels: [],
+    })
+  },
   /*
    * Sets the line to the given new line. This represents the line on the map
    * being used for the ruler measurement.

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -85,10 +85,8 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
-  clearLabels() {
-    this.set({
-      labels: [],
-    })
+  removeLabel(label) {
+    _.remove(this.get('labels'), e => e === label)
   },
   /*
    * Sets the line to the given new line. This represents the line on the map

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -186,25 +186,60 @@ module.exports = function OpenlayersMap(
         - if the label is selected
         - if the search for overlapping label should include hidden selected labels
       */
-  function showHideLabel({
-    geometry,
-    feature,
-    isSelected = false,
-    findSelected = false,
-  }) {
+  function showHideLabel({ geometry, feature, findSelected = false }) {
+    const isSelected = geometry.get('isSelected')
     const geometryInstance = feature.getGeometry()
     const labelWithSamePosition = findOverlappingLabel(
       findSelected,
       geometryInstance
     )
-    if (isSelected && labelWithSamePosition) {
+    if (
+      isSelected &&
+      labelWithSamePosition &&
+      !labelWithSamePosition.get('isSelected')
+    ) {
       labelWithSamePosition.setVisible(false)
     }
+    const otherLabelNotSelected = labelWithSamePosition
+      ? !labelWithSamePosition.get('isSelected')
+      : true
     const visible =
-      isSelected ||
+      (isSelected && otherLabelNotSelected) ||
       !labelWithSamePosition ||
       geometry.get('id') === labelWithSamePosition.get('id')
     geometry.setVisible(visible)
+  }
+
+  /*
+      Shows a hidden label. Used when deleting a label that is shown.
+      */
+  function showHiddenLabel(geometry) {
+    if (!geometry.getVisible()) {
+      return
+    }
+    const geometryInstance = geometry
+      .getSource()
+      .getFeatures()[0]
+      .getGeometry()
+    const hiddenLabel = _.find(
+      mapModel.get('labels'),
+      label =>
+        label
+          .getSource()
+          .getFeatures()[0]
+          .getGeometry()
+          .getCoordinates()[0] === geometryInstance.getCoordinates()[0] &&
+        label
+          .getSource()
+          .getFeatures()[0]
+          .getGeometry()
+          .getCoordinates()[1] === geometryInstance.getCoordinates()[1] &&
+        label.get('id') !== geometry.get('id') &&
+        !label.getVisible()
+    )
+    if (hiddenLabel) {
+      hiddenLabel.setVisible(true)
+    }
   }
 
   const exposedMethods = _.extend({}, Map, {
@@ -705,12 +740,11 @@ module.exports = function OpenlayersMap(
             })
           )
 
+          geometry.set('isSelected', options.isSelected)
           showHideLabel({
             geometry,
             feature,
-            isSelected: options.isSelected,
           })
-          geometry.set('isSelected', options.isSelected)
         }
       } else if (geometryInstance.getType() === 'LineString') {
         const styles = [
@@ -784,11 +818,12 @@ module.exports = function OpenlayersMap(
       }
     },
     removeGeometry(geometry) {
-      map.removeLayer(geometry)
       const feature = geometry.getSource().getFeatures()[0]
       if (feature.getProperties().isLabel) {
-        mapModel.clearLabels()
+        mapModel.removeLabel(geometry)
+        showHiddenLabel(geometry)
       }
+      map.removeLayer(geometry)
     },
     showPolygonShape(locationModel) {
       const polygon = new DrawPolygon.PolygonView({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -151,6 +151,58 @@ module.exports = function OpenlayersMap(
     wreqr.vent.off('resize', resizeMap)
   }
 
+  /*
+   * Returns a visible label that is in the same location as the provided label (geometryInstance) if one exists.
+   * If findSelected is true, the function will also check for hidden labels in the same location but are selected.
+   */
+  function findOverlappingLabel(findSelected, geometryInstance) {
+    return _.find(
+      mapModel.get('labels'),
+      label =>
+        label
+          .getSource()
+          .getFeatures()[0]
+          .getGeometry()
+          .getCoordinates()[0] === geometryInstance.getCoordinates()[0] &&
+        label
+          .getSource()
+          .getFeatures()[0]
+          .getGeometry()
+          .getCoordinates()[1] === geometryInstance.getCoordinates()[1] &&
+        ((findSelected && label.get('isSelected')) || label.getVisible())
+    )
+  }
+
+  /*
+   * Only shows one label if there are multiple labels in the same location.
+   * If isSelected is true, hide the existing label at that location and show the given label (geometry).
+   * If findSelected is true, look for a selected label to display (set to false when setting isSelected for labels).
+   */
+  function showHideLabel(isSelected, findSelected, geometry, feature) {
+    const geometryInstance = feature.getGeometry()
+    const labelWithSamePosition = findOverlappingLabel(
+      findSelected,
+      geometryInstance
+    )
+    if (isSelected) {
+      if (labelWithSamePosition !== undefined) {
+        labelWithSamePosition.setVisible(false)
+        labelWithSamePosition.set('isSelected', false)
+      }
+      geometry.setVisible(true)
+    } else {
+      if (
+        labelWithSamePosition === undefined ||
+        geometry.get('id') === labelWithSamePosition.get('id')
+      ) {
+        geometry.setVisible(true)
+      } else if (!findSelected) {
+        // only hide geometry if not looking for selected label
+        geometry.setVisible(false)
+      }
+    }
+  }
+
   const exposedMethods = _.extend({}, Map, {
     drawLine(model) {
       drawingTools.line.draw(model)
@@ -649,58 +701,8 @@ module.exports = function OpenlayersMap(
             })
           )
 
-          // only show one label if there are overlapping labels
+          showHideLabel(options.isSelected, false, geometry, feature)
           geometry.set('isSelected', options.isSelected)
-          if (options.isSelected) {
-            const labelWithSamePosition = _.find(
-              mapModel.get('labels'),
-              label =>
-                label
-                  .getSource()
-                  .getFeatures()[0]
-                  .getGeometry()
-                  .getCoordinates()[0] ===
-                  geometryInstance.getCoordinates()[0] &&
-                label
-                  .getSource()
-                  .getFeatures()[0]
-                  .getGeometry()
-                  .getCoordinates()[1] ===
-                  geometryInstance.getCoordinates()[1] &&
-                label.getVisible()
-            )
-            if (labelWithSamePosition !== undefined) {
-              labelWithSamePosition.setVisible(false)
-              labelWithSamePosition.set('isSelected', false)
-            }
-            geometry.setVisible(true)
-          } else {
-            const labelWithSamePosition = _.find(
-              mapModel.get('labels'),
-              label =>
-                label
-                  .getSource()
-                  .getFeatures()[0]
-                  .getGeometry()
-                  .getCoordinates()[0] ===
-                  geometryInstance.getCoordinates()[0] &&
-                label
-                  .getSource()
-                  .getFeatures()[0]
-                  .getGeometry()
-                  .getCoordinates()[1] ===
-                  geometryInstance.getCoordinates()[1] &&
-                label.getVisible()
-            )
-            if (
-              labelWithSamePosition === undefined ||
-              geometry.get('id') === labelWithSamePosition.get('id')
-            ) {
-              geometry.setVisible(true)
-            } else {
-              geometry.setVisible(false)
-            }
-          }
         }
       } else if (geometryInstance.getType() === 'LineString') {
         const styles = [
@@ -764,29 +766,7 @@ module.exports = function OpenlayersMap(
     showGeometry(geometry) {
       const feature = geometry.getSource().getFeatures()[0]
       if (feature.getProperties().isLabel) {
-        // only show one label at one location
-        const geometryInstance = feature.getGeometry()
-        const labelWithSamePosition = _.find(
-          mapModel.get('labels'),
-          label =>
-            label
-              .getSource()
-              .getFeatures()[0]
-              .getGeometry()
-              .getCoordinates()[0] === geometryInstance.getCoordinates()[0] &&
-            label
-              .getSource()
-              .getFeatures()[0]
-              .getGeometry()
-              .getCoordinates()[1] === geometryInstance.getCoordinates()[1] &&
-            (label.get('isSelected') || label.getVisible())
-        )
-        if (
-          labelWithSamePosition === undefined ||
-          geometry.get('id') === labelWithSamePosition.get('id')
-        ) {
-          geometry.setVisible(true)
-        }
+        showHideLabel(false, true, geometry, feature)
       } else {
         geometry.setVisible(true)
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -174,33 +174,38 @@ module.exports = function OpenlayersMap(
   }
 
   /*
-   * Only shows one label if there are multiple labels in the same location.
-   * If isSelected is true, hide the existing label at that location and show the given label (geometry).
-   * If findSelected is true, look for a selected label to display (set to false when setting isSelected for labels).
-   */
-  function showHideLabel(isSelected, findSelected, geometry, feature) {
+      Only shows one label if there are multiple labels in the same location.
+
+      Show the label in the following importance:
+        - it is selected
+        - there is no other label displayed at the same location
+        - it is the label that was found by findOverlappingLabel
+
+      Arguments are:
+        - the label to show/hide (geometry, feature)
+        - if the label is selected
+        - if the search for overlapping label should include hidden selected labels
+      */
+  function showHideLabel({
+    geometry,
+    feature,
+    isSelected = false,
+    findSelected = false,
+  }) {
     const geometryInstance = feature.getGeometry()
     const labelWithSamePosition = findOverlappingLabel(
       findSelected,
       geometryInstance
     )
-    if (isSelected) {
-      if (labelWithSamePosition !== undefined) {
-        labelWithSamePosition.setVisible(false)
-        labelWithSamePosition.set('isSelected', false)
-      }
-      geometry.setVisible(true)
-    } else {
-      if (
-        labelWithSamePosition === undefined ||
-        geometry.get('id') === labelWithSamePosition.get('id')
-      ) {
-        geometry.setVisible(true)
-      } else if (!findSelected) {
-        // only hide geometry if not looking for selected label
-        geometry.setVisible(false)
-      }
+    if (isSelected && labelWithSamePosition !== undefined) {
+      labelWithSamePosition.setVisible(false)
+      labelWithSamePosition.set('isSelected', false)
     }
+    const visible =
+      isSelected ||
+      !labelWithSamePosition ||
+      geometry.get('id') === labelWithSamePosition.get('id')
+    geometry.setVisible(visible)
   }
 
   const exposedMethods = _.extend({}, Map, {
@@ -701,7 +706,11 @@ module.exports = function OpenlayersMap(
             })
           )
 
-          showHideLabel(options.isSelected, false, geometry, feature)
+          showHideLabel({
+            geometry,
+            feature,
+            isSelected: options.isSelected,
+          })
           geometry.set('isSelected', options.isSelected)
         }
       } else if (geometryInstance.getType() === 'LineString') {
@@ -766,7 +775,11 @@ module.exports = function OpenlayersMap(
     showGeometry(geometry) {
       const feature = geometry.getSource().getFeatures()[0]
       if (feature.getProperties().isLabel) {
-        showHideLabel(false, true, geometry, feature)
+        showHideLabel({
+          geometry,
+          feature,
+          findSelected: true,
+        })
       } else {
         geometry.setVisible(true)
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -197,9 +197,8 @@ module.exports = function OpenlayersMap(
       findSelected,
       geometryInstance
     )
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.setVisible(false)
-      labelWithSamePosition.set('isSelected', false)
     }
     const visible =
       isSelected ||
@@ -786,6 +785,10 @@ module.exports = function OpenlayersMap(
     },
     removeGeometry(geometry) {
       map.removeLayer(geometry)
+      const feature = geometry.getSource().getFeatures()[0]
+      if (feature.getProperties().isLabel) {
+        mapModel.clearLabels()
+      }
     },
     showPolygonShape(locationModel) {
       const polygon = new DrawPolygon.PolygonView({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -103,27 +103,6 @@ module.exports = function OpenlayersMap(
   listenToResize()
   setupTooltip(map)
   const drawingTools = setupDrawingTools(map)
-  const labelVectorLayer = setupLabelLayer(map)
-
-  /*
-   * Sets up a new Vector Layer for holding labels with the declutter property.
-   * Declutter is used for making sure the label texts don't overlap on each
-   * other.
-   */
-  function setupLabelLayer(map) {
-    const vectorSource = new Openlayers.source.Vector({
-      features: [],
-    })
-    const vectorLayer = new Openlayers.layer.Vector({
-      source: vectorSource,
-      zIndex: 1,
-      declutter: true,
-    })
-
-    map.addLayer(vectorLayer)
-
-    return vectorLayer
-  }
 
   function setupTooltip(map) {
     map.on('pointermove', e => {
@@ -484,9 +463,9 @@ module.exports = function OpenlayersMap(
       return vectorLayer
     },
     /*
-     * Draws a label on the map by adding to the features in the label Vector
-     * Layer.
-     */
+          Adds a label utilizing the passed in point and options.
+          Options are an id and text.
+        */
     addLabel(point, options) {
       const pointObject = convertPointCoordinate(point)
       const feature = new Openlayers.Feature({
@@ -504,19 +483,21 @@ module.exports = function OpenlayersMap(
           }),
         })
       )
-
-      const labelVectorLayerFeatures = labelVectorLayer
-        .getSource()
-        .getFeatures()
-      // creates a new source with the new feature appended to the current list
-      // of features
-      const newVectorSource = new Openlayers.source.Vector({
-        features: [...labelVectorLayerFeatures, feature],
+      const vectorSource = new Openlayers.source.Vector({
+        features: [feature],
       })
-      // updates the vector layer containing the labels with the new source
-      labelVectorLayer.setSource(newVectorSource)
 
-      return labelVectorLayer
+      const vectorLayer = new Openlayers.layer.Vector({
+        source: vectorSource,
+        zIndex: 1,
+        id: options.id,
+        isSelected: false,
+      })
+
+      map.addLayer(vectorLayer)
+      mapModel.addLabel(vectorLayer)
+
+      return vectorLayer
     },
     /*
           Adds a polyline utilizing the passed in line and options.
@@ -667,6 +648,59 @@ module.exports = function OpenlayersMap(
               ),
             })
           )
+
+          // only show one label if there are overlapping labels
+          geometry.set('isSelected', options.isSelected)
+          if (options.isSelected) {
+            const labelWithSamePosition = _.find(
+              mapModel.get('labels'),
+              label =>
+                label
+                  .getSource()
+                  .getFeatures()[0]
+                  .getGeometry()
+                  .getCoordinates()[0] ===
+                  geometryInstance.getCoordinates()[0] &&
+                label
+                  .getSource()
+                  .getFeatures()[0]
+                  .getGeometry()
+                  .getCoordinates()[1] ===
+                  geometryInstance.getCoordinates()[1] &&
+                label.getVisible()
+            )
+            if (labelWithSamePosition !== undefined) {
+              labelWithSamePosition.setVisible(false)
+              labelWithSamePosition.set('isSelected', false)
+            }
+            geometry.setVisible(true)
+          } else {
+            const labelWithSamePosition = _.find(
+              mapModel.get('labels'),
+              label =>
+                label
+                  .getSource()
+                  .getFeatures()[0]
+                  .getGeometry()
+                  .getCoordinates()[0] ===
+                  geometryInstance.getCoordinates()[0] &&
+                label
+                  .getSource()
+                  .getFeatures()[0]
+                  .getGeometry()
+                  .getCoordinates()[1] ===
+                  geometryInstance.getCoordinates()[1] &&
+                label.getVisible()
+            )
+            if (
+              labelWithSamePosition === undefined ||
+              geometry.get('id') === labelWithSamePosition.get('id')
+            ) {
+              geometry.setVisible(true)
+            } else {
+              geometry.setVisible(false)
+            }
+          }
         }
       } else if (geometryInstance.getType() === 'LineString') {
         const styles = [
@@ -728,7 +762,34 @@ module.exports = function OpenlayersMap(
          Updates a passed in geometry to be shown
          */
     showGeometry(geometry) {
-      geometry.setVisible(true)
+      const feature = geometry.getSource().getFeatures()[0]
+      if (feature.getProperties().isLabel) {
+        // only show one label at one location
+        const geometryInstance = feature.getGeometry()
+        const labelWithSamePosition = _.find(
+          mapModel.get('labels'),
+          label =>
+            label
+              .getSource()
+              .getFeatures()[0]
+              .getGeometry()
+              .getCoordinates()[0] === geometryInstance.getCoordinates()[0] &&
+            label
+              .getSource()
+              .getFeatures()[0]
+              .getGeometry()
+              .getCoordinates()[1] === geometryInstance.getCoordinates()[1] &&
+            (label.get('isSelected') || label.getVisible())
+        )
+        if (
+          labelWithSamePosition === undefined ||
+          geometry.get('id') === labelWithSamePosition.get('id')
+        ) {
+          geometry.setVisible(true)
+        }
+      } else {
+        geometry.setVisible(true)
+      }
     },
     removeGeometry(geometry) {
       map.removeLayer(geometry)


### PR DESCRIPTION
### Original DDF PR: codice/ddf#5768 (4 approvals)

#### What does this PR do?
Fixes 2D map labels

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@mdang8 
@josephthweatt 
@aaronilovici 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@vinamartin 
@andrewkfiedler 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the Admin console and navigate to `Search UI -> Configuration -> Catalog UI Search`
2. Scroll down to `Show Custom Text Notations` and click the checkbox to enable it
3. Ingest some metacards in Intrigue (make sure some overlap)
4. Open the 2D map and run a * search
5. Verify the metacard map markers have a label next to each one
6. Rerun the search
7. Verify the map labels are still there
8. Enable clustering
9. Verify the non-clustered map markers have labels

Also verify that there are never any labels in the same location overlapping when selecting metacards, especially after re-running the search.

#### Any background context you want to provide?
Fixes functionality introduced in codice/ddf#5638 
The fix for the bug removed the benefit of 2D map labels not overlapping when zoomed out very far from the map. I also had to manually implement hiding logic for overlapping labels, but I think it is more important that the map labels continue to show up in subsequent searches. If there are any better ways to do this, please let me know.

#### What are the relevant tickets?
Fixes: codice/ddf#5767 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
