### PR TITLE
[3.4.x] DDF-UI-262 Workspace loosing tools when Theme Zoom Percentage greater than 100%

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.less
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.less
@@ -321,7 +321,7 @@
   }
 
   > .golden-layout-container {
-    height: ~'calc(100%)';
+    height: ~'calc(99.5%)';
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
@@ -216,7 +216,9 @@ module.exports = Marionette.LayoutView.extend({
     })
   },
   updateSize() {
-    this.goldenLayout.updateSize()
+    Common.repaintForTimeframe(2000, () => {
+      this.goldenLayout.updateSize()
+    })
   },
   showWidgetDropdown() {
     this.widgetDropdown.show(


### PR DESCRIPTION
#### What does this PR do?
When changing theme setting 'Zoom Percentage' to a value greater than 100%, can no longer see some of the control tools, such as the horizontal scroll bar, the 'Add Visual' etc., unless page is refreshed after the theme is updated.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@cassandrabailey293 
@zta6 

#### Select relevant component teams: 


#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Go to Workspace
2. Create new workspace
3. Upload some content
4. Search for items
5. Add Visual (2D Map, Table etc.)
6. Click on the setting wheel and go to theme
7. Update Zoom Percentage and Spacing and ensure everything looks good and nothing is out of place. Ensure you don't lose the control tools such as the 'Add Visual Button', zoom in and out button in 2d map, the horizontal scroll bar in Table etc. 
	**Note:** for 2D map the 'Add visual' button might be covering the zoom in/out control bar, but this is ok since the 'Add Visual' button will be remove in story.
8. Can move the added Visual tabs around and do step 6 to 7 and ensure not losing any control tools.
9. Resize the browser window and also ensure the control tools are not missing as well.

#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#262

#### Screenshots
<!--(if appropriate)-->
##### Before
<img width="1917" alt="Before - 2D map" src="https://user-images.githubusercontent.com/65194214/86809037-a5c3de00-c038-11ea-98be-376874b6313b.png">
<img width="1917" alt="Before - Table" src="https://user-images.githubusercontent.com/65194214/86809060-ae1c1900-c038-11ea-8144-a3a3ac59c566.png">
<img width="1919" alt="Before - split" src="https://user-images.githubusercontent.com/65194214/86809058-ac525580-c038-11ea-8725-bea70849ec56.png">
<img width="1808" alt="Before - Resize" src="https://user-images.githubusercontent.com/65194214/86809047-a8bece80-c038-11ea-8ff3-6a07873b174c.png">


##### After
<img width="1916" alt="After - 2D Map" src="https://user-images.githubusercontent.com/65194214/86808480-23d3b500-c038-11ea-80c7-4e8432e3517b.png">
<img width="1916" alt="After - Table" src="https://user-images.githubusercontent.com/65194214/86808838-757c3f80-c038-11ea-8337-dfcae92853f3.png">
<img width="1917" alt="After - split" src="https://user-images.githubusercontent.com/65194214/86808780-68f7e700-c038-11ea-81b1-4290cf2e4f76.png">
<img width="1814" alt="After - Resize" src="https://user-images.githubusercontent.com/65194214/86808743-5f6e7f00-c038-11ea-9f1e-5ef2938a9a16.png">







#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
