### PR TITLE
DDF-73 Fixed having to type numbers twice when manually inputting USNG coordinates for bounding box

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -505,6 +505,7 @@ module.exports = Backbone.AssociatedModel.extend({
       const { south, east } = converter.USNGtoLL(this.get('usngbbLowerRight'))
       return { north, south, east, west }
     }
+    return {}
   },
 
   setBboxUsngUL() {


### PR DESCRIPTION
#### What does this PR do?
Before, a console error was making it so that each number had to be typed twice in order for it to show up in the field when manually inputting USNG coordinates for a bounding box. This PR fixes that
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris
#### How should this be tested?
Create an advanced search with an anyGeo Bounding Box filter. Switch to USNG/MGRS coordinates and try to manually input a value number-by-number (i.e. 22R CA 75963 20865). Verify that you don't have to enter each number twice in order for it to show up in the field
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #73
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
