### PR TITLE
DDF-6035 G-8076 Fix result forms

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -28,8 +28,8 @@ const SortItemCollectionView = require('../sort/sort.view.js')
 const Common = require('../../js/Common.js')
 const properties = require('../../js/properties.js')
 const plugin = require('plugins/query-settings')
-const ResultForm = require('../result-form/result-form.js')
 const user = require('../singletons/user-instance.js')
+const ResultFormCollection = require('../result-form/result-form-collection-instance')
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
 import { showErrorMessages } from '../../react-component/utils/validation'
@@ -64,18 +64,11 @@ module.exports = plugin(
         'change:sortField change:sortOrder change:sources change:federation',
         Common.safeCallback(this.onBeforeShow)
       )
-      this.resultFormCollection = ResultForm.getResultCollection()
-      this.listenTo(
-        this.resultFormCollection,
-        'change:added',
-        this.handleFormUpdate
-      )
+      this.resultForms = ResultFormCollection.getCollection()
+      this.listenTo(this.resultForms, 'change', this.renderResultForms)
       this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
-        this.renderResultForms(this.resultFormCollection.filteredList)
+        this.renderResultForms()
       )
-    },
-    handleFormUpdate(newForm) {
-      this.renderResultForms(this.resultFormCollection.filteredList)
     },
     onBeforeShow() {
       this.setupSpellcheck()
@@ -83,32 +76,40 @@ module.exports = plugin(
       this.setupSortFieldDropdown()
       this.setupSrcDropdown()
       this.turnOnEditing()
-      this.renderResultForms(this.resultFormCollection.filteredList)
+      this.renderResultForms()
       this.setupExtensions()
     },
-    renderResultForms(resultTemplates) {
-      resultTemplates = resultTemplates ? resultTemplates : []
-      resultTemplates.push({
+    renderResultForms() {
+      // Each item in a dropdown needs a label and value so we add those here
+      let resultFormsForDropdown = this.resultForms.map(resultTemplate => {
+        const resultFormJson = resultTemplate.toJSON()
+        return {
+          ...resultFormJson,
+          label: resultFormJson.title,
+          value: resultFormJson.title,
+        }
+      })
+      resultFormsForDropdown.push({
         label: 'All Fields',
         value: 'allFields',
         id: 'All Fields',
         descriptors: [],
         description: 'All Fields',
       })
-      resultTemplates = _.uniq(resultTemplates, 'id')
-      let lastIndex = resultTemplates.length - 1
-      let defaultResultForm = resultTemplates.find(
+      resultFormsForDropdown = _.uniq(resultFormsForDropdown, 'id')
+      let lastIndex = resultFormsForDropdown.length - 1
+      let defaultResultForm = resultFormsForDropdown.find(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
       const propertyValue =
         this.model.get('detail-level') ||
         (defaultResultForm && defaultResultForm.value) ||
-        (resultTemplates &&
-          resultTemplates[lastIndex] &&
-          resultTemplates[lastIndex].value)
+        (resultFormsForDropdown &&
+          resultFormsForDropdown[lastIndex] &&
+          resultFormsForDropdown[lastIndex].value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
-        enum: resultTemplates,
+        enum: resultFormsForDropdown,
         value: [propertyValue],
         showValidationIssues: false,
         id: 'Result Form',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -37,7 +37,6 @@ module.exports = Backbone.AssociatedModel.extend({
   model: ResultForm,
   defaults: {
     doneLoading: false,
-    added: false,
     resultForms: [],
   },
   initialize() {
@@ -69,21 +68,6 @@ module.exports = Backbone.AssociatedModel.extend({
   ],
   addResultForms() {
     if (!this.isDestroyed) {
-      this.filteredList = _.map(resultTemplates, resultForm => ({
-        label: resultForm.title,
-        value: resultForm.title,
-        id: resultForm.id,
-        descriptors: resultForm.descriptors,
-        description: resultForm.description,
-        owner: resultForm.owner,
-        created: resultForm.created,
-        creator: resultForm.creator,
-        createdBy: resultForm.creator,
-        accessGroups: resultForm.accessGroups,
-        accessIndividuals: resultForm.accessIndividuals,
-        accessAdministrators: resultForm.accessAdministrators,
-      }))
-
       resultTemplates.forEach((value, index) => {
         this.addResultForm(
           new ResultForm({
@@ -113,9 +97,6 @@ module.exports = Backbone.AssociatedModel.extend({
   getDoneLoading() {
     return this.get('doneLoading')
   },
-  toggleUpdate() {
-    this.set('added', !this.get('added'))
-  },
   doneLoading() {
     this.set('doneLoading', true)
   },
@@ -123,13 +104,6 @@ module.exports = Backbone.AssociatedModel.extend({
     return this.get('resultForms')
   },
   deleteCachedTemplateById(id) {
-    if (this.filteredList) {
-      this.filteredList = _.filter(
-        this.filteredList,
-        template => template.id !== id
-      )
-      this.toggleUpdate()
-    }
     if (resultTemplates) {
       resultTemplates = _.filter(
         resultTemplates,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -14,6 +14,7 @@
  **/
 import * as React from 'react'
 import { ItemCheckbox } from '../../selection-checkbox/item-checkbox'
+import MarionetteRegionContainer from '../../../react-component/marionette-region-container'
 
 const Marionette = require('marionette')
 const CustomElements = require('../../../js/CustomElements.js')
@@ -29,9 +30,6 @@ module.exports = Marionette.LayoutView.extend({
   tagName: CustomElements.register('result-row'),
   events: {
     'click .result-download': 'triggerDownload',
-  },
-  regions: {
-    resultThumbnail: '.is-thumbnail',
   },
   attributes() {
     return {
@@ -57,44 +55,58 @@ module.exports = Marionette.LayoutView.extend({
               }`}
               data-value={`${property.value}`}
             >
-              <div>
-                {property.value.map(value => {
-                  console.log(value)
-                  return (
-                    <span data-value={`${value}`} title={`${alias}: ${value}`}>
-                      {value.toString().substring(0, 4) === 'http' ? (
-                        <a
-                          href={`${value}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
+              {property.property === 'thumbnail' ? (
+                <MarionetteRegionContainer
+                  view={HoverPreviewDropdown}
+                  viewOptions={{
+                    model: new DropdownModel(),
+                    modelForComponent: this.model,
+                  }}
+                />
+              ) : (
+                <React.Fragment>
+                  <div>
+                    {property.value.map(value => {
+                      return (
+                        <span
+                          data-value={`${value}`}
+                          title={`${alias}: ${value}`}
                         >
-                          {HandleBarsHelpers.getAlias(property.property)}
-                        </a>
-                      ) : (
-                        `${value}`
-                      )}
-                    </span>
-                  )
-                })}
-              </div>
-              <div className="for-bold">
-                {property.value.map(value => (
-                  <span data-value={`${value}`}>
-                    {value.toString().substring(0, 4) === 'http' ? (
-                      <a
-                        href={`${value}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {HandleBarsHelpers.getAlias(property.property)}
-                      </a>
-                    ) : (
-                      `${value}`
-                    )}
-                    :{value}
-                  </span>
-                ))}
-              </div>
+                          {value.toString().substring(0, 4) === 'http' ? (
+                            <a
+                              href={`${value}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {HandleBarsHelpers.getAlias(property.property)}
+                            </a>
+                          ) : (
+                            `${value}`
+                          )}
+                        </span>
+                      )
+                    })}
+                  </div>
+                  <div className="for-bold">
+                    {property.value.map(value => (
+                      <span data-value={`${value}`}>
+                        {value.toString().substring(0, 4) === 'http' ? (
+                          <a
+                            href={`${value}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {HandleBarsHelpers.getAlias(property.property)}
+                          </a>
+                        ) : (
+                          `${value}`
+                        )}
+                        :{value}
+                      </span>
+                    ))}
+                  </div>
+                </React.Fragment>
+              )}
             </td>
           )
         })}
@@ -141,25 +153,6 @@ module.exports = Marionette.LayoutView.extend({
     this.checkIfDownloadable()
     this.checkIfLinks()
     this.$el.attr(this.attributes())
-    this.handleResultThumbnail()
-  },
-  handleResultThumbnail() {
-    if (
-      this.model
-        .get('metacard')
-        .get('properties')
-        .get('thumbnail') &&
-      !this.isHidden('thumbnail')
-    ) {
-      if (this.resultThumbnail.$el) {
-        this.resultThumbnail.show(
-          new HoverPreviewDropdown({
-            model: new DropdownModel(),
-            modelForComponent: this.model,
-          })
-        )
-      }
-    }
   },
   checkIfDownloadable() {
     this.$el.toggleClass(


### PR DESCRIPTION
Forward port of 2.19.x PR https://github.com/codice/ddf/pull/6036

Fixes the following issues with result forms:
- Newly created result forms were not able to be used in queries until after a refresh.
- The table visualization would throw an error if the `thumbnail` attribute was not included in the attributes of the result form

Testing instructions are in 2.19.x PR
