### PR TITLE
[3.4.x] DDF-UI-179 Added null check for empty collections

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
@@ -37,7 +37,10 @@ module.exports = Marionette.CollectionView.extend({
   },
   initialize() {
     this.collection = new Backbone.Collection(this.options.list)
-    if (this.collection.first() && this.collection.first().get('filterChoice') === true) {
+    if (
+      this.collection.first() &&
+      this.collection.first().get('filterChoice') === true
+    ) {
       this.collection
         .first()
         .listenTo(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
@@ -37,7 +37,7 @@ module.exports = Marionette.CollectionView.extend({
   },
   initialize() {
     this.collection = new Backbone.Collection(this.options.list)
-    if (this.collection.first().get('filterChoice') === true) {
+    if (this.collection.first() && this.collection.first().get('filterChoice') === true) {
       this.collection
         .first()
         .listenTo(


### PR DESCRIPTION

#### Backport of https://github.com/codice/ddf-ui/pull/180
_________________________________
#### What does this PR do?
This PR adds a null check for empty collections to ensure that no errors are thrown
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?
Verify no regression in drop-down menus
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: codice/ddf-ui#179
G-8210
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.