### PR TITLE
[3.4.x] Use user-friendly attribute names in search forms

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsLoaderCommand.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsLoaderCommand.java
@@ -21,6 +21,8 @@ import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.Metacard;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import javax.xml.bind.JAXBException;
 import org.apache.karaf.shell.api.action.Action;
@@ -87,7 +89,9 @@ public class SearchFormsLoaderCommand extends SubjectCommands implements Action 
     console.println(ansi().fgBrightCyan().a("Initializing Search Form Template Loader").reset());
     final SearchFormsLoader loader = generateLoader();
 
-    List<Metacard> parsedMetacards = loader.retrieveSystemTemplateMetacards();
+    List<Metacard> parsedMetacards =
+        AccessController.doPrivileged(
+            (PrivilegedAction<List<Metacard>>) () -> loader.retrieveSystemTemplateMetacards());
 
     if (!parsedMetacards.isEmpty()) {
       printColor(GREEN, "Loader initialized, beginning ingestion of system templates.");

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -16,6 +16,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { getFilteredAttributeList } from './filterHelper'
 import EnumInput from '../inputs/enum-input'
+const metacardDefinitions = require('../../component/singletons/metacard-definitions')
 
 const Root = styled.div`
   display: inline-block;
@@ -40,7 +41,7 @@ const FilterAttributeDropdown = ({
           supportedAttributes={supportedAttributes}
         />
       ) : (
-        value
+        metacardDefinitions.getLabel(value)
       )}
     </Root>
   )


### PR DESCRIPTION
### Backport of #220
 
See original PR for testing instructions and screenshots

---------------------------------------------------------

Fixes two issues:
1. User-friendly attribute names are now displayed when a search form is used to run a query instead of the ugly internal names (i.e. `ext.some-attr`)
2. The `forms:load` command no longer errors out with a security error
