### PR TITLE
[3.4.x] DDF-UI-224 G-8398 Added error messaging for negative buffer values

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -546,12 +546,12 @@ function validateRadiusLineBuffer(key: string, value: any) {
         ' ' +
         value.units,
     }
-  } else if (buffer < 1) {
+  } else if (key.includes('radius') && buffer < 1) {
     return {
       error: true,
       message:
         label +
-        'must be greater than ' +
+        'must be at least ' +
         DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
         ' ' +
         value.units,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -532,18 +532,19 @@ function validateUtmUps(key: string, value: any) {
 
 function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
+  if (value.value.toString().length === 0) {
+    return initialErrorState
+  }
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
-  if (key.includes('Width')) {
-    if (buffer > 0 && buffer < 1) {
-      return {
-        error: true,
-        message:
-          label +
-          'must be 0, or at least ' +
-          DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
-          ' ' +
-          value.units,
-      }
+  if (key.includes('Width') && buffer < 1 && buffer !== 0) {
+    return {
+      error: true,
+      message:
+        label +
+        'must be 0, or at least ' +
+        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+        ' ' +
+        value.units,
     }
   } else if (buffer < 1) {
     return {


### PR DESCRIPTION
#### Backport of https://github.com/codice/ddf-ui/pull/225
#### 2.19.x PR https://github.com/codice/ddf/pull/6093
________________________
#### What does this PR do?
This PR adds inline and pop-up error messages when there's a negative value in the buffer field for polygon and line geo searches
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?
Enter a negative value in for buffer (both line and polygon) and verify that you see the inline error message pictured below (first screenshot) when you click out of the field. Also verify that if you try to execute the search, you see the pop-up error message pictured below (second screenshot) that prevents the search. Delete the negative buffer (or replace it with a valid value) and click out. Verify the inline message disappears and you are able to execute the search
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #224
G-8398
#### Screenshots
<!--(if appropriate)-->
![image](https://user-images.githubusercontent.com/39737329/82690486-8ce2a300-9c19-11ea-8da2-5d344c6a7c4a.png)
![image](https://user-images.githubusercontent.com/39737329/82690506-979d3800-9c19-11ea-9cab-bd8b8e2cc037.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
