### PR TITLE
DDF-UI-238 Allow admin config defaults for sources and table view columns

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -240,6 +240,9 @@ public class ConfigurationApplication implements SparkApplication {
 
   private String basicSearchMatchType;
 
+  private List<String> defaultSources = Collections.emptyList();
+  private List<String> defaultTableColumns = Collections.emptyList();
+
   private Set<String> editorAttributes = Collections.emptySet();
   private Set<String> requiredAttributes = Collections.emptySet();
   private Map<String, Set<String>> attributeEnumMap = Collections.emptyMap();
@@ -583,6 +586,8 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("useHyphensInUuid", uuidGenerator.useHyphens());
     config.put("i18n", i18n);
     config.put("attributeSuggestionList", attributeSuggestionList);
+    config.put("defaultSources", defaultSources);
+    config.put("defaultTableColumns", defaultTableColumns);
     return config;
   }
 
@@ -1310,5 +1315,39 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setBasicSearchMatchType(String basicSearchMatchType) {
     this.basicSearchMatchType = basicSearchMatchType;
+  }
+
+  public List<String> getDefaultSources() {
+    return defaultSources;
+  }
+
+  public void setDefaultSources(List<String> defaultSources) {
+    if (defaultSources == null || defaultSources.isEmpty()) {
+      this.defaultSources = Collections.emptyList();
+    } else {
+      this.defaultSources =
+          defaultSources
+              .stream()
+              .filter(StringUtils::isNotBlank)
+              .map(String::trim)
+              .collect(Collectors.toList());
+    }
+  }
+
+  public List<String> setDefaultTableColumns() {
+    return defaultTableColumns;
+  }
+
+  public void setDefaultTableColumns(List<String> defaultTableColumns) {
+    if (defaultTableColumns == null || defaultTableColumns.isEmpty()) {
+      this.defaultTableColumns = Collections.emptyList();
+    } else {
+      this.defaultTableColumns =
+          defaultTableColumns
+              .stream()
+              .filter(StringUtils::isNotBlank)
+              .map(String::trim)
+              .collect(Collectors.toList());
+    }
   }
 }

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -338,6 +338,22 @@
             cardinality="100"
             required="false">
         </AD>
+
+        <AD id="defaultSources"
+            name="Default Sources"
+            description="List of default sources for use in queries"
+            type="String"
+            cardinality="1000"
+            required="false">
+        </AD>
+
+        <AD id="defaultTableColumns"
+            name="Default Table Columns"
+            description="List of default columns for the table visualization"
+            type="String"
+            cardinality="1000"
+            required="false">
+        </AD>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.ui">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -27,6 +27,7 @@ const Property = require('../property/property.js')
 const SortItemCollectionView = require('../sort/sort.view.js')
 const Common = require('../../js/Common.js')
 const properties = require('../../js/properties.js')
+const sourcesInstance = require('../../component/singletons/sources-instance')
 const plugin = require('plugins/query-settings')
 const user = require('../singletons/user-instance.js')
 const ResultFormCollection = require('../result-form/result-form-collection-instance')
