### PR TITLE
[3.5.x] DDF-UI-258 refactor cql endpoint code

### DIFF
--- a/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/CqlParseException.java
+++ b/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/CqlParseException.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui;
+
+public class CqlParseException extends Exception {
+  public CqlParseException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/CqlRequest.java
+++ b/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/CqlRequest.java
@@ -17,6 +17,7 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryRequest;
 import java.util.List;
 import java.util.Set;
+import org.codice.ddf.catalog.ui.CqlParseException;
 
 /**
  * <b> This code is experimental. While this interface is functional and tested, it may change or be
@@ -80,7 +81,8 @@ public interface CqlRequest {
 
   void setNormalize(boolean normalize);
 
-  QueryRequest createQueryRequest(String localSource, FilterBuilder filterBuilder);
+  QueryRequest createQueryRequest(String localSource, FilterBuilder filterBuilder)
+      throws CqlParseException;
 
   String getSourceResponseString();
 

--- a/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/QueryRequestFactory.java
+++ b/ui-backend/catalog-ui-search-api/src/main/java/org/codice/ddf/catalog/ui/query/utility/QueryRequestFactory.java
@@ -13,21 +13,32 @@
  */
 package org.codice.ddf.catalog.ui.query.utility;
 
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.codice.ddf.catalog.ui.CqlParseException;
 
-/**
- * <b> This code is experimental. While this interface is functional and tested, it may change or be
- * removed in a future version of the library. </b>
- */
-public interface CqlQueries {
-  CqlQueryResponse executeCqlQuery(CqlRequest cqlRequest)
-      throws UnsupportedQueryException, SourceUnavailableException, FederationException,
-          CqlParseException;
+public interface QueryRequestFactory {
 
-  CqlRequest getCqlRequestFromJson(String jsonBody);
-
-  CsvTransform getCsvTransformFromJson(String jsonBody);
+  QueryRequest build(
+      String localSource,
+      FilterBuilder filterBuilder,
+      List<CqlRequest.Sort> sorts,
+      int start,
+      int count,
+      long timeout,
+      String id,
+      String cql,
+      @Nullable String src,
+      @Nullable List<String> srcs,
+      boolean isExcludeUnnecessaryAttribute,
+      @Nullable String batchId,
+      @Nullable String queryType,
+      boolean isSpellcheck,
+      boolean isPhonetics,
+      @Nullable String cacheId,
+      @Nullable Set<String> facets)
+      throws CqlParseException;
 }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -124,7 +124,7 @@ public class QueryApplication implements SparkApplication, Function {
             res.status(e.getErrorType().getStatusCode());
             return GSON.toJson(ImmutableMap.of(ID_KEY, e.getSourceId(), URL_KEY, e.getUrl()));
           } catch (CqlParseException e) {
-            LOGGER.debug("Unalbe to parse CQL", e);
+            LOGGER.debug("Unable to parse CQL", e);
             halt(400, "Unable to parse CQL filter");
             return null;
           }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -17,6 +17,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static spark.Spark.before;
 import static spark.Spark.exception;
 import static spark.Spark.get;
+import static spark.Spark.halt;
 import static spark.Spark.post;
 
 import com.google.common.collect.ImmutableMap;
@@ -29,6 +30,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.codice.ddf.catalog.ui.metacard.EntityTooLargeException;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
 import org.codice.ddf.catalog.ui.query.geofeature.FeatureService;
@@ -121,6 +123,10 @@ public class QueryApplication implements SparkApplication, Function {
           } catch (OAuthPluginException e) {
             res.status(e.getErrorType().getStatusCode());
             return GSON.toJson(ImmutableMap.of(ID_KEY, e.getSourceId(), URL_KEY, e.getUrl()));
+          } catch (CqlParseException e) {
+            LOGGER.debug("Unalbe to parse CQL", e);
+            halt(400, "Unable to parse CQL filter");
+            return null;
           }
         });
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequestImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequestImpl.java
@@ -13,50 +13,16 @@
  */
 package org.codice.ddf.catalog.ui.query.cql;
 
-import static ddf.catalog.Constants.ADDITIONAL_SORT_BYS;
-import static spark.Spark.halt;
-
-import com.google.common.collect.Sets;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
 import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.filter.FilterDelegate;
