### PR TITLE
DDF-92 Fix parsing of relative time queries

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -130,7 +130,7 @@ const comparisonClass = 'Comparison',
     DURING: ['TIME_PERIOD'],
     TIME: ['LOGICAL', 'RPAREN', 'END'],
     TIME_PERIOD: ['LOGICAL', 'RPAREN', 'END'],
-    RELATIVE: ['RPAREN'],
+    RELATIVE: ['RPAREN', 'END'],
     FILTER_FUNCTION: ['LPAREN', 'PROPERTY', 'VALUE', 'RPAREN'],
   },
   precedence = {


### PR DESCRIPTION
#### What does this PR do?
Fixes a parsing error that occurs when running relative time queries that are not wrapped in parentheses. Wrapping does not appear to be necessary: https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html#filter-ecql-reference

2.19.x PR: https://github.com/codice/ddf/pull/5823

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@aj-brooks 
@bennuttle 
@AzGoalie 
@lavoywj 
@leo-sakh 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
-->
@codice/ui 
<!--
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
-->
@andrewkfiedler
@bdeining
@millerw8

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Run a relative time query and ensure it works.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: https://github.com/codice/ddf-ui/issues/92

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.