### PR TITLE
DDF-UI-140 add check to selected search form

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -61,6 +61,12 @@ module.exports = Marionette.LayoutView.extend({
     this.listenForSave()
   },
   updateCurrentQuery(currentQuerySettings) {
+    if (
+      currentQuerySettings.get('type') !== 'custom' &&
+      currentQuerySettings.get('type') !== 'text'
+    ) {
+      return
+    }
     const searchForm = new SearchForm(currentQuerySettings.get('template'))
     const sharedAttributes = searchForm.transformToQueryStructure()
     this.model.set({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -105,7 +105,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     this.listenTo(user.getQuerySettings(), 'change', function() {
       this.$el.toggleClass(
         'is-current-template',
-        user.getQuerySettings().isTemplate(this.model)
+        user.getQuerySettings().isDefaultTemplate(this.model)
       )
     })
   },
@@ -113,7 +113,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')))
     this.$el.toggleClass(
       'is-current-template',
-      user.getQuerySettings().isTemplate(this.model)
+      user.getQuerySettings().isDefaultTemplate(this.model)
     )
     this.$el.toggleClass(
       'is-result-form-template',
@@ -201,6 +201,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     this.trigger('doneLoading')
   },
   handleMakeDefault() {
+    this.model.set('default', true)
     user.getQuerySettings().set({
       type: 'custom',
       template: this.model.toJSON(),
@@ -213,6 +214,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     )
   },
   handleClearDefault() {
+    this.model.set('default', false)
     user.getQuerySettings().set({
       template: undefined,
       type: 'text',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -32,6 +32,7 @@ module.exports = Backbone.Model.extend({
       accessGroups: [],
       accessAdministrators: [],
       querySettings: {},
+      default: false,
     }
   },
   transformToQueryStructure() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -139,7 +139,7 @@ const CustomSearchForm = props => {
 
 export default Marionette.LayoutView.extend({
   template(props) {
-    const isDefault = user.getQuerySettings().isTemplate(this.model)
+    const isDefault = user.getQuerySettings().isDefaultTemplate(this.model)
     if (props.type === 'custom') {
       return (
         <CustomSearchForm

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.container.tsx
@@ -32,8 +32,15 @@ class SearchInteractions extends React.Component<Props> {
     this.props.listenTo(this.props.model, 'change:type', this.props.onClose)
   }
   triggerQueryForm = (formId: string) => {
+    const querySetting = user.getQuerySettings()
     this.props.model.set('type', formId)
-    user.getQuerySettings().set('type', formId)
+    querySetting.set('type', formId)
+    if (
+      this.props.model.get('template') &&
+      !querySetting.isDefaultTemplate(this.props.model.get('template'))
+    ) {
+      querySetting.set('template', undefined)
+    }
     user.savePreferences()
     this.props.onClose()
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.presentation.tsx
@@ -73,12 +73,14 @@ export const SearchFormMenuItem = ({
   onClick,
   active,
   onHover,
+  selected,
 }: {
   value: any
   title: any
   onClick?: any
   active?: any
   onHover?: any
+  selected?: any
 }) => {
   return (
     <MenuItem
@@ -88,6 +90,7 @@ export const SearchFormMenuItem = ({
       onClick={onClick}
       active={active}
       onHover={onHover}
+      selected={selected}
     >
       <Text>
         <Icon className="fa fa-search" />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/search-interactions/search-interactions.tsx
@@ -42,6 +42,7 @@ const SearchInteractions = (props: SearchInteractionProps) => (
                 key={form.id}
                 value={form.id}
                 title={form.title}
+                selected={props.model.get('type') === form.id}
               />
             )
           })}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -39,4 +39,7 @@ module.exports = Backbone.Model.extend({
       return false
     }
   },
+  isDefaultTemplate(template) {
+    return this.isTemplate(template) && this.get('template').default
+  },
 })


### PR DESCRIPTION
### forward port of https://github.com/codice/ddf/pull/5943

#### What does this PR do?
- adds a check next to the selected search form so a user can easily identify which form is selected
- selected user forms will now stay selected after search/refresh if user does not have a default form
#### Who is reviewing it? 
@hayleynorton @zta6 @cassandrabailey293 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
- build / run
- create search forms
- open a new search and switch between forms, verify correct form is checked
- make one of the search forms default
- open a new search, verify correct form is checked
- switch search form and run, open a new search and verify default form is showing and checked

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: codice/ddf-ui#140

#### Screenshots
<img width="645" alt="Screen Shot 2020-03-25 at 3 52 25 PM" src="https://user-images.githubusercontent.com/39923178/77589086-b056cf00-6eb0-11ea-9839-5ee5d5ccf69b.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
