### PR TITLE
[3.4.x] DDF-UI-299 G-8412 Extended thumbnail onClick to allow for different url

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
@@ -19,18 +19,19 @@ const DropdownView = require('../dropdown.view')
 const ComponentView = require('../../hover-preview/hover-preview.view.js')
 const Common = require('../../../js/Common.js')
 const user = require('../../singletons/user-instance.js')
+const plugin = require('plugins/dropdown.hover-preview.view.js')
 
 module.exports = DropdownView.extend({
   events: {}, // remove base events
   template() {
-    const metadataThumbnail = this.modelForComponent
+    const metacardProperties = this.modelForComponent
       .get('metacard')
       .get('properties')
-      .get('thumbnail')
     const model = this.model
 
-    const openThumbnailInNewWindow = () =>
-      window.open(Common.getImageSrc(metadataThumbnail))
+    const openThumbnailInNewWindow = plugin(metacardProperties =>
+      window.open(Common.getImageSrc(metacardProperties.get('thumbnail')))
+    )
     const onMouseEnter = () => user.getHoverPreview() && model.open()
     const onMouseLeave = () => model.close()
     const onImageError = () => {
@@ -39,8 +40,11 @@ module.exports = DropdownView.extend({
     }
 
     return (
-      (metadataThumbnail && (
-        <React.Fragment>
+      (metacardProperties.get('thumbnail') && (
+        <div
+          onClick={() => openThumbnailInNewWindow(metacardProperties)}
+          title="Click to open image in a new window."
+        >
           {(this.imageLoadError && (
             <span>
               <i className="fa fa-picture-o" aria-hidden="true" />
@@ -48,7 +52,7 @@ module.exports = DropdownView.extend({
             </span>
           )) || (
             <img
-              src={Common.getImageSrc(metadataThumbnail)}
+              src={Common.getImageSrc(metacardProperties.get('thumbnail'))}
               onError={onImageError}
             />
           )}
@@ -56,12 +60,10 @@ module.exports = DropdownView.extend({
             className="is-primary"
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            onClick={openThumbnailInNewWindow}
-            title="Click to open image in a new window."
           >
             <span className="fa fa-search-plus" />
           </button>
-        </React.Fragment>
+        </div>
       )) || <React.Fragment />
     )
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/dropdown.hover-preview.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/plugins/dropdown.hover-preview.view.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+module.exports = v => v


### PR DESCRIPTION
#### 2.19.x PR https://github.com/codice/ddf/pull/6217
#### master PR https://github.com/codice/ddf-ui/pull/300
_____________
#### What does this PR do?
Adds a plugin for dropdown.hover-preview.view.js that wraps the `openThumbnailInNewWindow` function to allow for a different url to be opened in a new window
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@mojogitoverhere 
@shaundmorris 
#### How should this be tested?
Upload a result that has a thumbnail and ensure that clicking on the thumbnail image opens a new window that displays the image (basically, verify no regression in this feature)
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #299
G-8412
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
