### PR TITLE
[3.4.x] DDF-UI-191 G-5272 Allow users to remove themselves from the sharing list

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyExtension.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyExtension.java
@@ -134,6 +134,12 @@ public class AccessControlPolicyExtension implements PolicyExtension {
       return match; // Simply imply nothing early on (essentially a no-op in this extension)
     }
 
+    SecurityPredicate hasReadAccess =
+        (sub, mc) ->
+            (READ_ACTION.equals(allPerms.getAction())
+                && (hasAccessGroupsReadOnly.apply(sub, mc)
+                    || hasAccessIndividualsReadOnly.apply(sub, mc)));
+
     // To be able to have viewing access to the metacard, you must satisfy the following criteria
     SecurityPredicate subjectImpliesACL =
         (sub, mc) ->
@@ -141,9 +147,7 @@ public class AccessControlPolicyExtension implements PolicyExtension {
                 || hasAccessIndividuals.apply(sub, mc)
                 || hasAccessGroups.apply(sub, mc)
                 || (UPDATE_ACTION.equals(allPerms.getAction()) && hasRemoveAccess.apply(sub, mc))
-                || (READ_ACTION.equals(allPerms.getAction())
-                    && (hasAccessGroupsReadOnly.apply(sub, mc)
-                        || hasAccessIndividualsReadOnly.apply(sub, mc)));
+                || hasReadAccess.apply(sub, mc);
 
     // get all permissions implied by the subject, this function returns what permissions
     // to filter from the key-value permission collection

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyExtension.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyExtension.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.security.accesscontrol;
 
 import static ddf.security.permission.CollectionPermission.READ_ACTION;
+import static ddf.security.permission.CollectionPermission.UPDATE_ACTION;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -52,7 +53,8 @@ public class AccessControlPolicyExtension implements PolicyExtension {
               SecurityAttributes.ACCESS_INDIVIDUALS,
               SecurityAttributes.ACCESS_INDIVIDUALS_READ,
               SecurityAttributes.ACCESS_GROUPS_READ,
-              SecurityAttributes.ACCESS_GROUPS)
+              SecurityAttributes.ACCESS_GROUPS,
+              "remove-user-access")
           .build();
 
   private final SecurityPredicate isOwner;
