### PR TITLE
[3.4.x] DDF-UI-174 Fix IS EMPTY in search forms.

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-text-inputs/textFilterHelper.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-text-inputs/textFilterHelper.js
@@ -14,5 +14,7 @@
  **/
 
 export const deserializeValue = value => {
-  return (typeof value === 'object' ? value.value : value) || ''
+  return (
+    (typeof value === 'object' && value !== null ? value.value : value) || ''
+  )
 }


### PR DESCRIPTION
backport of https://github.com/codice/ddf-ui/pull/175
#### What does this PR do?
Fixes an error where if an 'is empty' search was run and then the search is edited such that the field is changed back to 'anytext' an error was thrown in the console and the field was deleted. 

#### Who is reviewing it? 
@cassandrabailey293 
@hayleynorton 
@andrewzimmer 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Run an 'IS EMPTY' query for any attribute. 
Edit the search and change the query attribute to 'anyText' 
verify that there is no console error and that the 'anyText' field is not deleted from the query editor. 
Run a 'contains' query with any attribute and value. Edit the search to change the attribute
Verify that the query is still a 'contains' query and still has the same value as before. 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #174 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
