### PR TITLE
Updates SecurityTokenHolder name to PrincipalHolder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.23.2</ddf.version>
+    <ddf.version>2.24.0</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <karaf.version>4.2.6</karaf.version>
     <camel.version>2.22.1</camel.version>

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
@@ -15,7 +15,7 @@ package org.codice.ddf.catalog.ui.ws;
 
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
-import ddf.security.common.SecurityTokenHolder;
+import ddf.security.common.PrincipalHolder;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import org.eclipse.jetty.websocket.api.Session;
@@ -57,7 +57,7 @@ public class SecureWebSocketServlet extends WebSocketServlet {
             new SocketWrapper(
                 executor,
                 ws,
-                (SecurityTokenHolder)
+                (PrincipalHolder)
                     req.getSession().getAttribute(SecurityConstants.SECURITY_TOKEN_KEY)));
   }
 
@@ -66,12 +66,12 @@ public class SecureWebSocketServlet extends WebSocketServlet {
 
     private final WebSocket ws;
     private final ExecutorService executor;
-    private final SecurityTokenHolder securityTokenHolder;
+    private final PrincipalHolder principalHolder;
 
-    SocketWrapper(ExecutorService executor, WebSocket ws, SecurityTokenHolder securityTokenHolder) {
+    SocketWrapper(ExecutorService executor, WebSocket ws, PrincipalHolder principalHolder) {
       this.ws = ws;
       this.executor = executor;
-      this.securityTokenHolder = securityTokenHolder;
+      this.principalHolder = principalHolder;
     }
 
     private void runWithUser(Session session, Runnable runnable) {
@@ -124,7 +124,7 @@ public class SecureWebSocketServlet extends WebSocketServlet {
     }
 
     private boolean isUserLoggedIn() {
-      return securityTokenHolder.getPrincipals() != null;
+      return principalHolder.getPrincipals() != null;
     }
   }
 }


### PR DESCRIPTION
Updates according to a name change that happened in ddf master (2.24.0-SNAPSHOT) that will resolve the issue when 2.24.0 has been released.

Long term the plan is to move the SecureWebSocketServlet class to DDF. 