### PR TITLE
DDF-UI-242 Form item dropdown switches order when form is made default

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -51,20 +51,20 @@ module.exports = Marionette.ItemView.extend({
         </div>
 
         <div
-          className="search-form-interaction interaction-share"
-          data-help="Allows template to be shared with other users"
-        >
-          <div className="interaction-icon fa fa-users" />
-          <div className="interaction-text">Share {formTitle}</div>
-        </div>
-
-        <div
           className="search-form-interaction interaction-clear"
           data-help={`Clears this ${formTitleLowerCase} as default.
 Causes new searches that are created to not necessarily default to this search ${formTitle}.`}
         >
           <div className="interaction-icon fa fa-eraser" />
           <div className="interaction-text">Clear Default {formTitle}</div>
+        </div>
+
+        <div
+          className="search-form-interaction interaction-share"
+          data-help="Allows template to be shared with other users"
+        >
+          <div className="interaction-icon fa fa-users" />
+          <div className="interaction-text">Share {formTitle}</div>
         </div>
 
         <div


### PR DESCRIPTION
#### What does this PR do?
Form item dropdown switches order when form is made default
#### Who is reviewing it? 
@andrewzimmer 
@hayleynorton
@cassandrabailey293 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere


#### How should this be tested?
1. Click three-dot menu for search or result form
2. Notice that "Make Default Form" is first 
3. Select "Make Default Form"
4. Click the three-dot menu again
5. Ensure that "Clear Default Form" is the first item

#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#242

#### Screenshots
<!--(if appropriate)-->
#### Before changes
<img width="1043" alt="Before(ResultForm)-p1" src="https://user-images.githubusercontent.com/65194214/84087631-c819fb80-a9a7-11ea-84b3-7d1f43d53ea3.png">
<img width="1163" alt="Before(ResultForm)-p2" src="https://user-images.githubusercontent.com/65194214/84087634-c94b2880-a9a7-11ea-98f2-8294afd9c7a0.png">
<img width="1228" alt="Before(SearchForm)-p1" src="https://user-images.githubusercontent.com/65194214/84087636-c9e3bf00-a9a7-11ea-8b11-30eb8e4056f5.png">
<img width="1480" alt="Before(SearchForm)-p2" src="https://user-images.githubusercontent.com/65194214/84087637-c9e3bf00-a9a7-11ea-8cd4-651743f75998.png">

#### After changes
<img width="1100" alt="After(ResultForm)-p1" src="https://user-images.githubusercontent.com/65194214/84087663-da943500-a9a7-11ea-97ef-34a7aa5eced0.png">
<img width="1073" alt="After(ResultForm)-p2" src="https://user-images.githubusercontent.com/65194214/84087666-dbc56200-a9a7-11ea-87ac-f1139c41c497.png">
<img width="1213" alt="After(SearchForm)-p1" src="https://user-images.githubusercontent.com/65194214/84087668-dc5df880-a9a7-11ea-84cb-45c9198aede7.png">
<img width="1398" alt="After(SearchForm)-p2" src="https://user-images.githubusercontent.com/65194214/84087672-dcf68f00-a9a7-11ea-9db0-2712a641cf76.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