@@ -154,10 +155,17 @@ module.exports = plugin(
       )
     },
     setupSrcDropdown() {
-      const sources = this.model.get('sources')
+      const sourceIds = sourcesInstance.models.map(src => src.id)
+      const defaultSources = this.model.get('sources')
+      const validDefaultSources =
+        defaultSources && defaultSources.filter(src => sourceIds.includes(src))
+      const hasValidDefaultSources =
+        validDefaultSources && validDefaultSources.length
       this._srcDropdownModel = new DropdownModel({
-        value: sources ? sources : [],
-        federation: this.model.get('federation'),
+        value: validDefaultSources || [],
+        federation: hasValidDefaultSources
+          ? this.model.get('federation')
+          : 'enterprise',
       })
       if (this.getExtensions() !== undefined) {
         return

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
@@ -76,6 +76,7 @@ module.exports = Marionette.ItemView.extend({
         element.getAttribute('data-propertyid')
       )
     )
+    prefs.set('hasSelectedColumns', true)
     prefs.savePreferences()
     this.destroy()
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-viz.view.js
@@ -20,6 +20,8 @@ import {
   Button,
   buttonTypeEnum,
 } from '../../../react-component/presentation/button'
+const user = require('catalog-ui-search/src/main/webapp/component/singletons/user-instance.js')
+const properties = require('catalog-ui-search/src/main/webapp/js/properties.js')
 const Marionette = require('marionette')
 const Backbone = require('backbone')
 const CustomElements = require('../../../js/CustomElements.js')
@@ -49,6 +51,37 @@ const filteredAttributesModel = Backbone.Model.extend({
     filteredAttributes: [],
   },
 })
+
+const defaultTableColumns = properties.defaultTableColumns.map(attr =>
+  attr.toLowerCase()
+)
+
+const setDefaultColumns = filteredAttributes => {
+  const hasSelectedColumns = user
+    .get('user')
+    .get('preferences')
+    .get('hasSelectedColumns')
+  const availableAttributes = filteredAttributes
+    .get('filteredAttributes')
+    .map(attr => attr.toLowerCase())
+  const validDefaultColumns = defaultTableColumns.filter(column =>
+    availableAttributes.includes(column)
+  )
+
+  if (
+    !hasSelectedColumns &&
+    availableAttributes.length &&
+    validDefaultColumns.length
+  ) {
+    const hiddenAttributes = availableAttributes.filter(
+      attr => !defaultTableColumns.includes(attr)
+    )
+    user
+      .get('user')
+      .get('preferences')
+      .set('columnHide', hiddenAttributes)
+  }
+}
 
 module.exports = Marionette.LayoutView.extend({
   tagName: CustomElements.register('table-viz'),
@@ -123,6 +156,8 @@ module.exports = Marionette.LayoutView.extend({
 
     this.filteredAttributes = new filteredAttributesModel()
     this.filterActiveSearchResultsAttributes()
+
+    setDefaultColumns(this.filteredAttributes)
 
     this.listenTo(
       this.options.selectionInterface,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -14,13 +14,18 @@
  **/
 
 const Backbone = require('backbone')
+const properties = require('../properties.js')
 
 module.exports = Backbone.Model.extend({
   defaults() {
+    const hasDefaultSources =
+      properties.defaultSources && properties.defaultSources.length > 0
+    const sources = hasDefaultSources ? properties.defaultSources : undefined
+
     return {
       type: 'text',
-      sources: undefined,
-      federation: 'enterprise',
+      sources,
+      federation: sources ? 'selected' : 'enterprise',
       sorts: [
         {
           attribute: 'modified',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -138,6 +138,7 @@ User.Preferences = Backbone.AssociatedModel.extend({
       visualization: '3dmap',
       columnHide: [],
       columnOrder: ['title', 'created', 'modified', 'thumbnail'],
+      hasSelectedColumns: false,
       uploads: [],
       oauth: [],
       fontSize: ThemeUtils.getFontSize(_get(properties, 'zoomPercentage', 100)),


### PR DESCRIPTION
#### What does this PR do?
Forward ports of [#6079](https://github.com/codice/ddf/pull/6079) and [#6089](https://github.com/codice/ddf/pull/6089), which were added to 2.20.x via [this commit](https://github.com/codice/ddf/commit/2cd2347392e26bbdd71ab113d1c47680af961d62)

Adds admin configurable defaults for sources and table view columns.

#### How should this be tested?

##### Setup DDF 2.24.x with this PR (version 3.6.0-SNAPSHOT)

1. Build DDF and this PR
1. Start solr (run 'docker-compose up' in ddf/distribution/docker/solrcloud/) and start ddf
1. In the karaf console: `profile:install karaf`
1. `feature:repo-add mvn:org.codice.ddf.search/intrigue-ui-app/3.6.0-SNAPSHOT/xml/features`
1. `feature:install catalog-ui-app`
1. `feature:repo-add mvn:org.codice.ddf.search/ui-frontend/3.6.0-SNAPSHOT/xml/features`
1. `feature:install ui-frontend`

##### Test new features (happy route)

1. In admin ui => system => catalog ui search, at the bottom, configure the new settings
   <img src=https://user-images.githubusercontent.com/22667297/83559816-0dcb5580-a4ca-11ea-9728-a4fa5b0dad56.png width=60% height=60% />
1. Ingest any file via the Upload route 
   <img src=https://user-images.githubusercontent.com/22667297/83559912-35222280-a4ca-11ea-869f-a1886f02679e.png width=60% height=60% />
1. Start a search and notice that your default source has been selected
   <img src=https://user-images.githubusercontent.com/22667297/83559976-4c611000-a4ca-11ea-9931-b7e670d2f49d.png  width=60% height=60% />
1. Search, select your item, and open the table visualization (bottom right). Notice that the columns shown match the ones selected
![image](https://user-images.githubusercontent.com/22667297/83560093-816d6280-a4ca-11ea-9443-ba91ec81558e.png)

##### Other potential tests (edge cases) 

Note:  you may need to clear your solr and restart your ddf to test new defaults depending on whether you saved your preferences (may have happened inadvertently). Let me know if you need help with this. 
- Add invalid sources for the source defaults
- Do not add any source defaults
- Add invalid attributes for the table column defaults
- Do not add any table column defaults
- Mix valid and invalid defaults

#### What are the relevant tickets?
Fixes: #238 

Review Comment Legend:
✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.