### PR TITLE
DDF-5360 Removes the use of constants defined in DDF from OAuthApplication

### DIFF
--- a/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplication.java
+++ b/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplication.java
@@ -18,11 +18,6 @@ import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_SEE_OTHER;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.CLIENT_ID;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.DISCOVERY_URL;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.SECRET;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.SOURCE_ID;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.STATE;
 import static spark.Spark.get;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -65,6 +60,11 @@ public class OAuthApplication implements SparkApplication {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OAuthApplication.class);
 
+  private static final String DISCOVERY_URL = "discovery_url";
+  private static final String CLIENT_ID = "client_id";
+  private static final String SECRET = "client_secret";
+  private static final String SOURCE_ID = "source_id";
+  private static final String STATE = "state";
   private static final String CODE = "code";
   private static final String REDIRECT_URI = "redirect_uri";
   private static final String REDIRECT_URL =

--- a/ui-backend/catalog-ui-oauth/src/test/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplicationTest.java
+++ b/ui-backend/catalog-ui-oauth/src/test/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplicationTest.java
@@ -13,10 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.oauth.app;
 
-import static org.codice.ddf.security.token.storage.api.TokenStorage.CLIENT_ID;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.DISCOVERY_URL;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.SECRET;
-import static org.codice.ddf.security.token.storage.api.TokenStorage.SOURCE_ID;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -68,6 +64,10 @@ import spark.Response;
 
 public class OAuthApplicationTest {
 
+  private static final String DISCOVERY_URL = "discovery_url";
+  private static final String CLIENT_ID = "client_id";
+  private static final String SECRET = "client_secret";
+  private static final String SOURCE_ID = "source_id";
   private static final String SESSION_ID = "sessionId";
   private static final String CSW_SOURCE = "CSW";
   private static final String ACCESS_TOKEN_VAL = "myAccessToken";


### PR DESCRIPTION
Changes in constants defined in DDF's TokenStorage will break the OAuthApplication. To prevent this from happening again and further decouple DDF and DDF-UI, this PR just defines the constants in OAuthApplication and uses them instead. 