### PR TITLE
DDF-UI-111 Retained bounding box over anti-meridian after search

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -594,12 +594,7 @@ module.exports = Backbone.AssociatedModel.extend({
     const west = parseFloat(this.get('west'))
     const east = parseFloat(this.get('east'))
 
-    if (
-      north !== undefined &&
-      south !== undefined &&
-      east !== undefined &&
-      west !== undefined
-    ) {
+    if (!isNaN(north) && !isNaN(south) && !isNaN(east) && !isNaN(west)) {
       this.set('bbox', [west, south, east, north].join(','), {
         silent:
           (this.get('locationType') === 'usng' ||

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -101,9 +101,28 @@ Draw.PolygonView = Marionette.View.extend({
   },
 
   modelToPolygon(model) {
-    const coords = model.get('polygon')
+    let coords = model.get('polygon')
     if (!coords) {
       return
+    }
+    if (model.get('bbox')) {
+      const bbox = model.get('bbox')
+      const south = Number(bbox[0])
+      const north = Number(bbox[1])
+      let west = Number(bbox[2])
+      let east = Number(bbox[3])
+      if (east - west < -180) {
+        east += 360
+      } else if (east - west > 180) {
+        west += 360
+      }
+      coords = [
+        [west, south],
+        [west, north],
+        [east, north],
+        [east, south],
+        [west, south],
+      ]
     }
     const isMultiPolygon = ShapeUtils.isArray3D(coords)
     const multiPolygon = isMultiPolygon ? coords : [coords]

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -108,9 +108,17 @@ class LocationInput extends React.Component {
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':
-        if (CQLUtils.isPointRadiusFilter(filter.value)) {
+        if (
+          CQLUtils.isPointRadiusFilter(
+            typeof filter.value === 'string' ? filter : filter.value
+          )
+        ) {
           wreqr.vent.trigger('search:circledisplay', this.locationModel)
-        } else if (CQLUtils.isPolygonFilter(filter.value)) {
+        } else if (
+          CQLUtils.isPolygonFilter(
+            typeof filter.value === 'string' ? filter : filter.value
+          )
+        ) {
           wreqr.vent.trigger('search:polydisplay', this.locationModel)
         } else {
           wreqr.vent.trigger('search:linedisplay', this.locationModel)


### PR DESCRIPTION
#### What does this PR do?
Before, if you drew a bounding box over the anti-meridian (180 degrees longitude) on the 2D map and searched with it, the query would return the correct results (within the drawn bounding box) but the map would show a bounding box that covers the entire globe except for the section that was drawn (see first gif below). This did not happen on the 3D map.
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?
See gifs below, verify you see the behavior from the "after" gif
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #codice/ddf-ui#111
#### Screenshots
Before
![antimeridian-min](https://user-images.githubusercontent.com/39737329/76033324-35c21180-5ef9-11ea-878f-6b5cae6300fe.gif)
After
![antimeridianfixed-min](https://user-images.githubusercontent.com/39737329/76033555-bc76ee80-5ef9-11ea-900a-5b8a14bede53.gif)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