@@ -66,6 +68,8 @@ public class AccessControlPolicyExtension implements PolicyExtension {
   private final SecurityPredicate hasAccessIndividuals;
 
   private final SecurityPredicate hasAccessIndividualsReadOnly;
+
+  private final SecurityPredicate hasRemoveAccess;
 
   private final Predicate<Map<String, Set<String>>> isSystem;
 
@@ -94,6 +98,8 @@ public class AccessControlPolicyExtension implements PolicyExtension {
     hasAccessIndividualsReadOnly =
         predicate(
             subjectIdentity.getIdentityAttribute(), SecurityAttributes.ACCESS_INDIVIDUALS_READ);
+
+    hasRemoveAccess = predicate(subjectIdentity.getIdentityAttribute(), "remove-user-access");
   }
 
   private Map<String, Set<String>> getPermissions(List<Permission> permissions) {
@@ -134,6 +140,7 @@ public class AccessControlPolicyExtension implements PolicyExtension {
             hasAccessAdministrators.apply(sub, mc)
                 || hasAccessIndividuals.apply(sub, mc)
                 || hasAccessGroups.apply(sub, mc)
+                || (UPDATE_ACTION.equals(allPerms.getAction()) && hasRemoveAccess.apply(sub, mc))
                 || (READ_ACTION.equals(allPerms.getAction())
                     && (hasAccessGroupsReadOnly.apply(sub, mc)
                         || hasAccessIndividualsReadOnly.apply(sub, mc)));

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
@@ -168,12 +168,16 @@ public class AccessControlPolicyPlugin implements PolicyPlugin {
   @Override
   public PolicyResponse processPreUpdate(Metacard metacard, Map<String, Serializable> properties) {
     Map<String, Set<String>> policy = getPolicy(metacard);
+    OperationTransaction operationProperties =
+        ((OperationTransaction) properties.get(OPERATION_TRANSACTION_KEY));
     Optional<Metacard> oldMetacard =
-        ((OperationTransaction) properties.get(OPERATION_TRANSACTION_KEY))
-            .getPreviousStateMetacards()
-            .stream()
-            .filter(m -> metacard.getId().equals(m.getId()))
-            .findFirst();
+        operationProperties != null
+            ? operationProperties
+                .getPreviousStateMetacards()
+                .stream()
+                .filter(m -> metacard.getId().equals(m.getId()))
+                .findFirst()
+            : Optional.empty();
     if (oldMetacard.isPresent() && onlyUserAccessControlRemoved(oldMetacard.get(), metacard)) {
       policy.put("remove-user-access", Collections.singleton(subjectSupplier.get()));
     }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
@@ -124,7 +124,7 @@ public class AccessControlPolicyPlugin implements PolicyPlugin {
     return new PolicyResponseImpl(Collections.emptyMap(), getPolicy(metacard));
   }
 
-  private boolean isUserOnlyRemoved(Metacard prev, Metacard updated, String attribute) {
+  private boolean isOnlyUserRemoved(Metacard prev, Metacard updated, String attribute) {
     List<String> prevValues = new ArrayList<>(getValuesOrEmpty(prev, attribute));
     List<String> updatedValues = getValuesOrEmpty(updated, attribute);
     if (prevValues.size() > updatedValues.size()) {
@@ -142,10 +142,10 @@ public class AccessControlPolicyPlugin implements PolicyPlugin {
     return (Security.ACCESS_ADMINISTRATORS.equals(attribute)
             || Security.ACCESS_INDIVIDUALS.equals(attribute)
             || Security.ACCESS_INDIVIDUALS_READ.equals(attribute))
-        && isUserOnlyRemoved(prev, updated, attribute);
+        && isOnlyUserRemoved(prev, updated, attribute);
   }
 
-  private boolean onlyUserAccessControlRemoved(Metacard prev, Metacard updated) {
+  private boolean isOnlyUserAccessControlRemoved(Metacard prev, Metacard updated) {
     if (isAnyObjectNull(prev, updated)
         || getOwner(prev).equals(subjectSupplier.get())
         || (!ACCESS_ADMIN_HAS_CHANGED.apply(prev, updated)
@@ -178,7 +178,7 @@ public class AccessControlPolicyPlugin implements PolicyPlugin {
                 .filter(m -> metacard.getId().equals(m.getId()))
                 .findFirst()
             : Optional.empty();
-    if (oldMetacard.isPresent() && onlyUserAccessControlRemoved(oldMetacard.get(), metacard)) {
+    if (oldMetacard.isPresent() && isOnlyUserAccessControlRemoved(oldMetacard.get(), metacard)) {
       policy.put("remove-user-access", Collections.singleton(subjectSupplier.get()));
     }
     return new PolicyResponseImpl(Collections.emptyMap(), policy);

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPlugin.java
@@ -13,31 +13,51 @@
  */
 package org.codice.ddf.catalog.ui.security.accesscontrol;
 
+import static ddf.catalog.Constants.OPERATION_TRANSACTION_KEY;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.ACCESS_ADMIN_HAS_CHANGED;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.ACCESS_INDIVIDUALS_HAS_CHANGED;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.ACCESS_INDIVIDUALS_READ_HAS_CHANGED;
 import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.CONTAINS_ACL_ATTRIBUTES;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.attributeHasChanged;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.getValuesOrEmpty;
+import static org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil.isAnyObjectNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
+import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.ResourceRequest;
 import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.plugin.PolicyPlugin;
 import ddf.catalog.plugin.PolicyResponse;
 import ddf.catalog.plugin.impl.PolicyResponseImpl;
+import ddf.security.SubjectIdentity;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.shiro.SecurityUtils;
 
 public class AccessControlPolicyPlugin implements PolicyPlugin {
+
+  private Supplier<String> subjectSupplier;
+
+  public AccessControlPolicyPlugin(SubjectIdentity subjectIdentity) {
+    this.subjectSupplier = () -> subjectIdentity.getUniqueIdentifier(SecurityUtils.getSubject());
+  }
 
   private Map<String, Set<String>> getAccessAdministratorPermission(Metacard metacard) {
     return ImmutableMap.of(
@@ -104,9 +124,60 @@ public class AccessControlPolicyPlugin implements PolicyPlugin {
     return new PolicyResponseImpl(Collections.emptyMap(), getPolicy(metacard));
   }
 
+  private boolean isUserOnlyRemoved(Metacard prev, Metacard updated, String attribute) {
+    List<String> prevValues = new ArrayList<>(getValuesOrEmpty(prev, attribute));
+    List<String> updatedValues = getValuesOrEmpty(updated, attribute);
+    if (prevValues.size() > updatedValues.size()) {
+      prevValues.removeAll(updatedValues);
+      return prevValues.size() == 1 && prevValues.contains(subjectSupplier.get());
+    }
+    return false;
+  }
+
+  private boolean isOnlyUserRemovedFromAccessControlAttribute(
+      Metacard prev, Metacard updated, String attribute) {
+    if (!attributeHasChanged(prev, updated, attribute)) {
+      return true;
+    }
+    return (Security.ACCESS_ADMINISTRATORS.equals(attribute)
+            || Security.ACCESS_INDIVIDUALS.equals(attribute)
+            || Security.ACCESS_INDIVIDUALS_READ.equals(attribute))
+        && isUserOnlyRemoved(prev, updated, attribute);
+  }
+
+  private boolean onlyUserAccessControlRemoved(Metacard prev, Metacard updated) {
+    if (isAnyObjectNull(prev, updated)
+        || getOwner(prev).equals(subjectSupplier.get())
+        || (!ACCESS_ADMIN_HAS_CHANGED.apply(prev, updated)
+            && !ACCESS_INDIVIDUALS_HAS_CHANGED.apply(prev, updated)
+            && !ACCESS_INDIVIDUALS_READ_HAS_CHANGED.apply(prev, updated))) {
+      return false;
+    }
+
+    Set<AttributeDescriptor> attributeDescriptors =
+        new HashSet<>(prev.getMetacardType().getAttributeDescriptors());
+    attributeDescriptors.addAll(updated.getMetacardType().getAttributeDescriptors());
+
+    return attributeDescriptors
+        .stream()
+        .allMatch(
+            attribute ->
+                isOnlyUserRemovedFromAccessControlAttribute(prev, updated, attribute.getName()));
+  }
+
   @Override
   public PolicyResponse processPreUpdate(Metacard metacard, Map<String, Serializable> properties) {
-    return new PolicyResponseImpl(Collections.emptyMap(), getPolicy(metacard));
+    Map<String, Set<String>> policy = getPolicy(metacard);
+    Optional<Metacard> oldMetacard =
+        ((OperationTransaction) properties.get(OPERATION_TRANSACTION_KEY))
+            .getPreviousStateMetacards()
+            .stream()
+            .filter(m -> metacard.getId().equals(m.getId()))
+            .findFirst();
+    if (oldMetacard.isPresent() && onlyUserAccessControlRemoved(oldMetacard.get(), metacard)) {
+      policy.put("remove-user-access", Collections.singleton(subjectSupplier.get()));
+    }
+    return new PolicyResponseImpl(Collections.emptyMap(), policy);
   }
 
   @Override

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlUtil.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlUtil.java
@@ -110,7 +110,7 @@ public class AccessControlUtil {
    * @param attribute the name of the attribute to check.
    * @return true if the given attribute changed across versions of the metacard, false otherwise.
    */
-  private static boolean attributeHasChanged(
+  public static boolean attributeHasChanged(
       Metacard oldMetacard, Metacard newMetacard, String attribute) {
     return !Sets.symmetricDifference(
             ATTRIBUTE_TO_SET.apply(oldMetacard, attribute),

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/provides.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/provides.xml
@@ -228,7 +228,7 @@ Services (OSGi) that catalog-ui-search PROVIDES to DDF
         </bean>
     </service>
 
-    <service interface="ddf.catalog.plugin.AccessPlugin">
+    <service interface="ddf.catalog.plugin.AccessPlugin" ranking="1">
         <bean class="org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlAccessPlugin">
             <argument ref="subjectIdentity"/>
         </bean>
@@ -242,7 +242,9 @@ Services (OSGi) that catalog-ui-search PROVIDES to DDF
     </service>
 
     <service interface="ddf.catalog.plugin.PolicyPlugin">
-        <bean class="org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlPolicyPlugin"/>
+        <bean class="org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlPolicyPlugin">
+            <argument ref="subjectIdentity"/>
+        </bean>
     </service>
 
     <service interface="ddf.catalog.plugin.PreIngestPlugin">

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPluginTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlPolicyPluginTest.java
@@ -17,6 +17,7 @@ import static org.codice.ddf.catalog.ui.security.accesscontrol.AclTestSupport.me
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -26,9 +27,11 @@ import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.plugin.PolicyPlugin;
 import ddf.catalog.plugin.PolicyResponse;
+import ddf.security.SubjectIdentity;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import org.codice.ddf.catalog.ui.security.Constants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,10 +45,14 @@ public class AccessControlPolicyPluginTest {
 
   private static final Serializable MOCK_ID = "100";
 
+  private SubjectIdentity subjectIdentity;
+
   @Before
   public void setUp() {
     properties = mock(Map.class);
-    plugin = new AccessControlPolicyPlugin();
+    subjectIdentity = mock(SubjectIdentity.class);
+    when(subjectIdentity.getIdentityAttribute()).thenReturn(Constants.EMAIL_ADDRESS_CLAIM_URI);
+    plugin = new AccessControlPolicyPlugin(subjectIdentity);
   }
 
   @Test

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -57,6 +57,12 @@
   }
 }
 
+@{customElementNamespace}search-form-interactions.is-not-shared-template {
+  > .interaction-remove-share {
+    display: none;
+  }
+}
+
 @{customElementNamespace}search-form-interactions.is-not-editable-template {
   > .interaction-trash {
     display: none;

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -508,6 +508,9 @@ User.Response = Backbone.AssociatedModel.extend({
   canShare(metacard) {
     return new Security(Restrictions.from(metacard)).canShare(this)
   },
+  hasGroupAccess(metacard) {
+    return new Security(Restrictions.from(metacard)).hasGroupAccess(this)
+  },
 })
 
 module.exports = User

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sharing/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sharing/container.tsx
@@ -52,6 +52,71 @@ export type Item = {
   access: Access
 }
 
+export const handleRemoveSharedMetacard = async (id: number) => {
+  const metacard = await fetchMetacard(id)
+  const res = Restrictions.from(metacard)
+  const security = new Security(res)
+
+  const individuals = security
+    .getIndividuals()
+    .filter(e => e.value !== user.getUserId())
+
+  const attributes = [
+    {
+      attribute: Restrictions.IndividualsWrite,
+      values: individuals
+        .filter(e => e.access === Access.Write)
+        .map(e => e.value),
+    },
+    {
+      attribute: Restrictions.IndividualsRead,
+      values: individuals
+        .filter(e => e.access === Access.Read)
+        .map(e => e.value),
+    },
+    {
+      attribute: Restrictions.GroupsWrite,
+      values: security
+        .getGroups([])
+        .filter(e => e.access === Access.Write)
+        .map(e => e.value),
+    },
+    {
+      attribute: Restrictions.GroupsRead,
+      values: security
+        .getGroups([])
+        .filter(e => e.access === Access.Read)
+        .map(e => e.value),
+    },
+    {
+      attribute: Restrictions.AccessAdministrators,
+      values: individuals
+        .filter(e => e.access === Access.Share)
+        .map(e => e.value),
+    },
+  ]
+  return handleSave(attributes, id)
+}
+
+const fetchMetacard = async (id: number) => {
+  const res = await fetch('/search/catalog/internal/metacard/' + id)
+  const metacard = await res.json()
+  return metacard.metacards[0]
+}
+
+const handleSave = (attributes: any, id: number) => {
+  return fetch(`/search/catalog/internal/metacards`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify([
+      {
+        ids: [id],
+        attributes: attributes,
+      },
+    ]),
+  })
+}
+
 export class Sharing extends React.Component<Props, State> {
   prevUsers: any
   constructor(props: Props) {
@@ -63,7 +128,7 @@ export class Sharing extends React.Component<Props, State> {
     }
   }
   componentDidMount = () => {
-    this.fetchMetacard(this.props.id).then(data => {
+    fetchMetacard(this.props.id).then(data => {
       const metacard = data
       const res = Restrictions.from(metacard)
       const security = new Security(res)
@@ -172,11 +237,11 @@ export class Sharing extends React.Component<Props, State> {
   // and should be removed when support for optimistic concurrency is added
   // https://github.com/codice/ddf/issues/4467
   attemptSave = async (attributes: any, usersToUnsubscribe: String[]) => {
-    const currMetacard = await this.fetchMetacard(this.props.id)
+    const currMetacard = await fetchMetacard(this.props.id)
     if (currMetacard['metacard.modified'] === this.state.modified) {
       await this.doSave(attributes)
       await this.unsubscribeUsers(usersToUnsubscribe)
-      const newMetacard = await this.fetchMetacard(this.props.id)
+      const newMetacard = await fetchMetacard(this.props.id)
       this.setState({
         items: [...this.state.items],
         modified: newMetacard['metacard.modified'],
@@ -187,16 +252,7 @@ export class Sharing extends React.Component<Props, State> {
   }
 
   doSave = async (attributes: any) => {
-    const res = await fetch(`/search/catalog/internal/metacards`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify([
-        {
-          ids: [this.props.id],
-          attributes: attributes,
-        },
-      ]),
-    })
+    const res = await handleSave(attributes, this.props.id)
 
     if (res.status !== 200) {
       throw new Error()
@@ -206,12 +262,6 @@ export class Sharing extends React.Component<Props, State> {
       this.props.onUpdate(attributes)
     }
     return await res.json()
-  }
-
-  fetchMetacard = async (id: number) => {
-    const res = await fetch('/search/catalog/internal/metacard/' + id)
-    const metacard = await res.json()
-    return metacard.metacards[0]
   }
 
   unsubscribeUsers = async (usersToUnsubscribe: String[]) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sharing/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sharing/index.tsx
@@ -12,4 +12,9 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { Sharing, Item, Category } from './container'
+export {
+  Sharing,
+  Item,
+  Category,
+  handleRemoveSharedMetacard,
+} from './container'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
@@ -112,6 +112,14 @@ export class Security {
     return this.canAccess(user, Access.Share)
   }
 
+  hasGroupAccess(user: any): boolean {
+    return (
+      Math.max(
+        ...user.getRoles().map((group: string) => this.getGroupAccess(group))
+      ) !== 0
+    )
+  }
+
   isShared(): boolean {
     return !(
       this.res.accessGroups.length == 0 &&

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
@@ -16,7 +16,7 @@ import * as React from 'react'
 import WorkspaceInteractionsPresentation from './presentation'
 import { hot } from 'react-hot-loader'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
-import { Sharing } from '../sharing'
+import { Sharing, handleRemoveSharedMetacard } from '../sharing'
 import { Security, Restrictions } from '../utils/security'
 const user = require('../../component/singletons/user-instance.js')
 const store = require('../../js/store.js')
@@ -24,6 +24,7 @@ const lightboxInstance = require('../../component/lightbox/lightbox.view.instanc
 const wreqr = require('../../js/wreqr.js')
 const LoadingView = require('../../component/loading/loading.view.js')
 const ConfirmationView = require('../../component/confirmation/confirmation.view.js')
+const announcement = require('../../component/announcement/index.jsx')
 
 type Props = {
   workspace: any
@@ -65,8 +66,45 @@ class WorkspaceInteractions extends React.Component<Props, State> {
   isShareable = () => {
     return user.canShare(this.props.workspace)
   }
+  isShared = () => {
+    return this.props.workspace.get('metacard.owner') !== user.getUserId()
+  }
+  hasGroupAccess = () => {
+    return user.hasGroupAccess(this.props.workspace)
+  }
   isDeletable = () => {
     return user.canWrite(this.props.workspace)
+  }
+  removeSharedForm = () => {
+    this.props.listenTo(
+      ConfirmationView.generateConfirmation({
+        prompt: `This will permanently remove your access to the shared workspace. Would you like to continue?`,
+        no: 'Cancel',
+        yes: 'Remove',
+      }),
+      'change:choice',
+      (confirmation: any) => {
+        if (confirmation.get('choice')) {
+          let loadingview = new LoadingView()
+          handleRemoveSharedMetacard(this.props.workspace.id).then(res => {
+            if (res.status !== 200) {
+              announcement.announce(
+                {
+                  title: 'Error',
+                  message: 'Unable to leave the $workspace',
+                  type: 'error',
+                },
+                2500
+              )
+              throw new Error()
+            } else {
+              this.props.workspace.destroyLocal()
+            }
+            loadingview.remove()
+          })
+        }
+      }
+    )
   }
   runAllSearches = () => {
     store.clearOtherWorkspaces(this.props.workspace.id)
@@ -188,6 +226,8 @@ class WorkspaceInteractions extends React.Component<Props, State> {
         isLocal={workspace.isLocal()}
         isShareable={this.isShareable()}
         isDeletable={this.isDeletable()}
+        isShared={this.isShared()}
+        hasGroupAccess={this.hasGroupAccess()}
         isSubscribed={subscribed}
         saveWorkspace={this.saveWorkspace}
         runAllSearches={this.runAllSearches}
@@ -199,6 +239,7 @@ class WorkspaceInteractions extends React.Component<Props, State> {
         viewDetails={this.viewDetails}
         duplicateWorkspace={this.duplicateWorkspace}
         deletionPrompt={this.deletionPrompt}
+        removeSharedForm={this.removeSharedForm}
       />
     )
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
@@ -31,10 +31,13 @@ type Props = {
   subscribeToWorkspace: () => void
   unsubscribeFromWorkspace: () => void
   deletionPrompt: () => void
+  removeSharedForm: () => void
   isSubscribed: boolean
   isLocal: boolean
   isDeletable: boolean
   isShareable: boolean
+  isShared: boolean
+  hasGroupAccess: boolean
 }
 
 const Root = styled.div`
@@ -54,10 +57,13 @@ const render = (props: Props) => {
     subscribeToWorkspace,
     unsubscribeFromWorkspace,
     deletionPrompt,
+    removeSharedForm,
     isSubscribed,
     isLocal,
     isDeletable,
     isShareable,
+    isShared,
+    hasGroupAccess,
   } = props
   return (
     <Root className="composed-menu">
@@ -177,6 +183,19 @@ const render = (props: Props) => {
           Delete Workspace
         </MenuAction>
       )}
+      {isShared &&
+        !hasGroupAccess && (
+          <MenuAction
+            help="Leave workspace. You will no longer have access to this workspace."
+            onClick={(_e, context) => {
+              removeSharedForm()
+              context.closeAndRefocus()
+            }}
+            icon="fa fa-trash-o"
+          >
+            Leave Workspace
+          </MenuAction>
+        )}
     </Root>
   )
 }


### PR DESCRIPTION
#### What does this PR do?
Allows a user who does not want to see a workspace that has been shared with them anymore to be able to remove themselves from the sharing list. 

forward port of https://github.com/codice/ddf/pull/6014
#### Who is reviewing it? 
@cassandrabailey293 @zta6 @hayleynorton 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@stustison

#### How should this be tested?
tbd

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #191 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
