### PR TITLE
DDF-UI-283 UI failing to pan to initial result when 2D is Opened

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -253,9 +253,7 @@ module.exports = Marionette.LayoutView.extend({
     )
 
     if (this.options.selectionInterface.getSelectedResults().length > 0) {
-      this.map.zoomToSelected(
-        this.options.selectionInterface.getSelectedResults()
-      )
+      Common.queueExecution(this.map.zoomToSelected.bind(this.map))
     } else {
       Common.queueExecution(this.zoomToHome.bind(this))
     }


### PR DESCRIPTION
#### What does this PR do?
UI failing to pan to initial result when 2D is Opened. Result must be selected before 2D map visual opened.

Expectation - 2D Map pan to selected result
Actual - 2D Map stays at home location
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer
@hayleynorton
@cassandrabailey293
@zta6
#### Select relevant component teams: 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
	1. Upload items (Click on Navigation icon on upper left corner)
	2. Open a new workspace and search for uploaded items
	3. Add locations attributes to items, so that icon is displayed on 2D map.
		a. Items can be added via the Inspector Visual. Example locations bellow:
			i.  POLYGON ((32.896 -22.1266, 32.896 -34.8398, 16.458 -34.8398, 16.458 -22.1266, 32.896 -22.1266)))
			ii. POLYGON ((137.1736 45.8825, 137.1736 45.7598, 136.9888 45.7598, 136.9888 45.8825, 137.1736 45.8825))
	4. Close 2D Map, select an item and reopen 2D Map
	5. Confirm map pan to correct location based on what was selected.
	6. Do it for couple item, also confirm when 2D map is open when selecting item, it pans appropriately.
#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#283

#### Screenshots
<!--(if appropriate)-->
##### Before
![Before-workspace-2D-Issue](https://user-images.githubusercontent.com/65194214/88077657-bbf19400-cb38-11ea-8197-89304ca01e8b.gif)

##### After
![After-workspace-2D-Issue](https://user-images.githubusercontent.com/65194214/88077709-c9a71980-cb38-11ea-944d-22b301abbccc.gif)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
