### PR TITLE
DDF-5829: map plugin support ported to ddf-ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.24.0</ddf.version>
+    <ddf.version>2.24.0-SNAPSHOT</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <karaf.version>4.2.6</karaf.version>
     <camel.version>2.22.1</camel.version>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -208,7 +208,10 @@ module.exports = function CesiumMap(
 ) {
   let overlays = {}
   let shapes = []
-  const { map, requestRenderHandler } = createMap(insertionElement, cameraOptions && cameraOptions.cesium)
+  const { map, requestRenderHandler } = createMap(
+    insertionElement,
+    cameraOptions && cameraOptions.cesium
+  )
   const drawHelper = new DrawHelper(map)
   const billboardCollection = setupBillboardCollection()
   const labelCollection = setupLabelCollection()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -75,7 +75,7 @@ function setupTerrainProvider(viewer, terrainProvider) {
   viewer.scene.terrainProvider = customTerrainProvider
 }
 
-function createMap(insertionElement) {
+function createMap(insertionElement, cameraOptions) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
   const layerCollectionController = new CesiumLayerCollectionController({
@@ -100,6 +100,7 @@ function createMap(insertionElement) {
       baseLayerPicker: false, // Hide the base layer picker,
       imageryProvider: false, // prevent default imagery provider
       mapMode2D: 0,
+      cameraOptions,
     },
   })
 
@@ -202,11 +203,12 @@ module.exports = function CesiumMap(
   selectionInterface,
   notificationEl,
   componentElement,
-  mapModel
+  mapModel,
+  cameraOptions
 ) {
   let overlays = {}
   let shapes = []
-  const { map, requestRenderHandler } = createMap(insertionElement)
+  const { map, requestRenderHandler } = createMap(insertionElement, cameraOptions && cameraOptions.cesium)
   const drawHelper = new DrawHelper(map)
   const billboardCollection = setupBillboardCollection()
   const labelCollection = setupLabelCollection()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -45,6 +45,8 @@ import MapInfo from '../../../react-component/map-info'
 import DistanceInfo from '../../../react-component/distance-info'
 import getDistance from 'geolib/es/getDistance'
 
+import plugin from 'plugins/map.view'
+
 function findExtreme({ objArray, property, comparator }) {
   if (objArray.length === 0) {
     return undefined
@@ -137,7 +139,7 @@ const defaultHomeBoundingBox = {
   north: 52,
 }
 
-module.exports = Marionette.LayoutView.extend({
+const View = Marionette.LayoutView.extend({
   tagName: CustomElements.register('map'),
   template,
   regions: {
@@ -266,6 +268,10 @@ module.exports = Marionette.LayoutView.extend({
     this.setupDistanceInfo()
     this.setupPopupPreview()
   },
+  /**
+   * Returns a map of camera options (such as min/max zoom, etc) for Open layers and Cesium map views
+   */
+  getCameraOptions() {},
   zoomToHome() {
     const home = [
       user
@@ -519,7 +525,8 @@ module.exports = Marionette.LayoutView.extend({
       this.options.selectionInterface,
       this.mapDrawingPopup.el,
       this.el,
-      this.mapModel
+      this.mapModel,
+      this.getCameraOptions()
     )
     this.setupCollections()
     this.setupListeners()
@@ -684,3 +691,5 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
 })
+
+module.exports = plugin(View)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -105,17 +105,17 @@ const OpenlayersMap = extension =>
     notificationEl,
     componentElement,
     mapModel,
-  cameraOptions
-) {
-  let overlays = {}
-  let shapes = []
-  const map = createMap(
-    insertionElement,
-    cameraOptions && cameraOptions.openlayers
-  )
-  listenToResize()
-  setupTooltip(map)
-  const drawingTools = setupDrawingTools(map)
+    cameraOptions
+  ) {
+    let overlays = {}
+    let shapes = []
+    const map = createMap(
+      insertionElement,
+      cameraOptions && cameraOptions.openlayers
+    )
+    listenToResize()
+    setupTooltip(map)
+    const drawingTools = setupDrawingTools(map)
 
     function setupTooltip(map) {
       map.on('pointermove', e => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -37,6 +37,8 @@ const User = require('../../../../js/model/User.js')
 const wreqr = require('../../../../js/wreqr.js')
 import { validateGeo } from '../../../../react-component/utils/validation'
 
+const DEFAULT_MAP_CAMERA_OPTIONS = { zoom: 3, minZoom: 1.9, center: [0, 0] }
+
 const defaultColor = '#3c6dd5'
 const rulerColor = '#506f85'
 
@@ -47,16 +49,17 @@ const OpenLayerCollectionController = LayerCollectionController.extend({
   },
 })
 
-function createMap(insertionElement) {
+function createMap(
+  insertionElement,
+  cameraOptions = DEFAULT_MAP_CAMERA_OPTIONS
+) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
   const layerCollectionController = new OpenLayerCollectionController({
     collection: layerPrefs,
   })
   const map = layerCollectionController.makeMap({
-    zoom: 2.7,
-    minZoom: 2.3,
-    center: [0, 0],
+    cameraOptions: cameraOptions,
     element: insertionElement,
   })
 
@@ -101,14 +104,18 @@ const OpenlayersMap = extension =>
     selectionInterface,
     notificationEl,
     componentElement,
-    mapModel
-  ) {
-    let overlays = {}
-    let shapes = []
-    const map = createMap(insertionElement)
-    listenToResize()
-    setupTooltip(map)
-    const drawingTools = setupDrawingTools(map)
+    mapModel,
+  cameraOptions
+) {
+  let overlays = {}
+  let shapes = []
+  const map = createMap(
+    insertionElement,
+    cameraOptions && cameraOptions.openlayers
+  )
+  listenToResize()
+  setupTooltip(map)
+  const drawingTools = setupDrawingTools(map)
 
     function setupTooltip(map) {
       map.on('pointermove', e => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -49,6 +49,12 @@ const Controller = CommonLayerController.extend({
     this.map.scene.requestRenderMode = true
     this.layerOrder = []
 
+    if (options.cesiumOptions.cameraOptions)
+      Object.entries(options.cesiumOptions.cameraOptions).forEach(
+        entry =>
+          (this.map.scene.screenSpaceCameraController[entry[0]] = entry[1])
+      )
+
     this.collection.forEach(function(model) {
       if (model.get('show')) {
         this.initLayer(model)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -149,8 +149,7 @@ const Controller = CommonLayerController.extend({
     const view = new ol.View({
       projection: ol.proj.get(properties.projection),
       center: ol.proj.transform([0, 0], 'EPSG:4326', properties.projection),
-      zoom: options.zoom,
-      minZoom: options.minZoom,
+      ...options.cameraOptions,
     })
 
     const config = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -147,9 +147,9 @@ const Controller = CommonLayerController.extend({
     })
 
     const view = new ol.View({
-      projection: ol.proj.get(properties.projection),
-      center: ol.proj.transform([0, 0], 'EPSG:4326', properties.projection),
       ...options.cameraOptions,
+      projection: ol.proj.get(properties.projection),
+      center: ol.proj.transform([0, 1], 'EPSG:4326', properties.projection),
     })
 
     const config = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+type MapViewCameraExtension = {
+  getCameraOptions: () => { [key: string]: {} }
+}
+
+export default (mapView: any) => mapView as MapViewCameraExtension


### PR DESCRIPTION
#### What does this PR do?
Ports ability to extend map (Cesium and OpenLayers) to `ddf-ui`. See: https://github.com/codice/ddf/pull/5830 for more details

#### Who is reviewing it? 
@bennuttle 
@frnkshin 
@hayleynorton 
@lavoywj 
@bdeining 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@AzGoalie
@bdeining

#### How should this be tested?
Interact with both 2D and 3D maps in the UI to verify no regressions have been introduced.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5829

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
