### PR TITLE
DDF-5649 G-6176 G-7742 Show warnings to the user

### DIFF
--- a/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/CqlQueryResponse.java
+++ b/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/CqlQueryResponse.java
@@ -16,6 +16,7 @@ package org.codice.ddf.catalog.ui.query.utility;
 import ddf.catalog.operation.QueryResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <b> This code is experimental. While this interface is functional and tested, it may change or be
@@ -32,4 +33,6 @@ public interface CqlQueryResponse {
   String getId();
 
   Status getStatus();
+
+  Set<String> getWarnings();
 }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -22,15 +22,18 @@ import static spark.Spark.post;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.plugin.OAuthPluginException;
 import ddf.catalog.source.UnsupportedQueryException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import org.codice.ddf.catalog.ui.metacard.EntityTooLargeException;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
+import org.codice.ddf.catalog.ui.query.cql.SourceWarningsFilterManager;
 import org.codice.ddf.catalog.ui.query.geofeature.FeatureService;
 import org.codice.ddf.catalog.ui.query.handlers.CqlTransformHandler;
 import org.codice.ddf.catalog.ui.query.suggestion.DmsCoordinateProcessor;
@@ -81,6 +84,8 @@ public class QueryApplication implements SparkApplication, Function {
 
   private final UtmUpsCoordinateProcessor utmUpsCoordinateProcessor;
 
+  private final SourceWarningsFilterManager sourceWarningsFilterManager;
+
   private FeatureService featureService;
 
   private CqlTransformHandler cqlTransformHandler;
@@ -97,13 +102,15 @@ public class QueryApplication implements SparkApplication, Function {
       LatLonCoordinateProcessor latLonCoordinateProcessor,
       DmsCoordinateProcessor dmsCoordinateProcessor,
       MgrsCoordinateProcessor mgrsCoordinateProcessor,
-      UtmUpsCoordinateProcessor utmUpsCoordinateProcessor) {
+      UtmUpsCoordinateProcessor utmUpsCoordinateProcessor,
+      SourceWarningsFilterManager sourceWarningsFilterManager) {
     this.latLonCoordinateProcessor = latLonCoordinateProcessor;
     this.dmsCoordinateProcessor = dmsCoordinateProcessor;
     this.mgrsCoordinateProcessor = mgrsCoordinateProcessor;
     this.utmUpsCoordinateProcessor = utmUpsCoordinateProcessor;
     this.cqlTransformHandler = cqlTransformHandler;
     this.cqlValidationHandler = cqlValidationHandler;
+    this.sourceWarningsFilterManager = sourceWarningsFilterManager;
   }
 
   @Override
@@ -117,6 +124,7 @@ public class QueryApplication implements SparkApplication, Function {
           try {
             CqlRequestImpl cqlRequest = GSON.fromJson(util.safeGetBody(req), CqlRequestImpl.class);
             CqlQueryResponse cqlQueryResponse = cqlQueryUtil.executeCqlQuery(cqlRequest);
+            addApplicableWarningsTo(cqlQueryResponse);
             return GSON.toJson(cqlQueryResponse);
           } catch (OAuthPluginException e) {
             res.status(e.getErrorType().getStatusCode());
@@ -233,5 +241,30 @@ public class QueryApplication implements SparkApplication, Function {
 
   public void setCqlQueryUtil(CqlQueriesImpl cqlQueryUtil) {
     this.cqlQueryUtil = cqlQueryUtil;
+  }
+
+  private void addApplicableWarningsTo(CqlQueryResponse response) {
+    if (response.getQueryResponse() == null) {
+      LOGGER.debug(
+          "could not add warnings to the response {} because the field of the response which would contain the warnings is null",
+          response);
+      return;
+    }
+
+    if (response.getWarnings() == null) {
+      LOGGER.debug(
+          "could not add warnings to the response {} because the application received a null value when it got the response's warnings",
+          response);
+      return;
+    }
+
+    response
+        .getQueryResponse()
+        .getProcessingDetails()
+        .stream()
+        .map(sourceWarningsFilterManager::filterWarningsOf)
+        .map(ProcessingDetails::getWarnings)
+        .filter(Objects::nonNull)
+        .forEach(response.getWarnings()::addAll);
   }
 }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponseImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponseImpl.java
@@ -32,6 +32,7 @@ import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.solr.SolrMetacardClientImpl;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,6 +72,8 @@ public class CqlQueryResponseImpl implements CqlQueryResponse {
   private final Boolean userSpellcheckIsOn;
 
   private final List<ResultHighlight> highlights;
+
+  private final Set<String> warnings = new HashSet<>();
 
   // Transient so as not to be serialized to/from JSON
   private final transient QueryResponse queryResponse;
@@ -205,5 +208,9 @@ public class CqlQueryResponseImpl implements CqlQueryResponse {
 
   public Status getStatus() {
     return status;
+  }
+
+  public Set<String> getWarnings() {
+    return warnings;
   }
 }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/SourceWarningsFilterManager.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/SourceWarningsFilterManager.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.cql;
+
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.impl.ProcessingDetailsImpl;
+import ddf.catalog.security.SourceWarningsFilter;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@code SourceWarningsFilterManager} {@linkplain #filterWarningsOf(ProcessingDetails) filters
+ * the {@code warnings} of} {@link ProcessingDetails} with the {@linkplain
+ * #getBestCompatibleFilterFor(ProcessingDetails) best compatible} {@link SourceWarningsFilter} in
+ * its {@code filters}} such that the {@link ProcessingDetails} only contain {@code warnings} which
+ * the {@link SourceWarningsFilter} deems useful to the user.
+ */
+public class SourceWarningsFilterManager {
+
+  private final List<SourceWarningsFilter> filters;
+
+  public SourceWarningsFilterManager(List<SourceWarningsFilter> filters) {
+    if (filters == null) {
+      throw new IllegalArgumentException(
+          "the constructor of SourceWarningsFilterManager received a null List of Filters");
+    }
+
+    this.filters = filters;
+  }
+
+  public ProcessingDetails filterWarningsOf(ProcessingDetails processingDetails) {
+    if (!canInspect(processingDetails)) {
+      return new ProcessingDetailsImpl();
+    }
+
+    return getBestCompatibleFilterFor(processingDetails)
+        .map(bestFilter -> bestFilter.filter(processingDetails))
+        .orElse(new ProcessingDetailsImpl());
+  }
+
+  private boolean canInspect(ProcessingDetails processingDetails) {
+    return processingDetails != null && !filters.isEmpty();
+  }
+
+  private Optional<SourceWarningsFilter> getBestCompatibleFilterFor(
+      ProcessingDetails processingDetails) {
+    return filters
+        .stream()
+        .filter(Objects::nonNull)
+        .filter(filter -> filter.canFilter(processingDetails))
+        .findFirst();
+  }
+}

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -321,6 +321,16 @@ Implementation details
         <argument ref="coordinateSystemTranslator"/>
     </bean>
 
+    <bean id="sourceWarningsFilters" class="org.codice.ddf.platform.util.SortedServiceList"/>
+
+    <reference-list interface="ddf.catalog.security.SourceWarningsFilter" availability="optional">
+        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin" ref="sourceWarningsFilters"/>
+    </reference-list>
+
+    <bean id="sourceWarningsFilterManager" class="org.codice.ddf.catalog.ui.query.cql.SourceWarningsFilterManager">
+        <argument ref="sourceWarningsFilters"/>
+    </bean>
+
     <bean id="queryApplication" class="org.codice.ddf.catalog.ui.query.QueryApplication">
         <property name="featureService" ref="featureService"/>
         <property name="endpointUtil" ref="endpointUtil"/>
@@ -331,6 +341,7 @@ Implementation details
         <argument ref="dmsProcessor"/>
         <argument ref="mgrsProcessor"/>
         <argument ref="utmUpsProcessor"/>
+        <argument ref="sourceWarningsFilterManager"/>
     </bean>
 
     <bean id="jsonRpc" class="org.codice.ddf.catalog.ui.ws.JsonRpc">

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/SourceWarningsFilterManagerTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/SourceWarningsFilterManagerTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.cql;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.security.SourceWarningsFilter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class SourceWarningsFilterManagerTest {
+
+  @Test
+  public void testNullProcessingDetailsProduceProcessingDetailsWithEmptyWarnings() {
+    SourceWarningsFilter mockedFilter = mock(SourceWarningsFilter.class);
+    when(mockedFilter.canFilter(any())).thenReturn(true);
+
+    ProcessingDetails mockedDetailsWithNonEmptyWarnings = mock(ProcessingDetails.class);
+    when(mockedDetailsWithNonEmptyWarnings.getWarnings())
+        .thenReturn(Collections.singletonList("doesn't look empty to me, boss"));
+    when(mockedFilter.filter(any())).thenReturn(mockedDetailsWithNonEmptyWarnings);
+
+    SourceWarningsFilterManager filterManager =
+        new SourceWarningsFilterManager(Collections.singletonList(mockedFilter));
+
+    ProcessingDetails detailsWithFilteredWarnings = filterManager.filterWarningsOf(null);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(Collections.emptyList()));
+  }
+
+  @Test
+  public void testEmptyFiltersProduceProcessingDetailsWithEmptyWarnings() {
+    SourceWarningsFilterManager filterManager =
+        new SourceWarningsFilterManager(Collections.emptyList());
+
+    ProcessingDetails mockedDetailsWithSourceId = mock(ProcessingDetails.class);
+    when(mockedDetailsWithSourceId.getSourceId()).thenReturn("source id");
+
+    ProcessingDetails detailsWithFilteredWarnings =
+        filterManager.filterWarningsOf(mockedDetailsWithSourceId);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(Collections.emptyList()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullArgumentToConstructorGeneratesIllegalArgumentException() {
+    new SourceWarningsFilterManager(null);
+  }
+
+  @Test
+  public void testManagerIgnoresNullMemberOfFilters() {
+    SourceWarningsFilterManager filterManager =
+        new SourceWarningsFilterManager(Collections.singletonList(null));
+
+    ProcessingDetails mockedDetailsWithSourceId = mock(ProcessingDetails.class);
+    when(mockedDetailsWithSourceId.getSourceId()).thenReturn("source id");
+
+    ProcessingDetails detailsWithFilteredWarnings =
+        filterManager.filterWarningsOf(mockedDetailsWithSourceId);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(Collections.emptyList()));
+  }
+
+  @Test
+  public void testIncompatibleFilterProducesProcessingDetailsWithEmptyWarnings() {
+    SourceWarningsFilter mockedFilter = mock(SourceWarningsFilter.class);
+    when(mockedFilter.canFilter(any(ProcessingDetails.class))).thenReturn(false);
+
+    ProcessingDetails mockedDetailsWithNonEmptyWarnings = mock(ProcessingDetails.class);
+    when(mockedDetailsWithNonEmptyWarnings.getWarnings())
+        .thenReturn(
+            Collections.singletonList(
+                "when you gaze into the abyss, the abyss gazes also into you"));
+    when(mockedFilter.filter(any(ProcessingDetails.class)))
+        .thenReturn(mockedDetailsWithNonEmptyWarnings);
+
+    SourceWarningsFilterManager filterManager =
+        new SourceWarningsFilterManager(Collections.singletonList(mockedFilter));
+
+    ProcessingDetails mockedDetailsWithSourceId = mock(ProcessingDetails.class);
+    when(mockedDetailsWithSourceId.getSourceId()).thenReturn("source id");
+
+    ProcessingDetails detailsWithFilteredWarnings =
+        filterManager.filterWarningsOf(mockedDetailsWithSourceId);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(Collections.emptyList()));
+  }
+
+  @Test
+  public void testCompatibleFilterProducesProcessingDetailsWithFilteredWarnings() {
+    SourceWarningsFilter mockedFilter = mock(SourceWarningsFilter.class);
+    when(mockedFilter.canFilter(any(ProcessingDetails.class))).thenReturn(true);
+
+    List<String> filteredWarnings = Collections.singletonList("filtered warnings");
+
+    ProcessingDetails mockedDetailsWithFilteredWarnings = mock(ProcessingDetails.class);
+    when(mockedDetailsWithFilteredWarnings.getWarnings()).thenReturn(filteredWarnings);
+    when(mockedFilter.filter(any(ProcessingDetails.class)))
+        .thenReturn(mockedDetailsWithFilteredWarnings);
+
+    SourceWarningsFilterManager filterManager =
+        new SourceWarningsFilterManager(Collections.singletonList(mockedFilter));
+
+    ProcessingDetails mockedDetailsWithSourceId = mock(ProcessingDetails.class);
+    when(mockedDetailsWithSourceId.getSourceId()).thenReturn("source id");
+
+    ProcessingDetails detailsWithFilteredWarnings =
+        filterManager.filterWarningsOf(mockedDetailsWithSourceId);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(filteredWarnings));
+  }
+
+  @Test
+  public void testManagerOnlyFiltersWithCompatibleFilterOfHighestPriority() {
+    List<SourceWarningsFilter> filters = new ArrayList<>();
+
+    SourceWarningsFilter prioritizedButIncompatibleMockedFilter = mock(SourceWarningsFilter.class);
+    when(prioritizedButIncompatibleMockedFilter.canFilter(any(ProcessingDetails.class)))
+        .thenReturn(false);
+
+    ProcessingDetails mockedDetailsWithImproperlyFilteredWarnings = mock(ProcessingDetails.class);
+    when(mockedDetailsWithImproperlyFilteredWarnings.getWarnings())
+        .thenReturn(Collections.singletonList("improperly filtered warnings"));
+    when(prioritizedButIncompatibleMockedFilter.filter(any(ProcessingDetails.class)))
+        .thenReturn(mockedDetailsWithImproperlyFilteredWarnings);
+    filters.add(prioritizedButIncompatibleMockedFilter);
+    filters.add(null);
+
+    SourceWarningsFilter lessPrioritizedButCompatibleMockedFilter =
+        mock(SourceWarningsFilter.class);
+    when(lessPrioritizedButCompatibleMockedFilter.canFilter(any(ProcessingDetails.class)))
+        .thenReturn(true);
+
+    List<String> properlyFilteredWarnings = Collections.singletonList("properly filtered warnings");
+
+    ProcessingDetails mockedDetailsWithProperlyFilteredWarnings = mock(ProcessingDetails.class);
+    when(mockedDetailsWithProperlyFilteredWarnings.getWarnings())
+        .thenReturn(properlyFilteredWarnings);
+    when(lessPrioritizedButCompatibleMockedFilter.filter(any(ProcessingDetails.class)))
+        .thenReturn(mockedDetailsWithProperlyFilteredWarnings);
+    filters.add(lessPrioritizedButCompatibleMockedFilter);
+
+    SourceWarningsFilter notPrioritizedButCompatibleMockedFilter = mock(SourceWarningsFilter.class);
+    when(notPrioritizedButCompatibleMockedFilter.canFilter(any(ProcessingDetails.class)))
+        .thenReturn(true);
+    when(notPrioritizedButCompatibleMockedFilter.filter(any(ProcessingDetails.class)))
+        .thenReturn(mockedDetailsWithImproperlyFilteredWarnings);
+    filters.add(notPrioritizedButCompatibleMockedFilter);
+
+    SourceWarningsFilterManager filterManager = new SourceWarningsFilterManager(filters);
+
+    ProcessingDetails mockedDetailsWithSourceId = mock(ProcessingDetails.class);
+    when(mockedDetailsWithSourceId.getSourceId()).thenReturn("source id");
+
+    ProcessingDetails detailsWithFilteredWarnings =
+        filterManager.filterWarningsOf(mockedDetailsWithSourceId);
+
+    assertThat(detailsWithFilteredWarnings, is(notNullValue()));
+
+    assertThat(detailsWithFilteredWarnings.getWarnings(), is(properlyFilteredWarnings));
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/announcement.less
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/announcement.less
@@ -1,4 +1,4 @@
-#announcments {
+#announcements {
   position: fixed;
   top: 80px;
   width: 600px;

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/announcements.jsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/announcements.jsx
@@ -41,7 +41,7 @@ var dim = function(Component) {
   }
 }
 
-var Announcment = dim(function(props) {
+var Announcement = dim(function(props) {
   var classes = props.removing ? 'announcement is-dismissed' : 'announcement'
   var height = props.boundingRect.height || 'auto'
 
@@ -62,19 +62,19 @@ var Announcment = dim(function(props) {
   )
 })
 
-var Announcments = function(props) {
+var Announcements = function(props) {
   var dismiss = function(id) {
     return function() {
       props.onDismiss(id)
     }
   }
 
-  var list = props.list.map(function(announcment) {
+  var list = props.list.map(function(announcement) {
     return (
-      <Announcment
-        {...announcment}
-        key={announcment.id}
-        onDismiss={dismiss(announcment.id)}
+      <Announcement
+        {...announcement}
+        key={announcement.id}
+        onDismiss={dismiss(announcement.id)}
       />
     )
   })
@@ -90,4 +90,4 @@ module.exports = connect(
   {
     onDismiss: actions.remove,
   }
-)(Announcments)
+)(Announcements)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/index.jsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/announcement/index.jsx
@@ -21,16 +21,16 @@ var Provider = require('react-redux').Provider
 var actions = require('./actions')
 var configureStore = require('./configureStore')
 
-var Announcments = require('./announcements')
+var Announcements = require('./announcements')
 
-var region = $('<div id="announcments">').get(0)
+var region = $('<div id="announcements">').get(0)
 $(window.document.body).append(region)
 
 var store = configureStore()
 
 render(
   <Provider store={store}>
-    <Announcments />
+    <Announcements />
   </Provider>,
   region
 )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
@@ -22,6 +22,7 @@ const Common = require('../Common.js')
 require('backbone-associations')
 const QueryResponseSourceStatus = require('./QueryResponseSourceStatus.js')
 const QueryResultCollection = require('./QueryResult.collection.js')
+const announcement = require('../../component/announcement/index')
 
 let rpc = null
 
@@ -209,6 +210,15 @@ module.exports = Backbone.AssociatedModel.extend({
   },
   parse(resp, options) {
     metacardDefinitions.addMetacardDefinitions(resp.types)
+    if (resp.warnings && resp.status && resp.status.id) {
+      _.forEach(resp.warnings, warning => {
+        announcement.announce({
+          title: resp.status.id,
+          message: warning,
+          type: 'error',
+        })
+      })
+    }
     if (resp.results) {
       const queryId = this.getQueryId()
       const color = this.getColor()


### PR DESCRIPTION
**What does this PR do?**

This PR:

- [adds a method called `getWarnings` to the `CqlQueryResponse`](https://github.com/codice/ddf-ui/pull/192/files#diff-dc2bbd07808579ad832d96271a7611f5R36-R37) so that the application [can add to the `CqlQueryResponse` any user-friendly warning which it has generated from the query before it serializes the `CqlQueryResponse` to the UI](https://github.com/codice/ddf-ui/pull/192/files#diff-770098fd5460b75665d959794e61fd7bR127)

- [implements `getWarnings` in the `CqlQueryResponseImpl`](https://github.com/codice/ddf-ui/pull/192/files#diff-db7a5b9d957f1ebb2d1bc9b662743b0fR35-R215)

- [creates a `SourceWarningsFilterManager`](https://github.com/codice/ddf-ui/pull/192/files#diff-f0034ba72b72d296732386e06ed2d5a5R1-R30) which [aggregates the `SourceWarningsFilters` which the application makes available](https://github.com/codice/ddf-ui/pull/192/files#diff-4778db6e796b30e349fc379c38b1c54aR324-R333) so that the `SourceWarningsFilterManager` [can filter the warnings of `ProcessingDetails` which it receives such that the `ProcessingDetails` only retain those warnings which the best compatible `SourceWarningsFilter` deems user-friendly](https://github.com/codice/ddf-ui/pull/192/files#diff-f0034ba72b72d296732386e06ed2d5a5R31-R65)

- [adds a `SourceWarningsFilterManager` to the `QueryApplication`](https://github.com/codice/ddf-ui/pull/192/files#diff-770098fd5460b75665d959794e61fd7bR87-R113) so that [when the `QueryApplication` generates a `CqlQueryResponse` which contains `ProcessingDetails`, the `QueryApplication` can filter as described above the `warnings` of the `ProcessingDetails` and add each user-friendly `warning` to the `CqlQueryResponse` before the `QueryApplication` serializes the `CqlQueryResponse` to the UI](https://github.com/codice/ddf-ui/pull/192/files#diff-770098fd5460b75665d959794e61fd7bR245-R267)

- [alters `catalog-ui-search`'s `blueprint.xml` such that `catalog-ui-search` listens for any `SourceWarningsFilter` which the application registers, adds each such `SourceWarningsFilter` to a list of `SourceWarningsFilter`s](https://github.com/codice/ddf-ui/pull/192/files#diff-4778db6e796b30e349fc379c38b1c54aR324-R328), [passes this list to the constructor of a `SourceWarningsFilterManager`](https://github.com/codice/ddf-ui/pull/192/files#diff-4778db6e796b30e349fc379c38b1c54aR330-R332), and [passes this `SourceWarningsFilterManager` to the constructor of the `QueryApplication`](https://github.com/codice/ddf-ui/pull/192/files#diff-4778db6e796b30e349fc379c38b1c54aR334-R345)

- [adds tests which verify the correct operation of the `SourceWarningsFilterManager`](https://github.com/codice/ddf-ui/pull/192/files#diff-5ba0e520871c0d51b1b539bc65661536R1-R191)

- [changes `QueryResponse.js` such that when it receives a `CqlQueryResponse` with non-empty `warnings`, it, for each `warning`, displays to the user an `announcement` which shows the ID of the source of the `warning` as well as the text of the `warning`
](https://github.com/codice/ddf-ui/pull/192/files#diff-c04f18cbeb1160f9a442fe48158973c3R25-R221)
- changes [each instance of `Announcment`, `accouncment`, or `Announcments`](https://github.com/codice/ddf-ui/pull/192/files#diff-15eef8e7a3f7b0b9e18a75a44eeb9e2cL1-R1) in [`catalog-ui-search`](https://github.com/codice/ddf-ui/pull/192/files#diff-19edb2527c5feec566f43c0e42cceb9eL44-R93) to [`Announcement`, `announcement`, or `Announcements`](https://github.com/codice/ddf-ui/pull/192/files#diff-bf461ec66c946c62da1f1a0180d38219L24-R33), respectively.

**Who is reviewing it?**

@Lambeaux 
@mojogitoverhere 
@brianfelix 
@brhumphe 

**Select relevant component teams:**

@codice/ui

**Ask 2 committers to review/merge the PR and tag them here.**

**How should this be tested?**

(if something goes awry with any of the steps which I list below, bug me on Slack)

- in your Terminal/Command Line/what have you, navigate to where you have your local `ddf-ui`

- run `git checkout master`

- run `git pull origin master`

- run `git fetch origin pull/192/head:ddf-5649`

- run `git checkout origin/pr/192`

- run `git checkout -b whateverYouWantToCallYourLocalBranchOfThisPR`

- run `git rebase master`

- verify that, in response, git outputs something like
`Current branch whateverYouWantToCallYourLocalBranchOfThisPR is up to date.`

- verify that, on your newly created local branch, `ddf-ui/pom.xml` contains `<ddf.version>2.24.0<.ddf.version>`

- run `mvn clean install`

- navigate to where you have your local `ddf` and, if you don't already have a local branch of https://github.com/codice/ddf/releases/tag/ddf-2.24.0, run 
`git fetch origin :remotes/origin/master`, and then `git checkout ddf-2.24.0`, and then `git checkout -b whateverYouNameYourLocalBranch`. Otherwise, run 
`git checkout whateverYouHaveNamedYourLocalBranch`

- verify that, on your local branch of `ddf-2.24.0`, `ddf/pom.xml` contains`<version>2.24.0</version>`

- message me on Slack so that I can send you `implementationOfSourceWarningsFilter.patch`

- `git apply implementationOfSourceWarningsFilter.patch` to your local branch

- build your local branch

- run `cd distribution/ddf/target && unzip ddf-2.24.0.zip && cd ddf-2.24.0/bin && ./ddf`

- if you haven't already started your Docker Desktop, do so

- in a separate tab or window of your Terminal/Command Line/what have you, navigate to where you have your local `ddf`

- run `cd distribution/docker/solrcloud`

- run `docker-compose up`

- in the tab or window of your Terminal/Command Line/what have you in which you've started the Karaf Console, run `profile:install standard`

- after `profile:install standard` has completed, navigate to https://localhost:8993/admin

- if prompted for credentials, enter the admin credentials

- create a source for OpenSearch and activate it

- go back to the window or tab of your Terminal/Command Line/what have you where you have your running instance of `ddf`

- run `feature:repo-add mvn:org.codice.ddf.search/intrigue-ui-app/3.6.0-SNAPSHOT/xml/features`

- run `feature:install catalog-ui-app`

- run `feature:repo-add mvn:org.codice.ddf.search/ui-frontend/3.6.0-SNAPSHOT/xml/features`

- run `feature:install ui-frontend`

- on a different browser than the one with which you created a source for OpenSearch, navigate to https://localhost:8993/search/catalog/

- run a wildcard search for the source which you created for OpenSearch

- an `announcement` should pop up which has the name of the source which you created for OpenSearch as its title, and "looks like the test passed!" as its message.

**Any background context you want to provide?**

This PR enables that DDF's UI display to the user any warning which
a `SourceWarningsFilter` has approved. With this enhancement, an `Object`
can communicate to the user specific, comprehensible information about a
malfunction, as well information about how the user may resolve the
malfunction.

**What are the relevant tickets?**

**Screenshots**

**Checklist:**

- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

**Notes on Review Process**

Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews.

**Review Comment Legend:**

- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
