### PR TITLE
G-8544 Fixed bounding box disappearing over anti-meridian

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
@@ -75,12 +75,29 @@ Draw.BboxView = Marionette.View.extend({
     let west = parseFloat(model.get('mapWest'))
 
     if (isNaN(north) || isNaN(south) || isNaN(east) || isNaN(west)) {
+      this.destroyPrimitive()
       return
     }
 
-    // If south is greater than north, return in order to
-    // prevent displaying the shape on the map
+    // If south is greater than north,
+    // remove shape from map
     if (south > north) {
+      this.destroyPrimitive()
+      return
+    }
+
+    if (
+      validateGeo(
+        'polygon',
+        JSON.stringify([
+          [west, north],
+          [east, north],
+          [west, south],
+          [east, south],
+          [west, north],
+        ])
+      ).error
+    ) {
       return
     }
 
@@ -121,10 +138,6 @@ Draw.BboxView = Marionette.View.extend({
     coords.push(southEast)
     coords.push(southWest)
     coords.push(northWest)
-
-    if (validateGeo('polygon', JSON.stringify(coords)).error) {
-      return
-    }
 
     const rectangle = new ol.geom.LineString(coords)
     return rectangle


### PR DESCRIPTION
#### 2.19.x PR https://github.com/codice/ddf/pull/6236
#### 3.4.x PR https://github.com/codice/ddf-ui/pull/320
_________________
#### What does this PR do?
Bounding boxes drawn over the anti-meridian were disappearing from the map because the call to `validateGeo` registers an error when the east/west values are outside of [-180, 180]. This PR moves `validateGeo` so that it's called before the anti-meridian adjustment of east/west values. This PR also explicitly removes bounding boxes from the map if any values are `NaN` or the south value is greater than or equal to the north value.
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere
#### How should this be tested?
Verify that bounding boxes drawn over the anti-meridian do not disappear after drawing is complete
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: G-8544
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
