### PR TITLE
DDF-UI-216 G-8307 Pan explicitly to location attribute

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -452,7 +452,7 @@ module.exports = function CesiumMap(
           .filter(result => result.hasGeometry())
           .map(
             result =>
-              _.map(result.getPoints(), coordinate =>
+              _.map(result.getPoints('location'), coordinate =>
                 Cesium.Cartographic.fromDegrees(
                   coordinate[0],
                   coordinate[1],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -334,7 +334,7 @@ const OpenlayersMap = extension =>
       },
       panToResults(results) {
         const coordinates = _.flatten(
-          results.map(result => result.getPoints()),
+          results.map(result => result.getPoints('location')),
           true
         )
         this.panToExtent(coordinates)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.js
@@ -42,7 +42,15 @@ module.exports = Backbone.AssociatedModel.extend({
     return
   },
   getPoints(attribute) {
-    return this.getGeometries(attribute).reduce(
+    const geometryAttributeValues = this.getGeometries(attribute)
+    const geometries = []
+    geometryAttributeValues.forEach(
+      geometry =>
+        Array.isArray(geometry)
+          ? geometry.forEach(geo => geometries.push(geo))
+          : geometries.push(geometry)
+    )
+    return geometries.reduce(
       (pointArray, wkt) =>
         pointArray.concat(
           TurfMeta.coordAll(wkx.Geometry.parse(wkt).toGeoJSON())

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.js
@@ -42,15 +42,7 @@ module.exports = Backbone.AssociatedModel.extend({
     return
   },
   getPoints(attribute) {
-    const geometryAttributeValues = this.getGeometries(attribute)
-    const geometries = []
-    geometryAttributeValues.forEach(
-      geometry =>
-        Array.isArray(geometry)
-          ? geometry.forEach(geo => geometries.push(geo))
-          : geometries.push(geometry)
-    )
-    return geometries.reduce(
+    return this.getGeometries(attribute).reduce(
       (pointArray, wkt) =>
         pointArray.concat(
           TurfMeta.coordAll(wkx.Geometry.parse(wkt).toGeoJSON())


### PR DESCRIPTION
#### Forward-port of https://github.com/codice/ddf-ui/pull/217
#### 2.19.x PR https://github.com/codice/ddf/pull/6065
________
#### What does this PR do?
This PR explicitly passes the `'location'` attribute to the `getPoints` function when panning to a result on the 2D and 3D maps
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #216
G-8307
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
