### PR TITLE
DDF-5909 Clear geo search drawing correctly when using query-basic form

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -44,8 +44,14 @@ function isNested(filter) {
   return nested
 }
 
+const requestMapRender = () => {
+  // Required to force rendering of the 3D map after drawing is cleared.
+  wreqr.vent.trigger('map:requestRender')
+}
+
 const turnOffDrawing = () => {
   wreqr.vent.trigger('search:drawend', store.get('content').get('drawingModel'))
+  requestMapRender()
 }
 
 function getMatchTypeAttribute() {
@@ -419,6 +425,11 @@ module.exports = Marionette.LayoutView.extend({
     if (this.filter.anyGeo) {
       currentValue = this.filter.anyGeo[0]
     }
+    const currentView = this.basicLocationSpecific.currentView
+    if (currentView && currentView.model) {
+      this.stopListening(currentView.model)
+    }
+
     this.basicLocationSpecific.show(
       new PropertyView({
         model: new Property({
@@ -427,6 +438,12 @@ module.exports = Marionette.LayoutView.extend({
           type: 'LOCATION',
         }),
       })
+    )
+
+    this.listenTo(
+      this.basicLocationSpecific.currentView.model,
+      'change:value',
+      requestMapRender
     )
   },
   handleTypeValue() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -20,6 +20,7 @@ const $ = require('jquery')
 const template = require('./query-basic.hbs')
 const CustomElements = require('../../js/CustomElements.js')
 const store = require('../../js/store.js')
+const wreqr = require('../../js/wreqr.js')
 const IconHelper = require('../../js/IconHelper.js')
 const PropertyView = require('../property/property.view.js')
 const Property = require('../property/property.js')
@@ -41,6 +42,10 @@ function isNested(filter) {
     nested = nested || subfilter.filters
   })
   return nested
+}
+
+const turnOffDrawing = () => {
+  wreqr.vent.trigger('search:drawend', store.get('content').get('drawingModel'))
 }
 
 function getMatchTypeAttribute() {
@@ -433,6 +438,10 @@ module.exports = Marionette.LayoutView.extend({
     const location = this.basicLocation.currentView.model.getValue()[0]
     this.$el.toggleClass('is-location-any', location === 'any')
     this.$el.toggleClass('is-location-specific', location === 'specific')
+    if (location === 'any') {
+      turnOffDrawing()
+      this.setupLocationInput()
+    }
   },
   setupTextMatchInput() {
     this.basicTextMatch.show(


### PR DESCRIPTION
**Forward port of [codice/ddf#5910](https://github.com/codice/ddf/pull/5910)**

#### What does this PR do?
Clears drawings from a basic location search when toggling from "Somewhere Specific" to "Anywhere" location filters.

#### Who is reviewing it? 
@jordanwilking @andrewkfiedler @stevenmalmgren 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@vinamartin

#### How should this be tested?
On the Basic Search menu, click the "Somewhere Specific" location filter. 
Draw any geo on a map visual.
Switch back to the "Anywhere" filter. The drawing should be cleared.

#### What are the relevant tickets?
Fixes: #5909 

#### Screenshots
<img width="600" alt="Screen Shot 2020-03-17 at 10 13 38 AM" src="https://user-images.githubusercontent.com/31322332/76909154-b07b1d00-6867-11ea-9b58-09c9950a9e51.png">

After toggling back to "Anywhere"
<img width="600" alt="Screen Shot 2020-03-17 at 10 14 14 AM" src="https://user-images.githubusercontent.com/31322332/76909435-73635a80-6868-11ea-983d-6d080d6a059a.png">
