### PR TITLE
DDF-UI-287 G-8723 Fixed point radius UTM/UPS error

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -286,9 +286,9 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsEasting']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo('utmUpsEasting', {
-              utmUpsEasting,
-              utmUpsNorthing,
+            validateGeo('easting', {
+              easting: utmUpsEasting,
+              northing: utmUpsNorthing,
               zoneNumber: utmUpsZone,
               hemisphere: utmUpsHemisphere,
             })
@@ -304,9 +304,9 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsNorthing']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo('utmUpsNorthing', {
-              utmUpsEasting,
-              utmUpsNorthing,
+            validateGeo('northing', {
+              easting: utmUpsEasting,
+              northing: utmUpsNorthing,
               zoneNumber: utmUpsZone,
               hemisphere: utmUpsHemisphere,
             })
@@ -319,9 +319,9 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsZone']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo('utmUpsZone', {
-              utmUpsEasting,
-              utmUpsNorthing,
+            validateGeo('zoneNumber', {
+              easting: utmUpsEasting,
+              northing: utmUpsNorthing,
               zoneNumber: utmUpsZone,
               hemisphere: utmUpsHemisphere,
             })
@@ -333,9 +333,9 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsHemisphere']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo('utmUpsHemisphere', {
-              utmUpsEasting,
-              utmUpsNorthing,
+            validateGeo('hemisphere', {
+              easting: utmUpsEasting,
+              northing: utmUpsNorthing,
               zoneNumber: utmUpsZone,
               hemisphere: utmUpsHemisphere,
             })


### PR DESCRIPTION
#### 2.19.x PR: https://github.com/codice/ddf/pull/6197
#### 3.4.x PR: https://github.com/codice/ddf-ui/pull/289
____________________________________________
#### What does this PR do?
Changes the keys of utm/ups easting, northing, zone and hemisphere when calling validateGeo in point-radius in order to match the changes made in https://github.com/codice/ddf/pull/5958
#### Who is reviewing it? 
@abel-connexta @andrewkfiedler @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@mojogitoverhere 
#### How should this be tested?
Verify that you can enter values into all fields under anyGeo > Point Radius > UTM/UPS
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #287
G-8723
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
