### PR TITLE
DDF-5649 G-6176 returns processing details to UI

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
@@ -32,6 +32,7 @@ import ddf.catalog.util.impl.ResultIterable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -108,7 +109,18 @@ public class CqlQueriesImpl implements CqlQueries {
                 .filter(Objects::nonNull)
                 .map(QueryResponse::getProperties)
                 .findFirst()
-                .orElse(Collections.emptyMap()));
+                .orElse(Collections.emptyMap()),
+            responses
+                .stream()
+                .filter(Objects::nonNull)
+                .map(QueryResponse::getProcessingDetails)
+                .reduce(
+                    new HashSet<>(),
+                    (l, r) -> {
+                      l.addAll(r);
+                      return l;
+                    }));
+    ;
 
     stopwatch.stop();
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
@@ -116,9 +116,9 @@ public class CqlQueriesImpl implements CqlQueries {
                 .map(QueryResponse::getProcessingDetails)
                 .reduce(
                     new HashSet<>(),
-                    (l, r) -> {
-                      l.addAll(r);
-                      return l;
+                    (left, right) -> {
+                      left.addAll(right);
+                      return left;
                     }));
     ;
 

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/CqlQueriesImplTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/CqlQueriesImplTest.java
@@ -27,10 +27,13 @@ import ddf.catalog.filter.AttributeBuilder;
 import ddf.catalog.filter.ContextualExpressionBuilder;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.codice.ddf.catalog.ui.config.ConfigurationApplication;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
 import org.codice.ddf.catalog.ui.query.utility.CqlQueryResponse;
@@ -50,6 +53,10 @@ public class CqlQueriesImplTest {
   private ActionRegistry actionRegistryMock;
 
   private QueryResponse responseMock;
+
+  private ProcessingDetails detailsMock1;
+
+  private ProcessingDetails detailsMock2;
 
   CatalogFramework catalogFrameworkMock;
 
@@ -71,7 +78,13 @@ public class CqlQueriesImplTest {
     filterAdapterMock = mock(FilterAdapter.class);
     actionRegistryMock = mock(ActionRegistry.class);
     responseMock = mock(QueryResponse.class);
+    detailsMock1 = mock(ProcessingDetails.class);
+    detailsMock2 = mock(ProcessingDetails.class);
 
+    HashSet<ProcessingDetails> details = new HashSet<>();
+    details.add(detailsMock1);
+    details.add(detailsMock2);
+    when(responseMock.getProcessingDetails()).thenReturn(details);
     when(filterBuilderMock.attribute(any())).thenReturn(attributeBuilderMock);
     when(attributeBuilderMock.is()).thenReturn(attributeBuilderMock);
     when(attributeBuilderMock.like()).thenReturn(contextualExpressionBuilderMock);
@@ -103,5 +116,19 @@ public class CqlQueriesImplTest {
     List<CqlResult> results = cqlQueryResponse.getResults();
     assertThat(results, hasSize(0));
     assertThat(cqlQueryResponse.getQueryResponse().getHits(), is(hitCount));
+  }
+
+  @Test
+  public void testQueryWithDetails() throws Exception {
+    long hitCount = 12L;
+    when(responseMock.getResults()).thenReturn(Collections.emptyList());
+    when(responseMock.getHits()).thenReturn(hitCount);
+    when(catalogFrameworkMock.query(any(QueryRequestImpl.class))).thenReturn(responseMock);
+
+    CqlQueryResponse cqlQueryResponse = cqlQueryUtil.executeCqlQuery(generateCqlRequest(1));
+    Set<ProcessingDetails> details = cqlQueryResponse.getQueryResponse().getProcessingDetails();
+    assertThat(details.size(), is(2));
+    assertThat(details.contains(detailsMock1), is(true));
+    assertThat(details.contains(detailsMock2), is(true));
   }
 }

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/CqlQueriesImplTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/CqlQueriesImplTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -128,7 +129,7 @@ public class CqlQueriesImplTest {
     CqlQueryResponse cqlQueryResponse = cqlQueryUtil.executeCqlQuery(generateCqlRequest(1));
     Set<ProcessingDetails> details = cqlQueryResponse.getQueryResponse().getProcessingDetails();
     assertThat(details.size(), is(2));
-    assertThat(details.contains(detailsMock1), is(true));
-    assertThat(details.contains(detailsMock2), is(true));
+    assertThat(details, hasItem(detailsMock1));
+    assertThat(details, hasItem(detailsMock2));
   }
 }


### PR DESCRIPTION
ProcessingDetails were not being included in the QueryResponse to the UI.  The UI code looks at the query response status and will display warning info if the details include exception information.   This PR ensures processing details are getting returned.