### PR TITLE
[3.4.x] DDF-UI-146 Add error messaging for when bounding box south >= north

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
@@ -13,10 +13,10 @@
  *
  **/
 const React = require('react')
-const dmsRegex = new RegExp('^(.*)°(.*)\'(.*\\.?.*)"$')
 const TextField = require('../../../react-component/text-field/index.js')
 const MaskedTextField = require('../inputs/masked-text-field')
 const { latitudeDMSMask, longitudeDMSMask } = require('./masks')
+const { buildDmsString, parseDmsCoordinate } = require('../utils/dms-utils')
 
 const Coordinate = props => {
   const { placeholder, value, onChange, children, ...otherProps } = props
@@ -57,7 +57,10 @@ const DmsLatitude = props => {
       placeholderChar="_"
       {...props}
       onBlur={event => {
-        props.onChange(pad(props.value), event.type)
+        props.onChange(
+          buildDmsString(parseDmsCoordinate(props.value)),
+          event.type
+        )
       }}
     />
   )
@@ -71,7 +74,10 @@ const DmsLongitude = props => {
       placeholderChar="_"
       {...props}
       onBlur={event => {
-        props.onChange(pad(props.value), event.type)
+        props.onChange(
+          buildDmsString(parseDmsCoordinate(props.value)),
+          event.type
+        )
       }}
     />
   )
@@ -111,35 +117,6 @@ const UsngCoordinate = props => {
       <TextField label="Grid" {...props} />
     </div>
   )
-}
-
-const pad = coordinate => {
-  if (coordinate === undefined) {
-    return coordinate
-  }
-  const matches = dmsRegex.exec(coordinate)
-  if (!matches) {
-    return coordinate
-  }
-  let deg = matches[1]
-  let min = matches[2]
-  let sec = matches[3]
-  deg = padComponent(deg)
-  min = padComponent(min)
-  sec = padComponent(sec)
-  return deg + '°' + min + "'" + sec + '"'
-}
-
-const padComponent = (numString = '') => {
-  while (numString.includes('_')) {
-    if (numString.includes('.')) {
-      numString = numString.replace('_', '0')
-    } else {
-      numString = numString.replace('_', '')
-      numString = '0' + numString
-    }
-  }
-  return numString
 }
 
 module.exports = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.js
@@ -113,34 +113,17 @@ function parseDdCoordinate(coordinate) {
   return _coordinate
 }
 
