### PR TITLE
Rename src to sources for RPC

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -13,20 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.metacard.query.data.model;
 
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.DETAIL_LEVEL;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.FACETS;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.PHONETICS;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_CQL;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_ENTERPRISE;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_FEDERATION;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_FILTER_TREE;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_POLLING;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SORTS;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SCHEDULES;
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SPELLCHECK;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
@@ -36,13 +22,16 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
+import org.codice.ddf.catalog.ui.metacard.query.data.metacard.QueryMetacardImpl;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.codice.ddf.catalog.ui.metacard.query.data.metacard.QueryMetacardImpl;
+
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.*;
 
 public class QueryBasic {
 
@@ -76,7 +65,7 @@ public class QueryBasic {
   @SerializedName("enterprise")
   private Boolean enterprise;
 
-  @SerializedName("src")
+  @SerializedName("sources")
   private List<String> sources;
 
   @SerializedName("sorts")

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -13,24 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.metacard.query.data.model;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.annotations.SerializedName;
-import ddf.catalog.data.Attribute;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.types.Core;
-import ddf.catalog.data.types.Security;
-import org.codice.ddf.catalog.ui.metacard.query.data.metacard.QueryMetacardImpl;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.DETAIL_LEVEL;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.FACETS;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.PHONETICS;
@@ -44,6 +26,23 @@ import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUER
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SCHEDULES;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SPELLCHECK;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Security;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.codice.ddf.catalog.ui.metacard.query.data.metacard.QueryMetacardImpl;
 
 public class QueryBasic {
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -31,7 +31,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.*;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.DETAIL_LEVEL;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.FACETS;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.PHONETICS;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_CQL;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_ENTERPRISE;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_FEDERATION;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_FILTER_TREE;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_POLLING;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SORTS;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SCHEDULES;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SPELLCHECK;
 
 public class QueryBasic {
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/SrcToQuerySources.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/SrcToQuerySources.java
@@ -13,9 +13,9 @@
  */
 package org.codice.ddf.catalog.ui.metacard.workspace.transformer.impl;
 
-import org.codice.ddf.catalog.ui.metacard.workspace.transformer.WorkspaceKeyTransformation;
-
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
+
+import org.codice.ddf.catalog.ui.metacard.workspace.transformer.WorkspaceKeyTransformation;
 
 public class SrcToQuerySources extends WorkspaceKeyTransformation {
   @Override

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/SrcToQuerySources.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/SrcToQuerySources.java
@@ -13,9 +13,9 @@
  */
 package org.codice.ddf.catalog.ui.metacard.workspace.transformer.impl;
 
-import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
-
 import org.codice.ddf.catalog.ui.metacard.workspace.transformer.WorkspaceKeyTransformation;
+
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
 
 public class SrcToQuerySources extends WorkspaceKeyTransformation {
   @Override
@@ -25,6 +25,6 @@ public class SrcToQuerySources extends WorkspaceKeyTransformation {
 
   @Override
   public String getJsonKey() {
-    return "src";
+    return "sources";
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -60,7 +60,7 @@ module.exports = plugin(
         : this.model
       this.listenTo(
         this.model,
-        'change:sortField change:sortOrder change:src change:federation',
+        'change:sortField change:sortOrder change:sources change:federation',
         Common.safeCallback(this.onBeforeShow)
       )
       this.resultFormCollection = ResultForm.getResultCollection()
@@ -145,7 +145,7 @@ module.exports = plugin(
       )
     },
     setupSrcDropdown() {
-      const sources = this.model.get('src')
+      const sources = this.model.get('sources')
       this._srcDropdownModel = new DropdownModel({
         value: sources ? sources : [],
         federation: this.model.get('federation'),
@@ -242,10 +242,10 @@ module.exports = plugin(
       let federation = this._srcDropdownModel.get('federation')
       const spellcheck = this.model.get('spellcheck')
       const phonetics = this.model.get('phonetics')
-      let src
+      let sources
       if (federation === 'selected') {
-        src = this._srcDropdownModel.get('value')
-        if (src === undefined || src.length === 0) {
+        sources = this._srcDropdownModel.get('value')
+        if (sources === undefined || sources.length === 0) {
           federation = 'local'
         }
       }
@@ -257,7 +257,7 @@ module.exports = plugin(
         detailLevel = undefined
       }
       return {
-        src,
+        sources,
         federation,
         sorts,
         'detail-level': detailLevel,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -39,7 +39,7 @@ module.exports = Backbone.Model.extend({
     return {
       title: this.get('title'),
       filterTree: this.get('filterTemplate'),
-      src: (querySettings && querySettings.src) || '',
+      sources: (querySettings && querySettings.sources) || '',
       facets: (querySettings && querySettings.facets) || [],
       federation: (querySettings && querySettings.federation) || 'enterprise',
       sorts:

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/QueryPolling.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/QueryPolling.js
@@ -138,7 +138,8 @@ function removeImpertinentFailures(queryId) {
   if (failedQueries[queryId]) {
     _.forEach(failedQueries[queryId].failures, (timeRanges, srcId) => {
       if (
-        failedQueries[queryId].originalQuery.get('src').indexOf(srcId) === -1
+        failedQueries[queryId].originalQuery.get('sources').indexOf(srcId) ===
+        -1
       ) {
         delete failedQueries[queryId].failures[srcId]
       }
@@ -218,7 +219,7 @@ handleReattempts = function() {
         }
         const queryToRun = subset.originalQuery.clone()
         queryToRun.set('federation', 'selected')
-        queryToRun.set('src', [srcId])
+        queryToRun.set('sources', [srcId])
         queryToRun.set(
           'cql',
           addTimeRangeToCQLString(subset.originalQuery, timeRange)
@@ -238,7 +239,7 @@ module.exports = {
   handleAddingQuery(query) {
     this.handleRemovingQuery(query)
     query.listenTo(query, 'change:polling', this.handlePollingUpdate.bind(this))
-    query.listenTo(query, 'change:src', this.handleSrcUpdate.bind(this))
+    query.listenTo(query, 'change:sources', this.handleSrcUpdate.bind(this))
     query.listenTo(query, 'change:federation', this.handleSrcUpdate.bind(this))
     const polling = query.get('polling')
     if (polling) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -203,7 +203,7 @@ Query.Model = PartialAssociatedModel.extend({
     this.trigger('resetToDefaults')
   },
   applyDefaults() {
-    this.set(_.pick(this.defaults(), ['sorts', 'federation', 'src']))
+    this.set(_.pick(this.defaults(), ['sorts', 'federation', 'sources']))
   },
   revert() {
     this.trigger('revert')
@@ -244,10 +244,10 @@ Query.Model = PartialAssociatedModel.extend({
 
     switch (data.federation) {
       case 'local':
-        data.src = [Sources.localCatalog]
+        data.sources = [Sources.localCatalog]
         break
       case 'enterprise':
-        data.src = _.pluck(Sources.toJSON(), 'id')
+        data.sources = _.pluck(Sources.toJSON(), 'id')
         break
       case 'selected':
         // already in correct format
@@ -263,7 +263,7 @@ Query.Model = PartialAssociatedModel.extend({
 
     return _.pick(
       data,
-      'src',
+      'sources',
       'start',
       'count',
       'timeout',
@@ -332,7 +332,7 @@ Query.Model = PartialAssociatedModel.extend({
     if (options.resultCountOnly) {
       data.count = 0
     }
-    const sources = data.src
+    const sources = data.sources
     const initialStatus = sources.map(src => ({
       id: src,
     }))
@@ -506,9 +506,9 @@ Query.Model = PartialAssociatedModel.extend({
       }
     })
     if (sourceArr.length > 0) {
-      this.set('src', sourceArr.join(','))
+      this.set('sources', sourceArr.join(','))
     } else {
-      this.set('src', '')
+      this.set('sources', '')
     }
   },
   getId() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -19,7 +19,7 @@ module.exports = Backbone.Model.extend({
   defaults() {
     return {
       type: 'text',
-      src: undefined,
+      sources: undefined,
       federation: 'enterprise',
       sorts: [
         {


### PR DESCRIPTION
The front end stores the sources on a query metacard in a property called src. When submitting with an RPC request the src property will be ignored as it doesn't match the "sources" definition on the metacard.