### PR TITLE
DDF-5815 fix result form action dropdown

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
@@ -31,7 +31,7 @@ module.exports = SearchFormViews.extend({
           title: 'Error',
           message:
             'You have read-only permission on result form ' +
-            this.model.get('name') +
+            this.model.get('title') +
             '.',
           type: 'error',
         },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -45,10 +45,6 @@
   > .interaction-default {
     display: none;
   }
-
-  > .interaction-edit {
-    display: none;
-  }
 }
 
 @{customElementNamespace}search-form-interactions.is-system-template {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -185,7 +185,11 @@ export default Marionette.LayoutView.extend({
     return { createdOn: Common.getMomentDate(createdOn), ...json }
   },
   onRender() {
-    if (this.model.get('type') === 'new-result') {
+    const newResult = this.model.get('type') === 'new-result'
+    const noActions =
+      this.model.get('type') === 'result' &&
+      (!user.canWrite(this.model) || this.model.get('createdBy') === 'system')
+    if (newResult || noActions) {
       this.$el.addClass('is-static')
     } else {
       this.searchFormActions.show(


### PR DESCRIPTION
#### What does this PR do?
Hides result form actions (vertical ellipsis) when no actions are present
re adds edit as a result form action
forwardport https://github.com/codice/ddf/pull/5816

#### Who is reviewing it? 
@zta6 @hayleynorton @cassandrabailey293 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
- build / install
- ingest system search form, verify there are no actions available
- verify edit action is available for editable result forms

#### Screenshots
<img width="1026" alt="Screen Shot 2020-02-05 at 10 44 44 AM" src="https://user-images.githubusercontent.com/39923178/73962147-1e2c4480-48cb-11ea-91d1-9594c3768f63.png">
<img width="439" alt="Screen Shot 2020-02-06 at 10 26 03 AM" src="https://user-images.githubusercontent.com/39923178/73962155-21bfcb80-48cb-11ea-9332-a0790df8dc83.png">