-function validateLatitudeRange(latitude) {
-  return latitude >= -90 && latitude <= 90
-}
-
-function validateLongitudeRange(longitude) {
-  return longitude >= -180 && longitude <= 180
-}
-
-function validateDdLatitude(latitude) {
-  const _latitude = parseDdCoordinate(latitude)
-  if (_latitude == null) {
-    return false
-  }
-  return validateLatitudeRange(_latitude)
-}
-
-function validateDdLongitude(longitude) {
-  const _longitude = parseDdCoordinate(longitude)
-  if (_longitude == null) {
-    return false
-  }
-  return validateLongitudeRange(_longitude)
+function inValidRange(coordinate, maximum) {
+  return coordinate >= -1 * maximum && coordinate <= maximum
 }
 
 function validateDdPoint(point) {
-  return (
-    validateDdLatitude(point.latitude) && validateDdLongitude(point.longitude)
-  )
+  const latitude = parseDdCoordinate(point.latitude)
+  const longitude = parseDdCoordinate(point.longitude)
+  if (latitude && longitude) {
+    return inValidRange(latitude, 90) && inValidRange(longitude, 180)
+  }
+  return false
 }
 
 function validateDdBoundingBox(boundingbox) {
@@ -154,10 +137,10 @@ function validateDdBoundingBox(boundingbox) {
   }
 
   if (
-    !validateLatitudeRange(north) ||
-    !validateLatitudeRange(south) ||
-    !validateLongitudeRange(east) ||
-    !validateLongitudeRange(west)
+    !inValidRange(north, 90) ||
+    !inValidRange(south, 90) ||
+    !inValidRange(east, 180) ||
+    !inValidRange(west, 180)
   ) {
     return false
   }
@@ -221,10 +204,14 @@ function validateDd(dd) {
       break
     case 'boundingbox':
       if (
-        !validateDdLatitude(dd.boundingbox.north) ||
-        !validateDdLatitude(dd.boundingbox.south) ||
-        !validateDdLongitude(dd.boundingbox.east) ||
-        !validateDdLongitude(dd.boundingbox.west)
+        !validateDdPoint({
+          latitude: dd.boundingbox.north,
+          longitude: dd.boundingbox.east,
+        }) ||
+        !validateDdPoint({
+          latitude: dd.boundingbox.south,
+          longitude: dd.boundingbox.west,
+        })
       ) {
         valid = false
         error = errorMessages.invalidCoordinates

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
@@ -16,7 +16,7 @@ const wkx = require('wkx')
 const { computeCircle, toKilometers } = require('./geo-helper')
 const errorMessages = require('./errors')
 
-const dmsRegex = new RegExp('^([0-9]*)°([0-9]*)\'([0-9]*\\.?[0-9]*)"$')
+const dmsRegex = new RegExp('^([0-9_]*)°([0-9_]*)\'([0-9_]*\\.?[0-9_]*)"$')
 const minimumDifference = 0.0001
 
 const LAT_DEGREES_DIGITS = 2
@@ -62,27 +62,30 @@ function inputIsBlank(dms) {
 }
 
 function parseDmsCoordinate(coordinate) {
-  const matches = dmsRegex.exec(coordinate.coordinate)
-  if (matches == null) {
-    return null
+  if (coordinate === undefined) {
+    return coordinate
   }
 
-  const seconds = parseFloat(matches[3])
+  const matches = dmsRegex.exec(coordinate)
+  if (!matches) {
+    return coordinate
+  }
+  const degrees = replacePlaceholderWithZeros(matches[1])
+  const minutes = replacePlaceholderWithZeros(matches[2])
+  const seconds = replacePlaceholderWithZeros(matches[3])
+  return { degrees, minutes, seconds }
+}
+
+function dmsCoordinateToDD(coordinate) {
+  const seconds = parseFloat(coordinate.seconds)
   if (isNaN(seconds)) {
     return null
   }
 
-  return {
-    degrees: parseInt(matches[1]),
-    minutes: parseInt(matches[2]),
-    seconds,
-    direction: coordinate.direction,
-  }
-}
-
-function dmsCoordinateToDD(coordinate) {
   const dd =
-    coordinate.degrees + coordinate.minutes / 60 + coordinate.seconds / 3600
+    parseInt(coordinate.degrees) +
+    parseInt(coordinate.minutes) / 60 +
+    seconds / 3600
   if (
     coordinate.direction === Direction.North ||
     coordinate.direction === Direction.East
@@ -166,60 +169,29 @@ function dmsToWkt(dms) {
 /*
  *  DMS validation utils
  */
-function validateLatitudeRange(coordinate) {
-  if (
-    coordinate.degrees > 90 ||
-    coordinate.minutes > 60 ||
-    coordinate.seconds > 60
-  ) {
+function inValidRange(coordinate, maximum) {
+  const degrees = parseInt(coordinate.degrees)
+  const minutes = parseInt(coordinate.minutes)
+  const seconds = parseFloat(coordinate.seconds)
+  if (isNaN(seconds)) {
     return false
   }
-  if (
-    coordinate.degrees === 90 &&
-    (coordinate.minutes > 0 || coordinate.seconds > 0)
-  ) {
+  if (degrees > maximum || minutes > 60 || seconds > 60) {
     return false
   }
-  return true
-}
-
-function validateLongitudeRange(coordinate) {
-  if (
-    coordinate.degrees > 180 ||
-    coordinate.minutes > 60 ||
-    coordinate.seconds > 60
-  ) {
-    return false
-  }
-  if (
-    coordinate.degrees === 180 &&
-    (coordinate.minutes > 0 || coordinate.seconds > 0)
-  ) {
+  if (degrees === maximum && (minutes > 0 || seconds > 0)) {
     return false
   }
   return true
-}
-
-function validateDmsLatitude(latitude) {
-  const _latitude = parseDmsCoordinate(latitude)
-  if (_latitude == null) {
-    return false
-  }
-  return validateLatitudeRange(_latitude)
-}
-
-function validateDmsLongitude(longitude) {
-  const _longitude = parseDmsCoordinate(longitude)
-  if (_longitude == null) {
-    return false
-  }
-  return validateLongitudeRange(_longitude)
 }
 
 function validateDmsPoint(point) {
-  return (
-    validateDmsLatitude(point.latitude) && validateDmsLongitude(point.longitude)
-  )
+  const latitude = parseDmsCoordinate(point.latitude)
+  const longitude = parseDmsCoordinate(point.longitude)
+  if (latitude && longitude) {
+    return inValidRange(latitude, 90) && inValidRange(longitude, 180)
+  }
+  return false
 }
 
 function validateDmsBoundingBox(boundingbox) {
@@ -228,15 +200,15 @@ function validateDmsBoundingBox(boundingbox) {
   const east = parseDmsCoordinate(boundingbox.east)
   const west = parseDmsCoordinate(boundingbox.west)
 
-  if (north == null || south == null || east == null || west == null) {
+  if (!north || !south || !east || !west) {
     return false
   }
 
   if (
-    !validateLatitudeRange(north) ||
-    !validateLatitudeRange(south) ||
-    !validateLongitudeRange(east) ||
-    !validateLongitudeRange(west)
+    !inValidRange(north, 90) ||
+    !inValidRange(south, 90) ||
+    !inValidRange(east, 180) ||
+    !inValidRange(west, 180)
   ) {
     return false
   }
@@ -307,10 +279,14 @@ function validateDms(dms) {
       break
     case 'boundingbox':
       if (
-        !validateDmsLatitude(dms.boundingbox.north) ||
-        !validateDmsLatitude(dms.boundingbox.south) ||
-        !validateDmsLongitude(dms.boundingbox.east) ||
-        !validateDmsLongitude(dms.boundingbox.west)
+        !validateDmsPoint({
+          latitude: dms.boundingbox.north,
+          longitude: dms.boundingbox.east,
+        }) ||
+        !validateDmsPoint({
+          latitude: dms.boundingbox.south,
+          longitude: dms.boundingbox.west,
+        })
       ) {
         valid = false
         error = errorMessages.invalidCoordinates
@@ -331,17 +307,36 @@ function roundTo(num, sigDigits) {
   return Math.round(num * scaler) / scaler
 }
 
-function pad(num, width) {
+function padWithZeros(num, width) {
   return num.toString().padStart(width, '0')
 }
 
-function padDecimal(num, width) {
+function padDecimalWithZeros(num, width) {
   const decimalParts = num.toString().split('.')
   if (decimalParts.length > 1) {
     return decimalParts[0].padStart(width, '0') + '.' + decimalParts[1]
   } else {
-    return pad(num, width)
+    return padWithZeros(num, width)
   }
+}
+
+function buildDmsString(components) {
+  if (!components) {
+    return components
+  }
+  return `${components.degrees}°${components.minutes}'${components.seconds}"`
+}
+
+function replacePlaceholderWithZeros(numString = '') {
+  while (numString.includes('_')) {
+    if (numString.includes('.')) {
+      numString = numString.replace('_', '0')
+    } else {
+      numString = numString.replace('_', '')
+      numString = '0' + numString
+    }
+  }
+  return numString
 }
 
 function ddToDmsCoordinate(
@@ -357,10 +352,11 @@ function ddToDmsCoordinate(
   const seconds = 3600 * degreeFraction - 60 * minutes
   const secondsRounded = roundTo(seconds, secondsPrecision)
   return {
-    coordinate: `${pad(degrees, degreesPad)}°${pad(minutes, 2)}'${padDecimal(
-      secondsRounded,
-      2
-    )}"`,
+    coordinate: buildDmsString({
+      degrees: padWithZeros(degrees, degreesPad),
+      minutes: padWithZeros(minutes, 2),
+      seconds: padDecimalWithZeros(secondsRounded, 2),
+    }),
     direction,
   }
 }
@@ -416,5 +412,6 @@ module.exports = {
   ddToDmsCoordinateLat,
   ddToDmsCoordinateLon,
   getSecondsPrecision,
+  buildDmsString,
   Direction,
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -23,7 +23,6 @@ const dmsUtils = require('../location-new/utils/dms-utils.js')
 const DistanceUtils = require('../../js/DistanceUtils.js')
 
 const converter = new usngs.Converter()
-const minimumDifference = 0.0001
 const utmUpsLocationType = 'utmUps'
 // offset used by utmUps for southern hemisphere
 const utmUpsBoundaryNorth = 84
@@ -31,41 +30,6 @@ const utmUpsBoundarySouth = -80
 const northingOffset = 10000000
 const usngPrecision = 6
 const Direction = dmsUtils.Direction
-
-function convertToValid(key, model) {
-  if (
-    key.mapSouth !== undefined &&
-    (key.mapSouth >= key.mapNorth ||
-      (key.mapNorth === undefined && key.mapSouth >= model.get('mapNorth')))
-  ) {
-    key.mapSouth =
-      parseFloat(key.mapNorth || model.get('mapNorth')) - minimumDifference
-  }
-  if (
-    key.mapNorth !== undefined &&
-    (key.mapNorth <= key.mapSouth ||
-      (key.mapSouth === undefined && key.mapNorth <= model.get('mapSouth')))
-  ) {
-    key.mapNorth =
-      parseFloat(key.mapSouth || model.get('mapSouth')) + minimumDifference
-  }
-  if (key.mapNorth !== undefined) {
-    key.mapNorth = Math.max(-90, key.mapNorth)
-    key.mapNorth = Math.min(90, key.mapNorth)
-  }
-  if (key.mapSouth !== undefined) {
-    key.mapSouth = Math.max(-90, key.mapSouth)
-    key.mapSouth = Math.min(90, key.mapSouth)
-  }
-  if (key.mapWest !== undefined) {
-    key.mapWest = Math.max(-180, key.mapWest)
-    key.mapWest = Math.min(180, key.mapWest)
-  }
-  if (key.mapEast !== undefined) {
-    key.mapEast = Math.max(-180, key.mapEast)
-    key.mapEast = Math.min(180, key.mapEast)
-  }
-}
 
 module.exports = Backbone.AssociatedModel.extend({
   defaults: {
@@ -132,7 +96,6 @@ module.exports = Backbone.AssociatedModel.extend({
       key = keyObject
       value = options
     }
-    convertToValid(key, this)
     Backbone.AssociatedModel.prototype.set.call(this, key, value, options)
     Common.queueExecution(() => {
       this.trigger('change', Object.keys(key))
@@ -466,11 +429,19 @@ module.exports = Backbone.AssociatedModel.extend({
   },
 
   usngBbFromLatLon({ north, west, south, east }) {
-    const usngbbUpperLeft = converter.LLtoUSNG(north, west, usngPrecision)
-    const usngbbLowerRight = converter.LLtoUSNG(south, east, usngPrecision)
+    try {
+      const usngbbUpperLeft = converter.LLtoUSNG(north, west, usngPrecision)
+      const usngbbLowerRight = converter.LLtoUSNG(south, east, usngPrecision)
+      return {
+        usngbbUpperLeft,
+        usngbbLowerRight,
+      }
+    } catch (err) {
+      // do nothing
+    }
     return {
-      usngbbUpperLeft,
-      usngbbLowerRight,
+      usngbbUpperLeft: undefined,
+      usngbbLowerRight: undefined,
     }
   },
 
@@ -844,20 +815,17 @@ module.exports = Backbone.AssociatedModel.extend({
   },
 
   setLatLonFromDms(dmsCoordinateKey, dmsDirectionKey, latLonKey) {
-    const coordinate = {}
-    coordinate.coordinate = this.get(dmsCoordinateKey)
-
-    const isDmsInputIncomplete =
-      coordinate.coordinate && coordinate.coordinate.includes('_')
-    if (isDmsInputIncomplete) {
-      return
-    }
-
-    coordinate.direction = this.get(dmsDirectionKey)
-
-    const dmsCoordinate = dmsUtils.parseDmsCoordinate(coordinate)
+    const dmsCoordinate = dmsUtils.parseDmsCoordinate(
+      this.get(dmsCoordinateKey)
+    )
     if (dmsCoordinate) {
-      this.set(latLonKey, dmsUtils.dmsCoordinateToDD(dmsCoordinate))
+      this.set(
+        latLonKey,
+        dmsUtils.dmsCoordinateToDD({
+          ...dmsCoordinate,
+          direction: this.get(dmsDirectionKey),
+        })
+      )
     } else {
       this.set(latLonKey, undefined)
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.bbox.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.bbox.js
@@ -221,7 +221,7 @@ Draw.BboxView = Marionette.View.extend({
     if (
       rectangle &&
       !_.isUndefined(rectangle) &&
-      (rectangle.north !== rectangle.south && rectangle.east !== rectangle.west)
+      (rectangle.north > rectangle.south && rectangle.east !== rectangle.west)
     ) {
       this.drawBorderedRectangle(rectangle)
       //only call this if the mouse button isn't pressed, if we try to draw the border while someone is dragging
@@ -237,7 +237,7 @@ Draw.BboxView = Marionette.View.extend({
     if (
       rectangle &&
       !_.isUndefined(rectangle) &&
-      (rectangle.north !== rectangle.south && rectangle.east !== rectangle.west)
+      (rectangle.north > rectangle.south && rectangle.east !== rectangle.west)
     ) {
       this.drawBorderedRectangle(rectangle)
     }
@@ -253,9 +253,10 @@ Draw.BboxView = Marionette.View.extend({
   drawBorderedRectangle(rectangle) {
     if (!rectangle) {
       // handles case where model changes to empty vars and we don't want to draw anymore
-
       return
     }
+
+    this.destroyOldPrimitive()
 
     if (
       isNaN(rectangle.north) ||
@@ -264,12 +265,8 @@ Draw.BboxView = Marionette.View.extend({
       isNaN(rectangle.west)
     ) {
       // handles case where model is incomplete and we don't want to draw anymore
-      this.destroyOldPrimitive()
-
       return
     }
-
-    this.destroyOldPrimitive()
 
     const coordinates = [
       [rectangle.east, rectangle.north],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
@@ -23,6 +23,7 @@ const NotificationView = require('./notification.view')
 const DrawingController = require('./drawing.controller')
 const olUtils = require('../OpenLayersGeometryUtils')
 const DistanceUtils = require('../DistanceUtils.js')
+import { validateGeo } from '../../react-component/utils/validation'
 
 const Draw = {}
 
@@ -73,6 +74,16 @@ Draw.BboxView = Marionette.View.extend({
     let east = parseFloat(model.get('mapEast'))
     let west = parseFloat(model.get('mapWest'))
 
+    if (isNaN(north) || isNaN(south) || isNaN(east) || isNaN(west)) {
+      return
+    }
+
+    // If south is greater than north, return in order to
+    // prevent displaying the shape on the map
+    if (south > north) {
+      return
+    }
+
     // If we are crossing the date line, we must go outside [-180, 180]
     // for openlayers to draw correctly. This means we can't draw boxes
     // that encompass more than half the world. This actually matches
@@ -110,6 +121,11 @@ Draw.BboxView = Marionette.View.extend({
     coords.push(southEast)
     coords.push(southWest)
     coords.push(northWest)
+
+    if (validateGeo('polygon', JSON.stringify(coords)).error) {
+      return
+    }
+
     const rectangle = new ol.geom.LineString(coords)
     return rectangle
   },
@@ -120,8 +136,8 @@ Draw.BboxView = Marionette.View.extend({
     if (
       rectangle &&
       !_.isUndefined(rectangle) &&
-      (model.get('north') !== model.get('south') &&
-        model.get('east') !== model.get('west'))
+      model.get('north') !== model.get('south') &&
+      model.get('east') !== model.get('west')
     ) {
       this.drawBorderedRectangle(rectangle)
       //only call this if the mouse button isn't pressed, if we try to draw the border while someone is dragging

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -23,6 +23,10 @@ const NORTHING_OFFSET = 10000000
 const LATITUDE = 'latitude'
 const LONGITUDE = 'longitude'
 const DistanceUtils = require('../../../js/DistanceUtils')
+const {
+  parseDmsCoordinate,
+  dmsCoordinateToDD,
+} = require('../../../component/location-new/utils/dms-utils.js')
 
 export function showErrorMessages(errors: any) {
   if (errors.length === 0) {
@@ -75,10 +79,10 @@ export function validateGeo(key: string, value: any) {
       return validateDmsLatLon(LONGITUDE, value)
     case 'usng':
       return validateUsng(value)
-    case 'utmUpsEasting':
-    case 'utmUpsNorthing':
-    case 'utmUpsZone':
-    case 'utmUpsHemisphere':
+    case 'easting':
+    case 'northing':
+    case 'zoneNumber':
+    case 'hemisphere':
       return validateUtmUps(key, value)
     case 'radius':
     case 'lineWidth':
@@ -90,6 +94,8 @@ export function validateGeo(key: string, value: any) {
     case 'multiline':
     case 'multipolygon':
       return validateLinePolygon(key, value)
+    case 'bbox':
+      return validateBoundingBox(value)
     default:
   }
 }
@@ -239,7 +245,8 @@ function getGeometryErrors(filter: any): Set<string> {
       if (
         [east, west, north, south].some(
           direction => direction === '' || direction === undefined
-        )
+        ) ||
+        Number(south) >= Number(north)
       ) {
         errors.add('Bounding box must have valid values')
       }
@@ -261,6 +268,72 @@ function validateLinePolygon(mode: string, currentValue: string) {
   } catch (e) {
     return { error: true, message: 'Not an acceptable value' }
   }
+}
+
+function validateBoundingBox(value: any) {
+  let north
+  let south
+  if (value.isDms) {
+    const coordinateNorth = parseDmsCoordinate(value.north)
+    const coordinateSouth = parseDmsCoordinate(value.south)
+    north = coordinateNorth
+      ? dmsCoordinateToDD({
+          ...coordinateNorth,
+          direction: value.dmsNorthDirection,
+        })
+      : null
+    south = coordinateSouth
+      ? dmsCoordinateToDD({
+          ...coordinateSouth,
+          direction: value.dmsSouthDirection,
+        })
+      : null
+  } else if (value.isUsng) {
+    const upperLeftCoord = converter.USNGtoLL(value.upperLeft, true)
+    const lowerRightCoord = converter.USNGtoLL(value.lowerRight, true)
+    north = upperLeftCoord.lat
+    south = lowerRightCoord.lat
+  } else if (value.isUtmUps) {
+    let northPole = value.upperLeft.hemisphere.toUpperCase() === 'NORTHERN'
+    const upperLeftParts = {
+      easting: parseFloat(value.upperLeft.easting),
+      northing: parseFloat(value.upperLeft.northing),
+      zoneNumber: value.upperLeft.zoneNumber,
+      hemisphere: value.upperLeft.hemisphere,
+      northPole,
+    }
+    upperLeftParts.northing =
+      upperLeftParts.zoneNumber === 0 || northPole
+        ? upperLeftParts.northing
+        : upperLeftParts.northing - NORTHING_OFFSET
+    north = Number(converter.UTMUPStoLL(upperLeftParts).lat.toFixed(5))
+    northPole = value.lowerRight.hemisphere.toUpperCase() === 'NORTHERN'
+    const lowerRightParts = {
+      easting: parseFloat(value.lowerRight.easting),
+      northing: parseFloat(value.lowerRight.northing),
+      zoneNumber: value.lowerRight.zoneNumber,
+      hemisphere: value.lowerRight.hemisphere,
+      northPole,
+    }
+    lowerRightParts.northing =
+      lowerRightParts.zoneNumber === 0 || northPole
+        ? lowerRightParts.northing
+        : lowerRightParts.northing - NORTHING_OFFSET
+    south = Number(converter.UTMUPStoLL(lowerRightParts).lat.toFixed(5))
+  } else {
+    north = Number(value.north)
+    south = Number(value.south)
+  }
+  if (south !== null && north !== null && south >= north) {
+    return {
+      error: true,
+      message:
+        value.isUsng || value.isUtmUps
+          ? 'Upper left coordinate must be located above lower right coordinate'
+          : 'North value must be greater than south value',
+    }
+  }
+  return initialErrorState
 }
 
 function validateDDLatLon(label: string, value: string, defaultCoord: number) {
@@ -300,7 +373,7 @@ function validateUsng(value: string) {
     return { error: true, message: 'USNG / MGRS coordinates cannot be empty' }
   }
   if (value === undefined) {
-    return { error: false, message: '' }
+    return initialErrorState
   }
   const result = converter.USNGtoLL(value, true)
   const isInvalid = Number.isNaN(result.lat) || Number.isNaN(result.lon)
@@ -315,43 +388,48 @@ function upsValidDistance(distance: number) {
 }
 
 function validateUtmUps(key: string, value: any) {
-  let { utmUpsEasting, utmUpsNorthing, zoneNumber, hemisphere } = value
+  let { easting, northing, zoneNumber, hemisphere } = value
   const northernHemisphere = hemisphere.toUpperCase() === 'NORTHERN'
   zoneNumber = Number.parseInt(zoneNumber)
   const isUps = zoneNumber === 0
-  let error = { error: false, message: '' }
+  let error = initialErrorState
   // Number('') returns 0, so we can't just blindly cast to number
   // since we want to differentiate '' from 0
-  let easting = utmUpsEasting === '' ? NaN : Number(utmUpsEasting)
-  let northing = utmUpsNorthing === '' ? NaN : Number(utmUpsNorthing)
-  const isNorthingInvalid = isNaN(northing) && utmUpsNorthing !== undefined
-  const isEastingInvalid = isNaN(easting) && utmUpsEasting !== undefined
-  if (!isNaN(easting)) {
-    easting = Number.parseFloat(utmUpsEasting)
+  let utmUpsEasting = easting === '' ? NaN : Number(easting)
+  let utmUpsNorthing = northing === '' ? NaN : Number(northing)
+  const isNorthingInvalid = isNaN(utmUpsNorthing) && northing !== undefined
+  const isEastingInvalid = isNaN(utmUpsEasting) && easting !== undefined
+  if (!isNaN(utmUpsEasting)) {
+    utmUpsEasting = Number.parseFloat(easting)
   } else if (
     key === 'utmUpsEasting' &&
-    utmUpsEasting !== undefined &&
+    easting !== undefined &&
     !isNorthingInvalid
   ) {
     return { error: true, message: 'Easting value is invalid' }
   }
-  if (!isNaN(northing)) {
-    northing = Number.parseFloat(utmUpsNorthing)
-    northing =
-      isUps || northernHemisphere ? northing : northing - NORTHING_OFFSET
+  if (!isNaN(utmUpsNorthing)) {
+    utmUpsNorthing = Number.parseFloat(northing)
+    utmUpsNorthing =
+      isUps || northernHemisphere
+        ? utmUpsNorthing
+        : utmUpsNorthing - NORTHING_OFFSET
   } else if (
     key === 'utmUpsNorthing' &&
-    utmUpsNorthing !== undefined &&
+    northing !== undefined &&
     !isEastingInvalid
   ) {
     return { error: true, message: 'Northing value is invalid' }
   }
-  if (isUps && (!upsValidDistance(northing) || !upsValidDistance(easting))) {
+  if (
+    isUps &&
+    (!upsValidDistance(utmUpsNorthing) || !upsValidDistance(utmUpsEasting))
+  ) {
     return { error: true, message: 'Invalid UPS distance' }
   }
   const utmUpsParts = {
-    easting,
-    northing,
+    easting: utmUpsEasting,
+    northing: utmUpsNorthing,
     zoneNumber,
     hemisphere,
     northPole: northernHemisphere,
@@ -370,8 +448,8 @@ function validateUtmUps(key: string, value: any) {
   // if one or more is undefined, we want to return true
   const isLatLonValid =
     !hasPointError([lon, lat]) ||
-    utmUpsNorthing === undefined ||
-    utmUpsEasting === undefined
+    northing === undefined ||
+    easting === undefined
   if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
     return { error: true, message: 'Invalid UTM/UPS coordinates' }
   }
@@ -404,7 +482,7 @@ function validateRadiusLineBuffer(key: string, value: any) {
         value.units,
     }
   }
-  return { error: false, message: '' }
+  return initialErrorState
 }
 
 const validateDmsInput = (input: any, placeHolder: string) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -270,60 +270,70 @@ function validateLinePolygon(mode: string, currentValue: string) {
   }
 }
 
-function validateBoundingBox(value: any) {
-  let north
-  let south
-  if (value.isDms) {
-    const coordinateNorth = parseDmsCoordinate(value.north)
-    const coordinateSouth = parseDmsCoordinate(value.south)
-    north = coordinateNorth
-      ? dmsCoordinateToDD({
-          ...coordinateNorth,
-          direction: value.dmsNorthDirection,
-        })
-      : null
-    south = coordinateSouth
-      ? dmsCoordinateToDD({
-          ...coordinateSouth,
-          direction: value.dmsSouthDirection,
-        })
-      : null
-  } else if (value.isUsng) {
-    const upperLeftCoord = converter.USNGtoLL(value.upperLeft, true)
-    const lowerRightCoord = converter.USNGtoLL(value.lowerRight, true)
-    north = upperLeftCoord.lat
-    south = lowerRightCoord.lat
-  } else if (value.isUtmUps) {
-    let northPole = value.upperLeft.hemisphere.toUpperCase() === 'NORTHERN'
-    const upperLeftParts = {
-      easting: parseFloat(value.upperLeft.easting),
-      northing: parseFloat(value.upperLeft.northing),
-      zoneNumber: value.upperLeft.zoneNumber,
-      hemisphere: value.upperLeft.hemisphere,
-      northPole,
-    }
-    upperLeftParts.northing =
-      upperLeftParts.zoneNumber === 0 || northPole
-        ? upperLeftParts.northing
-        : upperLeftParts.northing - NORTHING_OFFSET
-    north = Number(converter.UTMUPStoLL(upperLeftParts).lat.toFixed(5))
-    northPole = value.lowerRight.hemisphere.toUpperCase() === 'NORTHERN'
-    const lowerRightParts = {
-      easting: parseFloat(value.lowerRight.easting),
-      northing: parseFloat(value.lowerRight.northing),
-      zoneNumber: value.lowerRight.zoneNumber,
-      hemisphere: value.lowerRight.hemisphere,
-      northPole,
-    }
-    lowerRightParts.northing =
-      lowerRightParts.zoneNumber === 0 || northPole
-        ? lowerRightParts.northing
-        : lowerRightParts.northing - NORTHING_OFFSET
-    south = Number(converter.UTMUPStoLL(lowerRightParts).lat.toFixed(5))
-  } else {
-    north = Number(value.north)
-    south = Number(value.south)
+function getDdLatitudes(value: any) {
+  return { north: Number(value.north), south: Number(value.south) }
+}
+
+function getDmsLatitudes(value: any) {
+  const coordinateNorth = parseDmsCoordinate(value.north)
+  const coordinateSouth = parseDmsCoordinate(value.south)
+  const north = coordinateNorth
+    ? dmsCoordinateToDD({
+        ...coordinateNorth,
+        direction: value.dmsNorthDirection,
+      })
+    : null
+  const south = coordinateSouth
+    ? dmsCoordinateToDD({
+        ...coordinateSouth,
+        direction: value.dmsSouthDirection,
+      })
+    : null
+  return { north, south }
+}
+
+function getUsngLatitudes(upperLeft: any, lowerRight: any) {
+  const upperLeftCoord = converter.USNGtoLL(upperLeft, true)
+  const lowerRightCoord = converter.USNGtoLL(lowerRight, true)
+  return { north: upperLeftCoord.lat, south: lowerRightCoord.lat }
+}
+
+function getUtmUpsLatitudes(upperLeft: any, lowerRight: any) {
+  const upperLeftParts = {
+    easting: parseFloat(upperLeft.easting),
+    northing: parseFloat(upperLeft.northing),
+    zoneNumber: upperLeft.zoneNumber,
+    hemisphere: upperLeft.hemisphere,
+    northPole: upperLeft.hemisphere.toUpperCase() === 'NORTHERN',
   }
+  const lowerRightParts = {
+    easting: parseFloat(lowerRight.easting),
+    northing: parseFloat(lowerRight.northing),
+    zoneNumber: lowerRight.zoneNumber,
+    hemisphere: lowerRight.hemisphere,
+    northPole: lowerRight.hemisphere.toUpperCase() === 'NORTHERN',
+  }
+  upperLeftParts.northing =
+    upperLeftParts.zoneNumber === 0 || upperLeftParts.northPole
+      ? upperLeftParts.northing
+      : upperLeftParts.northing - NORTHING_OFFSET
+  lowerRightParts.northing =
+    lowerRightParts.zoneNumber === 0 || lowerRightParts.northPole
+      ? lowerRightParts.northing
+      : lowerRightParts.northing - NORTHING_OFFSET
+  const north = Number(converter.UTMUPStoLL(upperLeftParts).lat.toFixed(5))
+  const south = Number(converter.UTMUPStoLL(lowerRightParts).lat.toFixed(5))
+  return { north, south }
+}
+
+function validateBoundingBox(value: any) {
+  const { north, south } = value.isDms
+    ? getDmsLatitudes(value)
+    : value.isUsng
+      ? getUsngLatitudes(value.upperLeft, value.lowerRight)
+      : value.isUtmUps
+        ? getUtmUpsLatitudes(value.upperLeft, value.lowerRight)
+        : getDdLatitudes(value)
   if (south !== null && north !== null && south >= north) {
     return {
       error: true,


### PR DESCRIPTION
##### Backport of https://github.com/codice/ddf-ui/pull/154

#### What does this PR do?
This PR adds inline and pop-up error messaging for when a bounding box's south value is greater than or equal to the north value. It prevents the invalid bounding box from rendering on both maps and prevents the user from executing the search until the error is resolved.
This PR also refactors some of the validation functions in dms-utils and dd-utils
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@shaundmorris 
#### How should this be tested?
- Create an anyGeo search with a bounding box 
- Enter south values that are less than or equal to a north value
- Verify that you see the inline error message (first screenshot below)
- Switch to different coordinate systems and verify the message persists (USNG and UTM messages will be worded differently; see second screenshot below)
- Verify that nothing is rendered on the map (both 2D and 3D)
- Attempt to execute the search and verify that you see the generic "bounding box is invalid" pop-up error message
- Verify there is no regression with previous inline & pop-up error messaging related to bounding box geo searches
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #146
G-7959
#### Screenshots
![image](https://user-images.githubusercontent.com/39737329/78170784-b6006780-7410-11ea-8df6-9e3fa4513ee1.png)
![image](https://user-images.githubusercontent.com/39737329/78170861-d4fef980-7410-11ea-9186-d76f98dfa764.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.