-import ddf.catalog.filter.impl.SortByImpl;
-import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.impl.FacetedQueryRequest;
-import ddf.catalog.operation.impl.QueryImpl;
-import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.operation.impl.TermFacetPropertiesImpl;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.codice.ddf.catalog.ui.query.utility.CqlRequest;
-import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.filter.text.ecql.ECQL;
-import org.opengis.filter.Filter;
-import org.opengis.filter.sort.SortBy;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CqlRequestImpl implements CqlRequest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(CqlRequestImpl.class);
-
-  private static final String DEFAULT_SORT_ORDER = "desc";
-
-  private static final String LOCAL_SOURCE = "local";
-
-  private static final String CACHE_SOURCE = "cache";
-
-  private static final String MODE = "mode";
-
-  private static final String UPDATE = "update";
 
   private String id;
 
@@ -80,6 +46,16 @@ public class CqlRequestImpl implements CqlRequest {
 
   private Boolean phonetics;
 
+  private String cacheId;
+
+  private List<Sort> sorts = Collections.emptyList();
+
+  private Set<String> facets = Collections.emptySet();
+
+  private boolean normalize = false;
+
+  private boolean excludeUnnecessaryAttributes = true;
+
   public String getCacheId() {
     return cacheId;
   }
@@ -88,12 +64,6 @@ public class CqlRequestImpl implements CqlRequest {
     this.cacheId = cacheId;
   }
 
-  private String cacheId;
-
-  private List<Sort> sorts = Collections.emptyList();
-
-  private Set<String> facets = Collections.emptySet();
-
   public Set<String> getFacets() {
     return facets;
   }
@@ -101,10 +71,6 @@ public class CqlRequestImpl implements CqlRequest {
   public void setFacets(Set<String> facets) {
     this.facets = facets;
   }
-
-  private boolean normalize = false;
-
-  private boolean excludeUnnecessaryAttributes = true;
 
   public List<String> getSrcs() {
     return srcs;
@@ -202,148 +168,52 @@ public class CqlRequestImpl implements CqlRequest {
     this.normalize = normalize;
   }
 
-  private QueryRequest facetQueryRequest(QueryRequest request) {
-    if (facets.isEmpty()) {
-      return request;
+  @Override
+  public QueryRequest createQueryRequest(String localSource, FilterBuilder filterBuilder)
+      throws CqlParseException {
+
+    QueryRequestBuilder builder =
+        new QueryRequestBuilder(localSource, filterBuilder, sorts, start, count, timeout, id, cql);
+
+    if (src != null) {
+      builder.setSrc(src);
     }
 
-    return new FacetedQueryRequest(
-        request.getQuery(),
-        request.isEnterprise(),
-        request.getSourceIds(),
-        request.getProperties(),
-        new TermFacetPropertiesImpl(facets));
-  }
-
-  public QueryRequest createQueryRequest(String localSource, FilterBuilder filterBuilder) {
-    List<SortBy> sortBys =
-        sorts
-            .stream()
-            .filter(
-                s ->
-                    StringUtils.isNotEmpty(s.getAttribute())
-                        && StringUtils.isNotEmpty(s.getDirection()))
-            .map(s -> parseSort(s.getAttribute(), s.getDirection()))
-            .collect(Collectors.toList());
-    if (sortBys.isEmpty()) {
-      sortBys.add(new SortByImpl(Result.TEMPORAL, DEFAULT_SORT_ORDER));
-    }
-    Query query =
-        new QueryImpl(createFilter(filterBuilder), start, count, sortBys.get(0), true, timeout);
-
-    QueryRequest queryRequest;
-    if (!CollectionUtils.isEmpty(srcs)) {
-      parseSrcs(localSource);
-      queryRequest = new QueryRequestImpl(query, srcs);
-      queryRequest.getProperties().put(MODE, UPDATE);
-    } else {
-      String source = parseSrc(localSource);
-      if (CACHE_SOURCE.equals(source)) {
-        queryRequest = new QueryRequestImpl(query, true);
-        queryRequest.getProperties().put(MODE, CACHE_SOURCE);
-      } else {
-        queryRequest = new QueryRequestImpl(query, Collections.singleton(source));
-        queryRequest.getProperties().put(MODE, UPDATE);
-      }
+    if (srcs != null) {
+      builder.setSources(srcs);
     }
 
-    queryRequest = facetQueryRequest(queryRequest);
+    builder.setExcludeUnnecessaryAttributes(excludeUnnecessaryAttributes);
 
-    if (excludeUnnecessaryAttributes) {
-      queryRequest
-          .getProperties()
-          .put("excludeAttributes", Sets.newHashSet(Metacard.METADATA, "lux"));
+    if (batchId != null) {
+      builder.setBatchId(batchId);
     }
 
-    if (sortBys.size() > 1) {
-      queryRequest
-          .getProperties()
-          .put(ADDITIONAL_SORT_BYS, sortBys.subList(1, sortBys.size()).toArray(new SortBy[0]));
+    if (queryType != null) {
+      builder.setQueryType(queryType);
     }
 
-    queryRequest.getProperties().put("requestId", id);
-
-    if (StringUtils.isNotEmpty(batchId)) {
-      queryRequest.getProperties().put("batchId", batchId);
-    }
-
-    if (StringUtils.isNotEmpty(queryType)) {
-      queryRequest.getProperties().put("queryType", queryType);
-    }
-
-    if (spellcheck != null) {
-      queryRequest.getProperties().put("spellcheck", spellcheck);
-    }
-
-    if (phonetics != null) {
-      queryRequest.getProperties().put("phonetics", phonetics);
-    }
+    builder.setSpellcheck(spellcheck);
+    builder.setPhonetics(phonetics);
 
     if (cacheId != null) {
-      queryRequest.getProperties().put("cacheId", cacheId);
+      builder.setCacheId(cacheId);
     }
 
-    return queryRequest;
-  }
-
-  private String parseSrc(String localSource) {
-    if (StringUtils.equalsIgnoreCase(src, LOCAL_SOURCE) || StringUtils.isBlank(src)) {
-      src = localSource;
+    if (facets != null) {
+      builder.setFacets(facets);
     }
 
-    return src;
+    return builder.build();
   }
 
-  private void parseSrcs(String localSource) {
-    for (int i = 0; i < srcs.size(); i++) {
-      if (StringUtils.equalsIgnoreCase(srcs.get(i), LOCAL_SOURCE)) {
-        srcs.set(i, localSource);
-      }
-    }
-  }
-
+  @Override
   public String getSourceResponseString() {
     if (!CollectionUtils.isEmpty(srcs)) {
       return String.join(", ", srcs);
     } else {
       return src;
     }
-  }
-
-  private Filter createFilter(FilterBuilder filterBuilder) {
-    Filter filter = null;
-    try {
-      filter = ECQL.toFilter(cql);
-    } catch (CQLException e) {
-      halt(400, "Unable to parse CQL filter");
-    }
-
-    if (filter == null) {
-      LOGGER.debug("Received an empty filter. Using a wildcard contextual filter instead.");
-      filter =
-          filterBuilder.attribute(Metacard.ANY_TEXT).is().like().text(FilterDelegate.WILDCARD_CHAR);
-    }
-
-    return filter;
-  }
-
-  private SortBy parseSort(String sortField, String sortOrder) {
-    SortBy sort;
-    switch (sortOrder.toLowerCase(Locale.getDefault())) {
-      case "ascending":
-      case "asc":
-        sort = new SortByImpl(sortField, SortOrder.ASCENDING);
-        break;
-      case "descending":
-      case "desc":
-        sort = new SortByImpl(sortField, SortOrder.DESCENDING);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Incorrect sort order received, must be 'asc', 'ascending', 'desc', or 'descending'");
-    }
-
-    return sort;
   }
 
   public String getSource() {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestBuilder.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestBuilder.java
@@ -1,0 +1,297 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.cql;
+
+import static ddf.catalog.Constants.ADDITIONAL_SORT_BYS;
+
+import com.google.common.collect.Sets;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.FilterDelegate;
+import ddf.catalog.filter.impl.SortByImpl;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.FacetedQueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.TermFacetPropertiesImpl;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.catalog.ui.CqlParseException;
+import org.codice.ddf.catalog.ui.query.utility.CqlRequest;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryRequestBuilder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryRequestBuilder.class);
+
+  private static final String LOCAL_SOURCE = "local";
+
+  private static final String CACHE_SOURCE = "cache";
+
+  private static final String DEFAULT_SORT_ORDER = "desc";
+
+  private static final String MODE = "mode";
+
+  private static final String UPDATE = "update";
+
+  private final String localSource;
+
+  private final FilterBuilder filterBuilder;
+
+  private final List<CqlRequest.Sort> sorts;
+
+  private final int start;
+
+  private final int count;
+
+  private final long timeout;
+
+  private List<String> srcs = Collections.emptyList();
+
+  private String src;
+
+  private boolean excludeUnnecessaryAttributes = true;
+
+  private final String id;
+
+  private String batchId;
+
+  private String queryType;
+
+  private Boolean spellcheck;
+
+  private Boolean phonetics;
+
+  private String cacheId;
+
+  private Set<String> facets = Collections.emptySet();
+
+  private final String cql;
+
+  public QueryRequestBuilder(
+      String localSource,
+      FilterBuilder filterBuilder,
+      List<CqlRequest.Sort> sorts,
+      int start,
+      int count,
+      long timeout,
+      String id,
+      String cql) {
+    this.localSource = localSource;
+    this.filterBuilder = filterBuilder;
+    this.sorts = sorts;
+    this.start = start;
+    this.count = count;
+    this.timeout = timeout;
+    this.id = id;
+    this.cql = cql;
+  }
+
+  public QueryRequestBuilder setSrc(String src) {
+    this.src = src;
+    return this;
+  }
+
+  public QueryRequestBuilder setSources(List<String> srcs) {
+    this.srcs = srcs;
+    return this;
+  }
+
+  public QueryRequestBuilder setExcludeUnnecessaryAttributes(
+      boolean isExcludeUnnecessaryAttributes) {
+    this.excludeUnnecessaryAttributes = isExcludeUnnecessaryAttributes;
+    return this;
+  }
+
+  public QueryRequestBuilder setBatchId(String batchId) {
+    this.batchId = batchId;
+    return this;
+  }
+
+  public QueryRequestBuilder setQueryType(String queryType) {
+    this.queryType = queryType;
+    return this;
+  }
+
+  public QueryRequestBuilder setSpellcheck(Boolean isSpellcheck) {
+    this.spellcheck = isSpellcheck;
+    return this;
+  }
+
+  public QueryRequestBuilder setPhonetics(Boolean isPhonetics) {
+    this.phonetics = isPhonetics;
+    return this;
+  }
+
+  public QueryRequestBuilder setCacheId(String cacheId) {
+    this.cacheId = cacheId;
+    return this;
+  }
+
+  public QueryRequestBuilder setFacets(Set<String> facets) {
+    this.facets = facets;
+    return this;
+  }
+
+  public QueryRequest build() throws CqlParseException {
+
+    List<SortBy> sortBys =
+        sorts
+            .stream()
+            .filter(
+                s ->
+                    StringUtils.isNotEmpty(s.getAttribute())
+                        && StringUtils.isNotEmpty(s.getDirection()))
+            .map(s -> parseSort(s.getAttribute(), s.getDirection()))
+            .collect(Collectors.toList());
+    if (sortBys.isEmpty()) {
+      sortBys.add(new SortByImpl(Result.TEMPORAL, DEFAULT_SORT_ORDER));
+    }
+    Query query =
+        new QueryImpl(createFilter(filterBuilder), start, count, sortBys.get(0), true, timeout);
+
+    QueryRequest queryRequest;
+    if (!CollectionUtils.isEmpty(srcs)) {
+      parseSrcs(localSource);
+      queryRequest = new QueryRequestImpl(query, srcs);
+      queryRequest.getProperties().put(MODE, UPDATE);
+    } else {
+      String source = parseSrc(localSource);
+      if (CACHE_SOURCE.equals(source)) {
+        queryRequest = new QueryRequestImpl(query, true);
+        queryRequest.getProperties().put(MODE, CACHE_SOURCE);
+      } else {
+        queryRequest = new QueryRequestImpl(query, Collections.singleton(source));
+        queryRequest.getProperties().put(MODE, UPDATE);
+      }
+    }
+
+    queryRequest = facetQueryRequest(queryRequest);
+
+    if (excludeUnnecessaryAttributes) {
+      queryRequest
+          .getProperties()
+          .put("excludeAttributes", Sets.newHashSet(Metacard.METADATA, "lux"));
+    }
+
+    if (sortBys.size() > 1) {
+      queryRequest
+          .getProperties()
+          .put(ADDITIONAL_SORT_BYS, sortBys.subList(1, sortBys.size()).toArray(new SortBy[0]));
+    }
+
+    queryRequest.getProperties().put("requestId", id);
+
+    if (StringUtils.isNotEmpty(batchId)) {
+      queryRequest.getProperties().put("batchId", batchId);
+    }
+
+    if (StringUtils.isNotEmpty(queryType)) {
+      queryRequest.getProperties().put("queryType", queryType);
+    }
+
+    if (spellcheck != null) {
+      queryRequest.getProperties().put("spellcheck", spellcheck);
+    }
+
+    if (phonetics != null) {
+      queryRequest.getProperties().put("phonetics", phonetics);
+    }
+
+    if (cacheId != null) {
+      queryRequest.getProperties().put("cacheId", cacheId);
+    }
+
+    return queryRequest;
+  }
+
+  private QueryRequest facetQueryRequest(QueryRequest request) {
+    if (facets.isEmpty()) {
+      return request;
+    }
+
+    return new FacetedQueryRequest(
+        request.getQuery(),
+        request.isEnterprise(),
+        request.getSourceIds(),
+        request.getProperties(),
+        new TermFacetPropertiesImpl(facets));
+  }
+
+  private Filter createFilter(FilterBuilder filterBuilder) throws CqlParseException {
+
+    Filter filter;
+    try {
+      filter = ECQL.toFilter(cql);
+    } catch (CQLException e) {
+      throw new CqlParseException(e);
+    }
+
+    if (filter == null) {
+      LOGGER.debug("Received an empty filter. Using a wildcard contextual filter instead.");
+      filter =
+          filterBuilder.attribute(Metacard.ANY_TEXT).is().like().text(FilterDelegate.WILDCARD_CHAR);
+    }
+
+    return filter;
+  }
+
+  private String parseSrc(String localSource) {
+    if (StringUtils.equalsIgnoreCase(src, LOCAL_SOURCE) || StringUtils.isBlank(src)) {
+      src = localSource;
+    }
+
+    return src;
+  }
+
+  private void parseSrcs(String localSource) {
+    for (int i = 0; i < srcs.size(); i++) {
+      if (StringUtils.equalsIgnoreCase(srcs.get(i), LOCAL_SOURCE)) {
+        srcs.set(i, localSource);
+      }
+    }
+  }
+
+  private SortBy parseSort(String sortField, String sortOrder) {
+    SortBy sort;
+    switch (sortOrder.toLowerCase(Locale.getDefault())) {
+      case "ascending":
+      case "asc":
+        sort = new SortByImpl(sortField, SortOrder.ASCENDING);
+        break;
+      case "descending":
+      case "desc":
+        sort = new SortByImpl(sortField, SortOrder.DESCENDING);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Incorrect sort order received, must be 'asc', 'ascending', 'desc', or 'descending'");
+    }
+
+    return sort;
+  }
+}

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestFactoryImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestFactoryImpl.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.cql;
+
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.codice.ddf.catalog.ui.CqlParseException;
+import org.codice.ddf.catalog.ui.query.utility.CqlRequest;
+import org.codice.ddf.catalog.ui.query.utility.QueryRequestFactory;
+
+public class QueryRequestFactoryImpl implements QueryRequestFactory {
+  @Override
+  public QueryRequest build(
+      String localSource,
+      FilterBuilder filterBuilder,
+      List<CqlRequest.Sort> sorts,
+      int start,
+      int count,
+      long timeout,
+      String id,
+      String cql,
+      @Nullable String src,
+      @Nullable List<String> srcs,
+      boolean isExcludeUnnecessaryAttribute,
+      @Nullable String batchId,
+      @Nullable String queryType,
+      boolean isSpellcheck,
+      boolean isPhonetics,
+      @Nullable String cacheId,
+      @Nullable Set<String> facets)
+      throws CqlParseException {
+
+    QueryRequestBuilder builder =
+        new QueryRequestBuilder(localSource, filterBuilder, sorts, start, count, timeout, id, cql);
+
+    if (src != null) {
+      builder.setSrc(src);
+    }
+
+    if (srcs != null) {
+      builder.setSources(srcs);
+    }
+
+    builder.setExcludeUnnecessaryAttributes(isExcludeUnnecessaryAttribute);
+
+    if (batchId != null) {
+      builder.setBatchId(batchId);
+    }
+
+    if (queryType != null) {
+      builder.setQueryType(queryType);
+    }
+
+    builder.setSpellcheck(isSpellcheck);
+    builder.setPhonetics(isPhonetics);
+
+    if (cacheId != null) {
+      builder.setCacheId(cacheId);
+    }
+
+    if (facets != null) {
+      builder.setFacets(facets);
+    }
+
+    return builder.build();
+  }
+}

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -52,6 +52,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.codice.ddf.catalog.ui.metacard.transformer.CsvTransformImpl;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
 import org.codice.ddf.catalog.ui.query.utility.CqlQueryResponse;
@@ -241,7 +242,8 @@ public class CqlTransformHandler implements Route {
                     cqlQueryResponse = cqlQueryUtil.executeCqlQuery(cqlRequest);
                   } catch (UnsupportedQueryException
                       | SourceUnavailableException
-                      | FederationException e) {
+                      | FederationException
+                      | CqlParseException e) {
                     LOGGER.debug("Error fetching cql request for {}", cqlRequest.getSrc());
                     return null;
                   }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlRequestParser.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlRequestParser.java
@@ -20,6 +20,7 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryRequest;
 import java.io.IOException;
 import java.util.Date;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.codice.gsonsupport.GsonTypeAdapters.DateLongFormatTypeAdapter;
@@ -49,7 +50,7 @@ public class CqlRequestParser {
     this.endpointUtil = endpointUtil;
   }
 
-  public QueryRequest parse(Request request) throws IOException {
+  public QueryRequest parse(Request request) throws IOException, CqlParseException {
     CqlRequestImpl cqlRequest =
         GSON.fromJson(endpointUtil.safeGetBody(request), CqlRequestImpl.class);
     return cqlRequest.createQueryRequest(catalogFramework.getId(), filterBuilder);

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/CqlQueriesImpl.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.codice.ddf.catalog.ui.metacard.transformer.CsvTransformImpl;
 import org.codice.ddf.catalog.ui.query.cql.CqlQueryResponseImpl;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl;
@@ -80,7 +81,8 @@ public class CqlQueriesImpl implements CqlQueries {
 
   @Override
   public CqlQueryResponse executeCqlQuery(CqlRequest cqlRequest)
-      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException,
+          CqlParseException {
     QueryRequest request = cqlRequest.createQueryRequest(catalogFramework.getId(), filterBuilder);
     Stopwatch stopwatch = Stopwatch.createStarted();
 

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -65,6 +65,8 @@ Implementation details
         <property name="descriptors" ref="transformerDescriptors"/>
     </bean>
 
+    <service ref="cqlQueryUtil" interface="org.codice.ddf.catalog.ui.query.utility.CqlQueries"/>
+
     <bean id="accessControlSecurityConfiguration"
           class="org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlSecurityConfiguration">
         <cm:managed-properties
@@ -527,5 +529,9 @@ Implementation details
             </bean>
         </argument>
     </bean>
+
+    <bean id="queryFactory" class="org.codice.ddf.catalog.ui.query.cql.QueryRequestFactoryImpl"/>
+
+    <service ref="queryFactory" interface="org.codice.ddf.catalog.ui.query.utility.QueryRequestFactory"/>
 
 </blueprint>

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/CqlRequestImplTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/CqlRequestImplTest.java
@@ -25,11 +25,11 @@ import ddf.catalog.operation.QueryRequest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.codice.ddf.catalog.ui.CqlParseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
-import spark.HaltException;
 
 public class CqlRequestImplTest {
 
@@ -84,7 +84,7 @@ public class CqlRequestImplTest {
   }
 
   @Test
-  public void testMultipleSorts() {
+  public void testMultipleSorts() throws CqlParseException {
     List<CqlRequestImpl.Sort> sorts = new ArrayList<>();
     sorts.add(new CqlRequestImpl.Sort(SORT_PROPERTY, ASC_SORT_ORDER));
     sorts.add(new CqlRequestImpl.Sort("foobar", DESC_SORT_ORDER));
@@ -101,7 +101,7 @@ public class CqlRequestImplTest {
   }
 
   @Test
-  public void testCreateQueryWithLocalSource() {
+  public void testCreateQueryWithLocalSource() throws CqlParseException {
     QueryRequest queryRequest = cqlRequest.createQueryRequest(LOCAL_SOURCE, filterBuilder);
     SortBy sortBy = queryRequest.getQuery().getSortBy();
     assertThat(sortBy.getPropertyName().getPropertyName(), is(SORT_PROPERTY));
@@ -110,7 +110,7 @@ public class CqlRequestImplTest {
   }
 
   @Test
-  public void testCreateQueryWithCacheSource() {
+  public void testCreateQueryWithCacheSource() throws CqlParseException {
     cqlRequest.setSorts(
         Collections.singletonList(new CqlRequestImpl.Sort(SORT_PROPERTY, DESC_SORT_ORDER)));
     cqlRequest.setSrc(CACHE_SOURCE);
@@ -122,39 +122,39 @@ public class CqlRequestImplTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testBadSortOrder() {
+  public void testBadSortOrder() throws CqlParseException {
     cqlRequest.setSorts(Collections.singletonList(new CqlRequestImpl.Sort(SORT_PROPERTY, "bad")));
     cqlRequest.createQueryRequest(CACHE_SOURCE, filterBuilder);
   }
 
   @Test
-  public void testBadSortOrderString() {
+  public void testBadSortOrderString() throws CqlParseException {
     cqlRequest.setSorts(Collections.singletonList(new CqlRequestImpl.Sort(SORT_PROPERTY, null)));
     QueryRequest queryRequest = cqlRequest.createQueryRequest(LOCAL_SOURCE, filterBuilder);
     assertDefaultSortBy(queryRequest);
   }
 
   @Test
-  public void testBlankSortOrder() {
+  public void testBlankSortOrder() throws CqlParseException {
     cqlRequest.setSorts(Collections.emptyList());
     QueryRequest queryRequest = cqlRequest.createQueryRequest(LOCAL_SOURCE, filterBuilder);
     assertDefaultSortBy(queryRequest);
   }
 
-  @Test(expected = HaltException.class)
-  public void testBadCql() {
+  @Test(expected = CqlParseException.class)
+  public void testBadCql() throws CqlParseException {
     cqlRequest.setCql(BAD_CQL);
     cqlRequest.createQueryRequest(LOCAL_SOURCE, filterBuilder);
   }
 
   @Test
-  public void testBlankLocalSource() {
+  public void testBlankLocalSource() throws CqlParseException {
     cqlRequest.createQueryRequest("", filterBuilder);
     assertThat(cqlRequest.getSource(), is("source"));
   }
 
   @Test
-  public void testMultipleSources() {
+  public void testMultipleSources() throws CqlParseException {
     ArrayList<String> sources = new ArrayList<>();
     sources.add("local");
     sources.add("source2");
@@ -165,13 +165,13 @@ public class CqlRequestImplTest {
   }
 
   @Test
-  public void testSingleSourceResponseString() {
+  public void testSingleSourceResponseString() throws CqlParseException {
     cqlRequest.createQueryRequest("", filterBuilder);
     assertThat(cqlRequest.getSourceResponseString(), is("source"));
   }
 
   @Test
-  public void testMultipleSourceResponseString() {
+  public void testMultipleSourceResponseString() throws CqlParseException {
     ArrayList<String> sources = new ArrayList<>();
     sources.add("source1");
     sources.add("source2");
@@ -181,7 +181,7 @@ public class CqlRequestImplTest {
   }
 
   @Test
-  public void testLocalSource() {
+  public void testLocalSource() throws CqlParseException {
     cqlRequest.setSrc(LOCAL_SOURCE);
     cqlRequest.createQueryRequest(LOCAL_SOURCE, filterBuilder);
     assertThat(cqlRequest.getSource(), is(LOCAL_SOURCE));


### PR DESCRIPTION
A downstream project needs to create a thin layer over the existing cql endpoint. Some refactoring was needed.

This PR extracts the logic that creates the QueryRequest object into a service that can be used by the downstream project. Also, in the case the cql fails to parse, an exception is thrown instead of sending a "halt" to the HTTP layer. The QueryApplication catches that exception and issues to the same "halt" in order to maintain the same behavior.

closes #258 