### PR TITLE
[3.4.x] DDF-6159 Made Textbox Placeholder text more visible

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/components/base.less
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/components/base.less
@@ -4,6 +4,11 @@
   display: none;
 }
 
+::placeholder {
+  color: inherit;
+  opacity: 0.5;
+}
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
What does this PR do?
Changes the color of placeholder text to adapt to the user selected theme. This was done by adding the ::placeholder field to base.less, setting it to inherit the regular text color and setting the opacity to 0.5 to make it appear lighter than regular text. Back port of [https://github.com/codice/ddf-ui/pull/265](https://github.com/codice/ddf-ui/pull/265) and [https://github.com/codice/ddf/pull/6160](https://github.com/codice/ddf/pull/6160)

Who is reviewing it?
@leo-sakh
@lavoywj
@bennuttle
@rymach
@bdeining
@mojogitoverhere

Select relevant component teams:
Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@rzwiefel

How should this be tested?
Build, Install and start DDF
Click Search DDF Intrigue
Observe the placeholder test in the text input boxes
Any background context you want to provide?
What are the relevant tickets?
Fixes: #6159

Screenshots
Before:
Screen Shot 2020-07-07 at 9 43 00 AM

After:
Screen Shot 2020-07-06 at 12 22 09 PM

Checklist:
Documentation Updated
Update / Add Threat Dragon models
Update / Add Unit Tests
Update / Add Integration Tests
Notes on Review Process
Please see Notes on Review Process for further guidance on requirements for merging and abbreviated reviews.

Review Comment Legend:
✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.