### PR TITLE
Use user-friendly attribute names in search forms

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsLoaderCommand.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsLoaderCommand.java
@@ -21,6 +21,8 @@ import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.Metacard;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import javax.xml.bind.JAXBException;
 import org.apache.karaf.shell.api.action.Action;
@@ -87,7 +89,9 @@ public class SearchFormsLoaderCommand extends SubjectCommands implements Action 
     console.println(ansi().fgBrightCyan().a("Initializing Search Form Template Loader").reset());
     final SearchFormsLoader loader = generateLoader();
 
-    List<Metacard> parsedMetacards = loader.retrieveSystemTemplateMetacards();
+    List<Metacard> parsedMetacards =
+        AccessController.doPrivileged(
+            (PrivilegedAction<List<Metacard>>) () -> loader.retrieveSystemTemplateMetacards());
 
     if (!parsedMetacards.isEmpty()) {
       printColor(GREEN, "Loader initialized, beginning ingestion of system templates.");

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -16,6 +16,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { getFilteredAttributeList } from './filterHelper'
 import EnumInput from '../inputs/enum-input'
+const metacardDefinitions = require('../../component/singletons/metacard-definitions')
 
 const Root = styled.div`
   display: inline-block;
@@ -40,7 +41,7 @@ const FilterAttributeDropdown = ({
           supportedAttributes={supportedAttributes}
         />
       ) : (
-        value
+        metacardDefinitions.getLabel(value)
       )}
     </Root>
   )


### PR DESCRIPTION
Fixes two issues:
1. User-friendly attribute names are now displayed when a search form is used to run a query instead of the ugly internal names (i.e. `ext.some-attr`)
2. The `forms:load` command no longer errors out with a security error

### Testing
#### forms:load command
1. Install standard profile
2. Copy forms.json and system-form.xml from below to etc/forms/ of the distro
(forms.json)
```
[
  {
    "title": "System Form",
    "description": "A form everyone can use",
    "filterTemplateFile": "system-form.xml",
    "querySettings" : {
      "src" : [],
      "federation": "selected"
    }
  }
]
```
(system-form.xml)
```
<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
    <fes:And>
        <fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
            <fes:ValueReference>title</fes:ValueReference>
            <fes:Literal></fes:Literal>
        </fes:PropertyIsLike>
        <fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
            <fes:ValueReference>topic.keyword</fes:ValueReference>
            <fes:Literal></fes:Literal>
        </fes:PropertyIsLike>
    </fes:And>
</fes:Filter>
```
3. Run the `forms:load` command
4. Verify system templates are ingested successfully

#### user-friendly attribute names in search forms
5. Go to Intrigue -> `Search DDF Intrigue` -> `Use Another Search Form`(under 3 dot menu) -> `System Form`
6. Notice that the attribute names use the internal format because no aliases are configured for `title` and `topic.keywords`
7. Go to Admin UI -> `System` tab -> `Catalog UI Search Attribute Aliases`
8. Add two new aliases, `title=Title` and `topic.keyword=Keyword`
9. Go back to Intrigue and refresh the page
10. Verify the user-friendly aliases are now shown

### Screenshots
#### Search form before
<img width="580" alt="Screen Shot 2020-05-20 at 12 43 52 PM" src="https://user-images.githubusercontent.com/8922441/82491901-300cae80-9a9a-11ea-9a7a-84b6480c6f43.png">

#### Search form after
<img width="589" alt="Screen Shot 2020-05-20 at 12 44 57 PM" src="https://user-images.githubusercontent.com/8922441/82491927-3a2ead00-9a9a-11ea-86f7-6f9ca13467d5.png">

#### forms:load command before
<img width="1217" alt="Screen Shot 2020-05-20 at 12 56 20 PM" src="https://user-images.githubusercontent.com/8922441/82491981-53375e00-9a9a-11ea-8072-40c54ff27131.png">

#### forms:load command after
<img width="1211" alt="Screen Shot 2020-05-20 at 12 57 24 PM" src="https://user-images.githubusercontent.com/8922441/82492038-69ddb500-9a9a-11ea-87c9-903a22c67144.png">

