### PR TITLE
Fix security calls that fetch system subject

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsLoader.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsLoader.java
@@ -126,7 +126,11 @@ public class SearchFormsLoader {
    * @param systemTemplates system templates loaded from config.
    */
   public void bootstrap(List<Metacard> systemTemplates) {
-    security.getSystemSubject().execute(() -> this.createSystemMetacards(systemTemplates));
+    security.runAsAdmin(
+        () -> {
+          security.getSystemSubject().execute(() -> this.createSystemMetacards(systemTemplates));
+          return null;
+        });
   }
 
   public List<Metacard> retrieveSystemTemplateMetacards() {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -1055,7 +1055,7 @@ public class MetacardApplication implements SparkApplication {
    * @return result of the callable func
    */
   private <T> T executeAsSystem(Callable<T> func) {
-    return security.getSystemSubject().execute(func);
+    return security.runAsAdmin(() -> security.getSystemSubject().execute(func));
   }
 
   private Instant getVersionedOnDate(Metacard mc) {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/monitor/impl/SecurityServiceImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/monitor/impl/SecurityServiceImpl.java
@@ -30,7 +30,7 @@ public class SecurityServiceImpl implements SecurityService {
 
   @Override
   public Subject getSystemSubject() {
-    return security.getSystemSubject();
+    return security.runAsAdmin(() -> security.getSystemSubject());
   }
 
   @Override


### PR DESCRIPTION
The security calls need to be ran by the admin user in order to get the system subject -- so this adds the required `runAsAdmin` around the getSystemSubject calls. 