### PR TITLE
DDF-UI-269 G-8544 update map for USNG shortest distance while drawing

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -141,7 +141,7 @@ module.exports = Backbone.AssociatedModel.extend({
     this.listenTo(
       this,
       'change:usngbbUpperLeft change:usngbbLowerRight',
-      this.setBboxUsngUL
+      this.setBboxUsng
     )
     this.listenTo(this, 'change:locationType', this.handleLocationType)
     this.listenTo(this, 'change:bbox', _.debounce(this.setBboxLatLon, 150))
@@ -453,7 +453,7 @@ module.exports = Backbone.AssociatedModel.extend({
     return {}
   },
 
-  setBboxUsngUL() {
+  setBboxUsng() {
     if (this.get('locationType') !== 'usng') {
       return
     }
@@ -492,45 +492,6 @@ module.exports = Backbone.AssociatedModel.extend({
     }
   },
 
-  setBboxUsng() {
-    if (this.get('locationType') !== 'usng') {
-      return
-    }
-
-    let result
-    try {
-      result = converter.USNGtoLL(this.get('usngbb'))
-    } catch (err) {
-      // do nothing
-    }
-
-    if (result === undefined) {
-      return
-    }
-
-    const newResult = {}
-    newResult.mapNorth = result.north
-    newResult.mapSouth = result.south
-    newResult.mapEast = result.east
-    newResult.mapWest = result.west
-    this.set(newResult)
-    this.set(result, { silent: true })
-
-    var utmUps = this.LLtoUtmUps(result.north, result.west)
-    if (utmUps !== undefined) {
-      var utmUpsFormatted = this.formatUtmUps(utmUps)
-      this.setUtmUpsUpperLeft(utmUpsFormatted, true)
-    }
-
-    // eslint-disable-next-line no-redeclare
-    var utmUps = this.LLtoUtmUps(result.south, result.east)
-    if (utmUps !== undefined) {
-      // eslint-disable-next-line no-redeclare
-      var utmUpsFormatted = this.formatUtmUps(utmUps)
-      this.setUtmUpsLowerRight(utmUpsFormatted, true)
-    }
-  },
-
   setBBox() {
     //we need these to always be inferred
     //as numeric values and never as strings
@@ -552,14 +513,12 @@ module.exports = Backbone.AssociatedModel.extend({
           !this.get('drawing'),
       })
     }
-    if (this.get('locationType') !== 'usng' && !this.isLocationTypeUtmUps()) {
-      this.set({
-        mapNorth: north,
-        mapSouth: south,
-        mapEast: east,
-        mapWest: west,
-      })
-    }
+    this.set({
+      mapNorth: north,
+      mapSouth: south,
+      mapEast: east,
+      mapWest: west,
+    })
   },
 
   setRadiusUsng() {


### PR DESCRIPTION
#### Link to 2.19.x PR https://github.com/codice/ddf/pull/6171
#### Link to 3.4.x PR https://github.com/codice/ddf-ui/pull/271
_____________

#### What does this PR do?
This PR removes the condition that prevented the map state variables (those that update the map while drawing) from being set while in USNG/MGRS (it did not affect UTM/UPS because for some reason the `locationType` is changed from `utm` to `latlon` while drawing in UTM/UPS then switches back when drawing ends). This PR also removes an unused function.
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #269
G-8544
#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
