### PR TITLE
Only enforce owner setting if it is missing

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPreIngestPlugin.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPreIngestPlugin.java
@@ -86,20 +86,22 @@ public class AccessControlPreIngestPlugin implements PreIngestPlugin {
             .stream()
             .anyMatch(metacard -> StringUtils.isEmpty(AccessControlUtil.getOwner(metacard)));
 
-    if (missingOwner && SubjectUtils.isGuest(ownerSubject)) {
-      throw new StopProcessingException(
-          "Guest user not allowed to create access-controlled resources");
-    }
+    if (missingOwner) {
+      if (SubjectUtils.isGuest(ownerSubject)) {
+        throw new StopProcessingException(
+            "Guest user not allowed to create access-controlled resources");
+      }
 
-    metacards.forEach(
-        metacard -> {
-          String owner =
-              AccessControlUtil.getOwner(metacard) != null
-                  ? AccessControlUtil.getOwner(metacard)
-                  : subjectIdentity.getUniqueIdentifier(ownerSubject);
-          AccessControlUtil.setOwner(metacard, owner);
-          setAccessAdministrator(metacard, owner);
-        });
+      metacards.forEach(
+          metacard -> {
+            String owner =
+                AccessControlUtil.getOwner(metacard) != null
+                    ? AccessControlUtil.getOwner(metacard)
+                    : subjectIdentity.getUniqueIdentifier(ownerSubject);
+            AccessControlUtil.setOwner(metacard, owner);
+            setAccessAdministrator(metacard, owner);
+          });
+    }
 
     return request;
   }


### PR DESCRIPTION
The AccessControlPreIngestPlugin checks to see if there is an owner or not on a metacard that is being created.  It then basically ignores that check and resets the owner and `security.access-administrators`.  This is a problem if the original metacard did in fact have an owner and the security attributes were populated with valid data.

This PR makes it only apply this if there is no owner set on the metacard and the user is not guest.