### PR TITLE
DDF-UI-299 G-8412 Extended thumbnail onClick to allow for different url

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import React from 'react'
+
+const DropdownView = require('../dropdown.view')
+const ComponentView = require('../../hover-preview/hover-preview.view.js')
+const Common = require('../../../js/Common.js')
+const user = require('../../singletons/user-instance.js')
+const plugin = require('plugins/dropdown.hover-preview.view.js')
+
+module.exports = DropdownView.extend({
+  events: {}, // remove base events
+  template() {
+    const metacardProperties = this.modelForComponent
+      .get('metacard')
+      .get('properties')
+    const model = this.model
+
+    const openThumbnailInNewWindow = plugin(metacardProperties =>
+      window.open(Common.getImageSrc(metacardProperties.get('thumbnail')))
+    )
+    const onMouseEnter = () => user.getHoverPreview() && model.open()
+    const onMouseLeave = () => model.close()
+    const onImageError = () => {
+      this.imageLoadError = true
+      this.render()
+    }
+
+    return (
+      (metacardProperties.get('thumbnail') && (
+        <div
+          onClick={() => openThumbnailInNewWindow(metacardProperties)}
+          title="Click to open image in a new window."
+        >
+          {(this.imageLoadError && (
+            <span>
+              <i className="fa fa-picture-o" aria-hidden="true" />
+              {` Unable to load image`}
+            </span>
+          )) || (
+            <img
+              src={Common.getImageSrc(metacardProperties.get('thumbnail'))}
+              onError={onImageError}
+            />
+          )}
+          <button
+            className="is-primary"
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+          >
+            <span className="fa fa-search-plus" />
+          </button>
+        </div>
+      )) || <React.Fragment />
+    )
+  },
+  imageLoadError: false,
+  className: 'is-hover-preview',
+  componentToShow: ComponentView,
+  initialize() {
+    DropdownView.prototype.initialize.call(this)
+  },
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/dropdown.hover-preview.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/dropdown.hover-preview.view.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+module.exports = v => v


### PR DESCRIPTION
#### 2.19.x PR https://github.com/codice/ddf/pull/6217
#### 3.4.x PR https://github.com/codice/ddf-ui/pull/301
_____________
#### What does this PR do?
Adds a plugin for dropdown.hover-preview.view.js that wraps the `openThumbnailInNewWindow` function to allow for a different url to be opened in a new window
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@mojogitoverhere 
@shaundmorris 
#### How should this be tested?
Upload a result that has a thumbnail and ensure that clicking on the thumbnail image opens a new window that displays the image (basically, verify no regression in this feature)
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #299
G-8412
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
