### PR TITLE
DDF-UI-112 allow intersects query for line

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -21,7 +21,7 @@ const LineString = {
       properties: { buffer } = {},
     } = json
 
-    const { width = 1, unit = 'meters' } = buffer
+    const { width = 0, unit = 'meters' } = buffer
 
     return {
       mode: 'line',
@@ -31,7 +31,7 @@ const LineString = {
     }
   },
   'location->json': location => {
-    const { line = [], lineWidth = 1, lineUnits = 'meters' } = location
+    const { line = [], lineWidth = 0, lineUnits = 'meters' } = location
 
     return {
       type: 'Feature',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -524,14 +524,15 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   handleFilterAsLine(filter, color) {
-    const pointText = filter.value.value.substring(11, filter.value.value.length - 1)
+    const pointText = filter.value.value.substring(
+      11,
+      filter.value.value.length - 1
+    )
     const locationModel = new LocationModel({
       lineWidth: filter.distance || 0,
       line: pointText
         .split(',')
-        .map(coordinate =>
-          coordinate.split(' ').map(value => Number(value))
-        ),
+        .map(coordinate => coordinate.split(' ').map(value => Number(value))),
       color,
     })
     this.map.showLineShape(locationModel)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -42,8 +42,6 @@ const Gazetteer = require('../../../react-component/location/gazetteer.js')
 
 import MapSettings from '../../../react-component/map-settings'
 import MapInfo from '../../../react-component/map-info'
-import DistanceInfo from '../../../react-component/distance-info'
-import getDistance from 'geolib/es/getDistance'
 
 function findExtreme({ objArray, property, comparator }) {
   if (objArray.length === 0) {
@@ -239,19 +237,6 @@ module.exports = Marionette.LayoutView.extend({
     )
     this.handleCurrentQuery()
 
-    // listener for when the measurement state changes in map model
-    this.listenTo(
-      this.mapModel,
-      'change:measurementState',
-      this.handleMeasurementStateChange.bind(this)
-    )
-
-    this.listenTo(
-      this.mapModel,
-      'change:mouseLat change:mouseLon',
-      this.updateDistance.bind(this)
-    )
-
     if (this.options.selectionInterface.getSelectedResults().length > 0) {
       this.map.zoomToSelected(
         this.options.selectionInterface.getSelectedResults()
@@ -364,91 +349,6 @@ module.exports = Marionette.LayoutView.extend({
       targetMetacard,
     })
   },
-  /*
-   *  Redraw and recalculate the ruler line and distanceInfo tooltip. Will not redraw while the menu is currently
-   *  displayed updateOnMenu allows updating while the menu is up
-   */
-  updateDistance(updateOnMenu = false) {
-    if (this.mapModel.get('measurementState') === 'START') {
-      const openMenu = this.mapContextMenu.currentView.model.changed.isOpen
-      const lat = this.mapModel.get('mouseLat')
-      const lon = this.mapModel.get('mouseLon')
-
-      if ((updateOnMenu === true || !openMenu) && lat && lon) {
-        // redraw ruler line
-        const mousePoint = { lat, lon }
-        this.map.setRulerLine(mousePoint)
-
-        // update distance info
-        const startingCoordinates = this.mapModel.get('startingCoordinates')
-        const dist = getDistance(
-          { latitude: lat, longitude: lon },
-          {
-            latitude: startingCoordinates['lat'],
-            longitude: startingCoordinates['lon'],
-          }
-        )
-        this.mapModel.setDistanceInfoPosition(event.clientX, event.clientY)
-        this.mapModel.setCurrentDistance(dist)
-      }
-    }
-  },
-  /*
-    Handles drawing or clearing the ruler as needed by the measurement state.
-
-    START indicates that a starting point should be drawn, 
-    so the map clears any previous points drawn and draws a new start point.
-
-    END indicates that an ending point should be drawn,
-    so the map draws an end point and a line, and calculates the distance.
-
-    NONE indicates that the ruler should be cleared.
-  */
-  handleMeasurementStateChange() {
-    const state = this.mapModel.get('measurementState')
-    let point = null
-    switch (state) {
-      case 'START':
-        this.clearRuler()
-        point = this.map.addRulerPoint(this.mapModel.get('coordinateValues'))
-        this.mapModel.addPoint(point)
-        this.mapModel.setStartingCoordinates({
-          lat: this.mapModel.get('coordinateValues')['lat'],
-          lon: this.mapModel.get('coordinateValues')['lon'],
-        })
-        const polyline = this.map.addRulerLine(
-          this.mapModel.get('coordinateValues')
-        )
-        this.mapModel.setLine(polyline)
-        break
-      case 'END':
-        point = this.map.addRulerPoint(this.mapModel.get('coordinateValues'))
-        this.mapModel.addPoint(point)
-        this.map.setRulerLine({
-          lat: this.mapModel.get('coordinateValues')['lat'],
-          lon: this.mapModel.get('coordinateValues')['lon'],
-        })
-        break
-      case 'NONE':
-        this.clearRuler()
-        break
-      default:
-        break
-    }
-  },
-  /*
-    Handles tasks for clearing the ruler, which include removing all points
-    (endpoints of the line) and the line.
-  */
-  clearRuler() {
-    const points = this.mapModel.get('points')
-    points.forEach(point => {
-      this.map.removeRulerPoint(point)
-    })
-    this.mapModel.clearPoints()
-    const line = this.mapModel.removeLine()
-    this.map.removeRulerLine(line)
-  },
   onRightClick(event, mapEvent) {
     event.preventDefault()
     this.$el
@@ -457,7 +357,6 @@ module.exports = Marionette.LayoutView.extend({
       .css('top', event.offsetY)
     this.mapModel.updateClickCoordinates()
     this.mapContextMenu.currentView.model.open()
-    this.updateDistance(true)
   },
   setupRightClickMenu() {
     this.mapContextMenu.show(
@@ -582,12 +481,7 @@ module.exports = Marionette.LayoutView.extend({
       .get('preferences')
       .get('resultFilter')
     if (resultFilter) {
-      this.handleFilter(
-        CQLUtils.transformCQLToFilter(
-          CQLUtils.transformFilterToCQL(resultFilter)
-        ),
-        '#c89600'
-      )
+      this.handleFilter(CQLUtils.transformCQLToFilter(resultFilter), '#c89600')
     }
   },
   handleFilter(filter, color) {
@@ -598,15 +492,14 @@ module.exports = Marionette.LayoutView.extend({
     } else {
       let pointText
       let locationModel
-      const value = filter.value
       switch (filter.type) {
         case 'DWITHIN':
-          if (CQLUtils.isPolygonFilter(value)) {
-            this.handleFilterAsPolygon(value, color, filter.distance)
+          if (CQLUtils.isPolygonFilter(filter.value)) {
+            this.handleFilterAsPolygon(filter.value, color, filter.distance)
             break
           }
-          if (CQLUtils.isPointRadiusFilter(value)) {
-            pointText = value.value.substring(6)
+          if (CQLUtils.isPointRadiusFilter(filter.value)) {
+            pointText = filter.value.value.substring(6)
             pointText = pointText.substring(0, pointText.length - 1)
             const latLon = pointText.split(' ')
             locationModel = new LocationModel({
@@ -616,26 +509,32 @@ module.exports = Marionette.LayoutView.extend({
               color,
             })
             this.map.showCircleShape(locationModel)
-          } else {
-            pointText = value.value.substring(11)
-            pointText = pointText.substring(0, pointText.length - 1)
-            locationModel = new LocationModel({
-              lineWidth: filter.distance,
-              line: pointText
-                .split(',')
-                .map(coordinate =>
-                  coordinate.split(' ').map(value => Number(value))
-                ),
-              color,
-            })
-            this.map.showLineShape(locationModel)
+          } else if (CQLUtils.isLineFilter(filter.value)) {
+            this.handleFilterAsLine(filter, color)
           }
           break
         case 'INTERSECTS':
-          this.handleFilterAsPolygon(value, color, filter.distance)
+          if (CQLUtils.isPolygonFilter(filter.value)) {
+            this.handleFilterAsPolygon(filter.value, color, filter.distance)
+          } else if (CQLUtils.isLineFilter) {
+            this.handleFilterAsLine(filter, color)
+          }
           break
       }
     }
+  },
+  handleFilterAsLine(filter, color) {
+    const pointText = filter.value.value.substring(11, filter.value.value.length - 1)
+    const locationModel = new LocationModel({
+      lineWidth: filter.distance || 0,
+      line: pointText
+        .split(',')
+        .map(coordinate =>
+          coordinate.split(' ').map(value => Number(value))
+        ),
+      color,
+    })
+    this.map.showLineShape(locationModel)
   },
   handleFilterAsPolygon(value, color, distance) {
     const filterValue = typeof value === 'string' ? value : value.value

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -42,6 +42,8 @@ const Gazetteer = require('../../../react-component/location/gazetteer.js')
 
 import MapSettings from '../../../react-component/map-settings'
 import MapInfo from '../../../react-component/map-info'
+import DistanceInfo from '../../../react-component/distance-info'
+import getDistance from 'geolib/es/getDistance'
 
 function findExtreme({ objArray, property, comparator }) {
   if (objArray.length === 0) {
@@ -237,6 +239,19 @@ module.exports = Marionette.LayoutView.extend({
     )
     this.handleCurrentQuery()
 
+    // listener for when the measurement state changes in map model
+    this.listenTo(
+      this.mapModel,
+      'change:measurementState',
+      this.handleMeasurementStateChange.bind(this)
+    )
+
+    this.listenTo(
+      this.mapModel,
+      'change:mouseLat change:mouseLon',
+      this.updateDistance.bind(this)
+    )
+
     if (this.options.selectionInterface.getSelectedResults().length > 0) {
       this.map.zoomToSelected(
         this.options.selectionInterface.getSelectedResults()
@@ -349,6 +364,91 @@ module.exports = Marionette.LayoutView.extend({
       targetMetacard,
     })
   },
+  /*
+   *  Redraw and recalculate the ruler line and distanceInfo tooltip. Will not redraw while the menu is currently
+   *  displayed updateOnMenu allows updating while the menu is up
+   */
+  updateDistance(updateOnMenu = false) {
+    if (this.mapModel.get('measurementState') === 'START') {
+      const openMenu = this.mapContextMenu.currentView.model.changed.isOpen
+      const lat = this.mapModel.get('mouseLat')
+      const lon = this.mapModel.get('mouseLon')
+
+      if ((updateOnMenu === true || !openMenu) && lat && lon) {
+        // redraw ruler line
+        const mousePoint = { lat, lon }
+        this.map.setRulerLine(mousePoint)
+
+        // update distance info
+        const startingCoordinates = this.mapModel.get('startingCoordinates')
+        const dist = getDistance(
+          { latitude: lat, longitude: lon },
+          {
+            latitude: startingCoordinates['lat'],
+            longitude: startingCoordinates['lon'],
+          }
+        )
+        this.mapModel.setDistanceInfoPosition(event.clientX, event.clientY)
+        this.mapModel.setCurrentDistance(dist)
+      }
+    }
+  },
+  /*
+    Handles drawing or clearing the ruler as needed by the measurement state.
+
+    START indicates that a starting point should be drawn, 
+    so the map clears any previous points drawn and draws a new start point.
+
+    END indicates that an ending point should be drawn,
+    so the map draws an end point and a line, and calculates the distance.
+
+    NONE indicates that the ruler should be cleared.
+  */
+  handleMeasurementStateChange() {
+    const state = this.mapModel.get('measurementState')
+    let point = null
+    switch (state) {
+      case 'START':
+        this.clearRuler()
+        point = this.map.addRulerPoint(this.mapModel.get('coordinateValues'))
+        this.mapModel.addPoint(point)
+        this.mapModel.setStartingCoordinates({
+          lat: this.mapModel.get('coordinateValues')['lat'],
+          lon: this.mapModel.get('coordinateValues')['lon'],
+        })
+        const polyline = this.map.addRulerLine(
+          this.mapModel.get('coordinateValues')
+        )
+        this.mapModel.setLine(polyline)
+        break
+      case 'END':
+        point = this.map.addRulerPoint(this.mapModel.get('coordinateValues'))
+        this.mapModel.addPoint(point)
+        this.map.setRulerLine({
+          lat: this.mapModel.get('coordinateValues')['lat'],
+          lon: this.mapModel.get('coordinateValues')['lon'],
+        })
+        break
+      case 'NONE':
+        this.clearRuler()
+        break
+      default:
+        break
+    }
+  },
+  /*
+    Handles tasks for clearing the ruler, which include removing all points
+    (endpoints of the line) and the line.
+  */
+  clearRuler() {
+    const points = this.mapModel.get('points')
+    points.forEach(point => {
+      this.map.removeRulerPoint(point)
+    })
+    this.mapModel.clearPoints()
+    const line = this.mapModel.removeLine()
+    this.map.removeRulerLine(line)
+  },
   onRightClick(event, mapEvent) {
     event.preventDefault()
     this.$el
@@ -357,6 +457,7 @@ module.exports = Marionette.LayoutView.extend({
       .css('top', event.offsetY)
     this.mapModel.updateClickCoordinates()
     this.mapContextMenu.currentView.model.open()
+    this.updateDistance(true)
   },
   setupRightClickMenu() {
     this.mapContextMenu.show(
@@ -481,7 +582,12 @@ module.exports = Marionette.LayoutView.extend({
       .get('preferences')
       .get('resultFilter')
     if (resultFilter) {
-      this.handleFilter(CQLUtils.transformCQLToFilter(resultFilter), '#c89600')
+      this.handleFilter(
+        CQLUtils.transformCQLToFilter(
+          CQLUtils.transformFilterToCQL(resultFilter)
+        ),
+        '#c89600'
+      )
     }
   },
   handleFilter(filter, color) {
@@ -492,14 +598,15 @@ module.exports = Marionette.LayoutView.extend({
     } else {
       let pointText
       let locationModel
+      const value = filter.value
       switch (filter.type) {
         case 'DWITHIN':
-          if (CQLUtils.isPolygonFilter(filter.value)) {
-            this.handleFilterAsPolygon(filter.value, color, filter.distance)
+          if (CQLUtils.isPolygonFilter(value)) {
+            this.handleFilterAsPolygon(value, color, filter.distance)
             break
           }
-          if (CQLUtils.isPointRadiusFilter(filter.value)) {
-            pointText = filter.value.value.substring(6)
+          if (CQLUtils.isPointRadiusFilter(value)) {
+            pointText = value.value.substring(6)
             pointText = pointText.substring(0, pointText.length - 1)
             const latLon = pointText.split(' ')
             locationModel = new LocationModel({
@@ -509,8 +616,21 @@ module.exports = Marionette.LayoutView.extend({
               color,
             })
             this.map.showCircleShape(locationModel)
-          } else if (CQLUtils.isLineFilter(filter.value)) {
-            this.handleFilterAsLine(filter, color)
+          } else if (CQLUtils.isLineFilter(value)) {
+            this.handleFIlterAsLine(filter, color)
+          } else {
+            pointText = value.value.substring(11)
+            pointText = pointText.substring(0, pointText.length - 1)
+            locationModel = new LocationModel({
+              lineWidth: filter.distance,
+              line: pointText
+                .split(',')
+                .map(coordinate =>
+                  coordinate.split(' ').map(value => Number(value))
+                ),
+              color,
+            })
+            this.map.showLineShape(locationModel)
           }
           break
         case 'INTERSECTS':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -617,7 +617,7 @@ module.exports = Marionette.LayoutView.extend({
             })
             this.map.showCircleShape(locationModel)
           } else if (CQLUtils.isLineFilter(value)) {
-            this.handleFIlterAsLine(filter, color)
+            this.handleFilterAsLine(filter, color)
           } else {
             pointText = value.value.substring(11)
             pointText = pointText.substring(0, pointText.length - 1)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -87,7 +87,7 @@ function generateAnyGeoFilter(property, model) {
         return defaultGeoFilter
       }
       return {
-        type: 'DWITHIN',
+        type: model.lineWidth > 0 ? 'DWITHIN' : 'INTERSECTS',
         property,
         value:
           'LINESTRING' +
@@ -303,6 +303,10 @@ const isPolygonFilter = filter => {
   return geometryFilterContainsString(filter, 'POLYGON')
 }
 
+const isLineFilter = filter => {
+  return geometryFilterContainsString(filter, 'LINESTRING')
+}
+
 function isPointRadiusFilter(filter) {
   return geometryFilterContainsString(filter, 'POINT')
 }
@@ -389,6 +393,7 @@ module.exports = {
   transformFilterToCQL,
   transformCQLToFilter,
   isPolygonFilter,
+  isLineFilter,
   isPointRadiusFilter,
   buildIntersectCQL,
   arrayFromPolygonWkt,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
@@ -393,7 +393,7 @@ function matchesFilter(metacard, filter) {
           break
         case 'INTERSECTS':
           if (CQLUtils.isPolygonFilter(filter)) {
-            if (matchesBufferedPOLYGON(valuesToCheck[i], filter)) {
+            if (matchesPOLYGON(valuesToCheck[i], filter)) {
               return true
             }
           } else if (CQLUtils.isLineFilter(filter)) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
@@ -187,7 +187,7 @@ function intersects(terraformerObject, value) {
 }
 
 function matchesPOLYGON(value, filter) {
-  const polygonToCheck = TerraformerWKTParser.parse(filter.value.value)
+  const polygonToCheck = TerraformerWKTParser.parse(filter.value)
   if (intersects(polygonToCheck, value)) {
     return true
   }
@@ -196,7 +196,7 @@ function matchesPOLYGON(value, filter) {
 
 const matchesBufferedPOLYGON = (value, filter) => {
   const bufferedPolygon = createBufferedPolygon(
-    polygonStringToCoordinates(filter.value.value),
+    polygonStringToCoordinates(filter.value),
     filter.distance
   )
   const teraformedPolygon = new Terraformer.Polygon({
@@ -210,9 +210,7 @@ function matchesCIRCLE(value, filter) {
   if (filter.distance <= 0) {
     return false
   }
-  const points = filter.value.value
-    .substring(6, filter.value.value.length - 1)
-    .split(' ')
+  const points = filter.value.substring(6, filter.value.length - 1).split(' ')
   const circleToCheck = new Terraformer.Circle(points, filter.distance, 64)
   const polygonCircleToCheck = new Terraformer.Polygon(circleToCheck.geometry)
   if (intersects(polygonCircleToCheck, value)) {
@@ -222,7 +220,7 @@ function matchesCIRCLE(value, filter) {
 }
 
 function matchesLINESTRING(value, filter) {
-  let pointText = filter.value.value.substring(11)
+  let pointText = filter.value.substring(11)
   pointText = pointText.substring(0, pointText.length - 1)
   const lineWidth = filter.distance || 0
   if (lineWidth <= 0) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/filter.js
@@ -187,7 +187,7 @@ function intersects(terraformerObject, value) {
 }
 
 function matchesPOLYGON(value, filter) {
-  const polygonToCheck = TerraformerWKTParser.parse(filter.value)
+  const polygonToCheck = TerraformerWKTParser.parse(filter.value.value)
   if (intersects(polygonToCheck, value)) {
     return true
   }
@@ -196,7 +196,7 @@ function matchesPOLYGON(value, filter) {
 
 const matchesBufferedPOLYGON = (value, filter) => {
   const bufferedPolygon = createBufferedPolygon(
-    polygonStringToCoordinates(filter.value),
+    polygonStringToCoordinates(filter.value.value),
     filter.distance
   )
   const teraformedPolygon = new Terraformer.Polygon({
@@ -210,7 +210,9 @@ function matchesCIRCLE(value, filter) {
   if (filter.distance <= 0) {
     return false
   }
-  const points = filter.value.substring(6, filter.value.length - 1).split(' ')
+  const points = filter.value.value
+    .substring(6, filter.value.value.length - 1)
+    .split(' ')
   const circleToCheck = new Terraformer.Circle(points, filter.distance, 64)
   const polygonCircleToCheck = new Terraformer.Polygon(circleToCheck.geometry)
   if (intersects(polygonCircleToCheck, value)) {
@@ -220,7 +222,7 @@ function matchesCIRCLE(value, filter) {
 }
 
 function matchesLINESTRING(value, filter) {
-  let pointText = filter.value.substring(11)
+  let pointText = filter.value.value.substring(11)
   pointText = pointText.substring(0, pointText.length - 1)
   const lineWidth = filter.distance || 0
   if (lineWidth <= 0) {
@@ -390,8 +392,14 @@ function matchesFilter(metacard, filter) {
           }
           break
         case 'INTERSECTS':
-          if (matchesPOLYGON(valuesToCheck[i], filter)) {
-            return true
+          if (CQLUtils.isPolygonFilter(filter)) {
+            if (matchesBufferedPOLYGON(valuesToCheck[i], filter)) {
+              return true
+            }
+          } else if (CQLUtils.isLineFilter(filter)) {
+            if (matchesLINESTRING(valuesToCheck[i], filter)) {
+              return true
+            }
           }
           break
         case 'DWITHIN':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -115,7 +115,11 @@ class LocationInput extends React.Component {
         }
         break
       case 'INTERSECTS':
-        wreqr.vent.trigger('search:polydisplay', this.locationModel)
+        if (CQLUtils.isLineFilter(filter)) {
+          wreqr.vent.trigger('search:linedisplay', this.locationModel)
+        } else {
+          wreqr.vent.trigger('search:polydisplay', this.locationModel)
+        }
         break
       // these cases are for when the model matches the location model
       default:

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -116,13 +116,6 @@ const BaseLine = props => {
           : JSON.stringify(props[geometryKey])
       )
       if (props.drawing) {
-        // if (
-        //   geometryKey.includes('line') &&
-        //   (lineWidth === undefined || Number(lineWidth) <= 0)
-        // ) {
-        //   setState({ [widthKey]: 1 })
-        //   setBufferError(initialErrorState)
-        // }
         setBaseLineError(initialErrorState)
       }
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -116,13 +116,13 @@ const BaseLine = props => {
           : JSON.stringify(props[geometryKey])
       )
       if (props.drawing) {
-        if (
-          geometryKey.includes('line') &&
-          (lineWidth === undefined || Number(lineWidth) <= 0)
-        ) {
-          setState({ [widthKey]: 1 })
-          setBufferError(initialErrorState)
-        }
+        // if (
+        //   geometryKey.includes('line') &&
+        //   (lineWidth === undefined || Number(lineWidth) <= 0)
+        // ) {
+        //   setState({ [widthKey]: 1 })
+        //   setBufferError(initialErrorState)
+        // }
         setBaseLineError(initialErrorState)
       }
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -109,7 +109,7 @@ const BaseLine = props => {
 
   useEffect(
     () => {
-      const { geometryKey, lineWidth } = props
+      const { geometryKey } = props
       setCurrentValue(
         typeof props[geometryKey] === 'string'
           ? props[geometryKey]

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -469,7 +469,7 @@ function validateUtmUps(key: string, value: any) {
 function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
-  if (key === 'polygonBufferWidth' || key === 'bufferWidth') {
+  if (key.includes('Width')) {
     if (buffer > 0 && buffer < 1) {
       return {
         error: true,


### PR DESCRIPTION
UI PORTION OF the Forward-port of https://github.com/codice/ddf/pull/5889

**This pr must be built on top of this DDF PR: https://github.com/codice/ddf/pull/5914

__________________________________________________________________________________
#### What does this PR do?
Allows a line to have a zero-buffer. Solves https://github.com/codice/ddf-ui/issues/112

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton @andrewzimmer @zta6 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@bdeining 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Advanced search - anyGeo
- Select Line
- Draw a line and verify that it doesn't automatically change the buffer width to 1
- Verify that you can search with nothing (and/or 0) in the buffer width input, and that the outgoing cql uses INTERSECTS instead of DWITHIN
- Verify that searching with a buffer width greater than 1 meter is allowed and that the outgoing cql uses DWITHIN
- Verify that searching with a buffer width of greater than 0 but less than 1 meter displays an inline error message "Buffer width must be 0 or at least 1 meter".  similar message should display when clicking search (the search should be prevented). Error message should change based on which units you have selected
- Verify no regression with Line searches

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes:  https://github.com/codice/ddf-ui/issues/112

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
