### PR TITLE
[3.6.x] Updates summary view management

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -69,6 +69,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
@@ -308,6 +309,26 @@ public class EndpointUtil implements EndpointUtility {
 
   public Map<String, Result> getMetacardsWithTagByAttributes(
       String attributeName, Collection<String> attributeValues, Filter tagFilter) {
+    return getMetacardsWithTagByAttributes(attributeName, attributeValues, tagFilter, null);
+  }
+
+  public Map<String, Result> getMetacardsWithTagByAttributes(
+      String attributeName,
+      Collection<String> attributeValues,
+      String tag,
+      @Nullable Set<String> storeIds) {
+    return getMetacardsWithTagByAttributes(
+        attributeName,
+        attributeValues,
+        filterBuilder.attribute(Core.METACARD_TAGS).is().like().text(tag),
+        storeIds);
+  }
+
+  public Map<String, Result> getMetacardsWithTagByAttributes(
+      String attributeName,
+      Collection<String> attributeValues,
+      Filter tagFilter,
+      @Nullable Set<String> storeIds) {
     if (attributeValues.isEmpty()) {
       return new HashMap<>();
     }
@@ -327,7 +348,7 @@ public class EndpointUtil implements EndpointUtility {
                     false,
                     TimeUnit.SECONDS.toMillis(10)),
                 false,
-                null,
+                storeIds,
                 additionalSort(new HashMap<>(), Core.ID, SortOrder.ASCENDING)));
 
     return resultIterable

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
@@ -16,8 +16,7 @@ package org.codice.ddf.catalog.ui.metacard;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -36,6 +35,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import javax.ws.rs.NotFoundException;
 import org.codice.ddf.catalog.ui.metacard.edit.AttributeChange;
@@ -66,7 +66,9 @@ public class MetacardApplicationTest {
 
   @Test(expected = NotFoundException.class)
   public void testPatchMetacardsWhenIdNotFound() throws Exception {
-    doReturn(Collections.emptyMap()).when(mockUtil).getMetacardsWithTagById(any(), eq("*"));
+    doReturn(Collections.emptyMap())
+        .when(mockUtil)
+        .getMetacardsWithTagByAttributes(any(), any(), any(String.class), any());
     app.doPatchMetacards(generateTitleChange());
   }
 
@@ -76,7 +78,7 @@ public class MetacardApplicationTest {
     when(mockFramework.update(requestCaptor.capture())).thenReturn(null);
     doReturn(generateCatalogStateWithTitle())
         .when(mockUtil)
-        .getMetacardsWithTagById(any(), eq("*"));
+        .getMetacardsWithTagByAttributes(any(), any(), any(String.class), any());
 
     app.doPatchMetacards(generateTitleChange());
 
@@ -91,7 +93,7 @@ public class MetacardApplicationTest {
     when(mockFramework.update(requestCaptor.capture())).thenReturn(null);
     doReturn(generateCatalogStateWithCreatedDate())
         .when(mockUtil)
-        .getMetacardsWithTagById(any(), eq("*"));
+        .getMetacardsWithTagByAttributes(any(), any(), any(String.class), any());
     doAnswer(MetacardApplicationTest::doParseDate).when(mockUtil).parseDate(any());
 
     app.doPatchMetacards(generateCreatedDateChange());
@@ -157,7 +159,8 @@ public class MetacardApplicationTest {
   }
 
   /**
-   * Test class that exposes the protected {@link MetacardApplication#patchMetacards(List, String)}.
+   * Test class that exposes the protected {@link MetacardApplication#patchMetacards(List, String,
+   * Set <String>)}.
    *
    * <p>Note the original method returns an UpdateResponse but we're not testing the Catalog
    * Framework's ability to return a good response; we're testing the app's ability to correctly
@@ -188,7 +191,7 @@ public class MetacardApplicationTest {
     }
 
     private void doPatchMetacards(List<MetacardChanges> metacardChanges) throws Exception {
-      patchMetacards(metacardChanges, null);
+      patchMetacards(metacardChanges, null, null);
     }
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -29,6 +29,8 @@ import { useLazyResultsSelectedResultsFromSelectionInterface } from '../../selec
 import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
 import TransferList from './transfer-list'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
+import AddIcon from '@material-ui/icons/Add'
+import Box from '@material-ui/core/Box'
 //metacardDefinitions.metacardTypes[attribute].type
 //metacardDefinitions.metacardTypes[attribute].multivalued
 //properties.isReadOnly(attribute)
@@ -228,81 +230,82 @@ export const Editor = ({
       <DialogContent style={{ minHeight: '30em', minWidth: '60vh' }}>
         {values.map((val: any, index: number) => {
           return (
-            <>
+            <Grid container direction="row">
               {index !== 0 ? <Divider style={{ margin: '5px 0px' }} /> : null}
-              {(() => {
-                switch (attrType) {
-                  case 'DATE':
-                    return (
-                      <KeyboardDateTimePicker
-                        disabled={mode === 'saving'}
-                        value={val}
-                        onChange={(e: any) => {
-                          values[index] = e.toISOString()
-                          setValues([...values])
-                        }}
-                        DialogProps={{
-                          disablePortal: true,
-                          style: {
-                            minWidth: '500px',
-                          },
-                        }}
-                        format={getDateTimeFormat()}
-                        fullWidth
-                      />
-                    )
+              <Grid item md={11}>
+                {(() => {
+                  switch (attrType) {
+                    case 'DATE':
+                      return (
+                        <KeyboardDateTimePicker
+                          disabled={mode === 'saving'}
+                          value={val}
+                          onChange={(e: any) => {
+                            values[index] = e.toISOString()
+                            setValues([...values])
+                          }}
+                          DialogProps={{
+                            disablePortal: true,
+                            style: {
+                              minWidth: '500px',
+                            },
+                          }}
+                          format={getDateTimeFormat()}
+                          fullWidth
+                        />
+                      )
 
-                  case 'BINARY':
-                    return (
-                      <ThumbnailInput
-                        disabled={mode === 'saving'}
-                        value={val}
-                        onChange={update => {
-                          values[index] = update
-                          setValues([...values])
-                        }}
-                      />
-                    )
-                  case 'BOOLEAN':
-                    return (
-                      <Checkbox
-                        disabled={mode === 'saving'}
-                        checked={val}
-                        onChange={e => {
-                          values[index] = e.target.checked
-                          setValues([...values])
-                        }}
-                        color="primary"
-                      />
-                    )
-                  case 'LONG':
-                  case 'DOUBLE':
-                  case 'FLOAT':
-                  case 'INTEGER':
-                  case 'SHORT':
-                    return (
-                      <TextField
-                        disabled={mode === 'saving'}
-                        value={val}
-                        onChange={e => {
-                          values[index] = e.target.value
-                          setValues([...values])
-                        }}
-                        type="number"
-                        fullWidth
-                      />
-                    )
-                  case 'GEOMETRY':
-                    return (
-                      <TextField
-                        disabled={mode === 'saving'}
-                        value={val}
-                        onChange={e => {
-                          values[index] = e.target.value
-                          setValues([...values])
-                        }}
-                        fullWidth
-                        helperText="WKT Syntax is supported for geometries, here are some examples:
+                    case 'BINARY':
+                      return (
+                        <ThumbnailInput
+                          disabled={mode === 'saving'}
+                          value={val}
+                          onChange={update => {
+                            values[index] = update
+                            setValues([...values])
+                          }}
+                        />
+                      )
+                    case 'BOOLEAN':
+                      return (
+                        <Checkbox
+                          disabled={mode === 'saving'}
+                          checked={val}
+                          onChange={e => {
+                            values[index] = e.target.checked
+                            setValues([...values])
+                          }}
+                          color="primary"
+                        />
+                      )
+                    case 'LONG':
+                    case 'DOUBLE':
+                    case 'FLOAT':
+                    case 'INTEGER':
+                    case 'SHORT':
+                      return (
+                        <TextField
+                          disabled={mode === 'saving'}
+                          value={val}
+                          onChange={e => {
+                            values[index] = e.target.value
+                            setValues([...values])
+                          }}
+                          type="number"
+                          fullWidth
+                        />
+                      )
+                    case 'GEOMETRY':
+                      return (
+                        <TextField
+                          disabled={mode === 'saving'}
+                          value={val}
+                          onChange={e => {
+                            values[index] = e.target.value
+                            setValues([...values])
+                          }}
+                          fullWidth
+                          helperText="WKT Syntax is supported for geometries, here are some examples:
                           POINT (50 40)
                           LINESTRING (30 10, 10 30, 40 40)
                           POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))
@@ -310,27 +313,28 @@ export const Editor = ({
                           MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))
                           MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))
                           GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"
-                      />
-                    )
-                  default:
-                    return (
-                      <TextField
-                        disabled={mode === 'saving'}
-                        value={val}
-                        onChange={(e: any) => {
-                          values[index] = e.target.value
-                          setValues([...values])
-                        }}
-                        style={{ whiteSpace: 'pre-line', flexGrow: 50 }}
-                        fullWidth
-                        multiline={true}
-                        rowsMax={1000}
-                      />
-                    )
-                }
-              })()}
+                        />
+                      )
+                    default:
+                      return (
+                        <TextField
+                          disabled={mode === 'saving'}
+                          value={val}
+                          onChange={(e: any) => {
+                            values[index] = e.target.value
+                            setValues([...values])
+                          }}
+                          style={{ whiteSpace: 'pre-line', flexGrow: 50 }}
+                          fullWidth
+                          multiline={true}
+                          rowsMax={1000}
+                        />
+                      )
+                  }
+                })()}
+              </Grid>
               {isMultiValued ? (
-                <Grid item>
+                <Grid item md={1}>
                   <Button
                     disabled={mode === 'saving'}
                     onClick={() => {
@@ -342,23 +346,31 @@ export const Editor = ({
                   </Button>
                 </Grid>
               ) : null}
-            </>
+            </Grid>
           )
         })}
-        <Button
-          disabled={mode === 'saving' || (!isMultiValued && values.length > 0)}
-          onClick={() => {
-            let defaultValue = ''
-            switch (attrType) {
-              case 'DATE':
-                defaultValue = new Date().toISOString()
-                break
-            }
-            setValues([...values, defaultValue])
-          }}
-        >
-          Add New Value
-        </Button>
+        {isMultiValued &&
+          values.length > 0 && (
+            <Button
+              disabled={mode === 'saving'}
+              variant="text"
+              color="primary"
+              onClick={() => {
+                let defaultValue = ''
+                switch (attrType) {
+                  case 'DATE':
+                    defaultValue = new Date().toISOString()
+                    break
+                }
+                setValues([...values, defaultValue])
+              }}
+            >
+              <Box color="text.primary">
+                <AddIcon />
+              </Box>
+              Add New Value
+            </Button>
+          )}
       </DialogContent>
       <Divider />
       <DialogActions>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -364,8 +364,7 @@ export const Editor = ({
       <DialogActions>
         <Button
           disabled={mode === 'saving'}
-          color="secondary"
-          variant="contained"
+          variant="text"
           onClick={() => {
             onCancel()
           }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -1,0 +1,493 @@
+/* https://material-ui.com/components/transfer-list/ */
+import { hot } from 'react-hot-loader'
+import React from 'react'
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
+import Grid from '@material-ui/core/Grid'
+import List from '@material-ui/core/List'
+import Card from '@material-ui/core/Card'
+import CardHeader from '@material-ui/core/CardHeader'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+import Checkbox from '@material-ui/core/Checkbox'
+import Button from '@material-ui/core/Button'
+import Divider from '@material-ui/core/Divider'
+import {
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  useTheme,
+  Typography,
+  LinearProgress,
+  CircularProgress,
+} from '@material-ui/core'
+import { useDialog } from '@connexta/atlas/atoms/dialog'
+import TypedMetacardDefs from './metacardDefinitions'
+import EditIcon from '@material-ui/icons/Edit'
+import { Editor } from './summary'
+import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
+import {
+  DropResult,
+  DragDropContext,
+  Droppable,
+  Draggable,
+} from 'react-beautiful-dnd'
+import extension from '../../../extension-points'
+const user = require('../../singletons/user-instance')
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 'auto',
+    },
+    cardHeader: {
+      padding: theme.spacing(1, 2),
+    },
+    list: {
+      width: 400,
+      height: 500,
+      backgroundColor: theme.palette.background.paper,
+      overflow: 'auto',
+    },
+    button: {
+      margin: theme.spacing(0.5, 0),
+    },
+  })
+)
+
+function not(a: string[], b: string[]) {
+  return a.filter(value => b.indexOf(value) === -1)
+}
+
+function intersection(a: string[], b: string[]) {
+  return a.filter(value => b.indexOf(value) !== -1)
+}
+
+function union(a: string[], b: string[]) {
+  return [...a, ...not(b, a)]
+}
+
+const TransferList = ({
+  startingLeft,
+  startingRight,
+  updateActive,
+  lazyResult,
+  onSave,
+}: {
+  startingLeft: string[]
+  startingRight: string[]
+  updateActive: (arg: any) => void
+  lazyResult: LazyQueryResult
+  onSave: () => void
+}) => {
+  const classes = useStyles()
+  const dialogContext = useDialog()
+  const [mode, setMode] = React.useState('loading' as
+    | 'normal'
+    | 'saving'
+    | 'loading')
+  const [checked, setChecked] = React.useState<string[]>([])
+  const [left, setLeft] = React.useState(startingLeft)
+  const [right, setRight] = React.useState(startingRight)
+  const [
+    customEditableAttributes,
+    setCustomEditableAttributes,
+  ] = React.useState([] as string[])
+
+  React.useEffect(() => {
+    setMode('loading')
+    getCustomAttrs()
+  }, [])
+
+  const getCustomAttrs = async () => {
+    const attrs = await extension.customEditableAttributes()
+    if (attrs !== undefined) {
+      setCustomEditableAttributes(attrs)
+    }
+    setMode('normal')
+  }
+
+  const checkIsReadOnly = (attribute: string) => {
+    const perm = extension.customCanWritePermission({
+      attribute,
+      lazyResult,
+      user,
+      editableAttributes: customEditableAttributes,
+    })
+    if (perm !== undefined) {
+      return !perm
+    }
+    return (
+      (lazyResult.isRemote() &&
+        !(user.canWrite(lazyResult.getBackbone()) as boolean)) ||
+      TypedMetacardDefs.isReadonly({ attr: attribute })
+    )
+  }
+
+  const theme = useTheme()
+
+  const leftChecked = intersection(checked, left)
+  const rightChecked = intersection(checked, right)
+
+  const handleToggle = (value: string) => () => {
+    const currentIndex = checked.indexOf(value)
+    const newChecked = [...checked]
+
+    if (currentIndex === -1) {
+      newChecked.push(value)
+    } else {
+      newChecked.splice(currentIndex, 1)
+    }
+
+    setChecked(newChecked)
+  }
+
+  const numberOfChecked = (items: string[]) =>
+    intersection(checked, items).length
+
+  const handleToggleAll = (items: string[]) => () => {
+    if (numberOfChecked(items) === items.length) {
+      setChecked(not(checked, items))
+    } else {
+      setChecked(union(checked, items))
+    }
+  }
+
+  const handleCheckedRight = () => {
+    setRight(right.concat(leftChecked))
+    setLeft(not(left, leftChecked))
+    setChecked(not(checked, leftChecked))
+  }
+
+  const handleCheckedLeft = () => {
+    setLeft(left.concat(rightChecked))
+    setRight(not(right, rightChecked))
+    setChecked(not(checked, rightChecked))
+  }
+
+  const customList = (
+    title: React.ReactNode,
+    items: string[],
+    lazyResult: LazyQueryResult,
+    updateItems: (arg: string[]) => void,
+    isDnD: boolean // Is drag and drop allowed?
+  ) => {
+    const [filter, setFilter] = React.useState('')
+
+    return (
+      <Card>
+        <CardHeader
+          className={classes.cardHeader}
+          avatar={
+            <Checkbox
+              onClick={handleToggleAll(items)}
+              checked={
+                numberOfChecked(items) === items.length && items.length !== 0
+              }
+              indeterminate={
+                numberOfChecked(items) !== items.length &&
+                numberOfChecked(items) !== 0
+              }
+              disabled={items.length === 0}
+              inputProps={{ 'aria-label': 'all items selected' }}
+            />
+          }
+          title={title}
+          subheader={`${numberOfChecked(items)}/${items.length} selected`}
+        />
+        <Divider />
+        <TextField
+          size="small"
+          variant="outlined"
+          label="Filter by keyword"
+          fullWidth={true}
+          value={filter}
+          inputProps={{
+            style:
+              filter !== ''
+                ? {
+                    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+                  }
+                : {},
+          }}
+          onChange={e => {
+            setFilter(e.target.value)
+          }}
+        />
+        <Divider />
+        {mode === 'loading' ? (
+          <CircularProgress />
+        ) : (
+          <List className={classes.list} dense component="div" role="list">
+            {isDnD && (
+              <Typography variant="caption">
+                Click and drag attributes to reorder.
+              </Typography>
+            )}
+            <DragDropContext
+              onDragEnd={(result: DropResult) => {
+                //Put these NO-OPs up front for performance reasons:
+                //1. If the item is dropped outside the list, do nothing
+                //2. If the item is moved into the same place, do nothing
+                if (!result.destination) {
+                  return
+                }
+                if (result.source.index === result.destination.index) {
+                  return
+                }
+
+                if (result.reason === 'DROP' && result.destination) {
+                  const originalIndex = result.source.index
+                  const destIndex = result.destination.index
+                  const clonedList = items.slice()
+                  clonedList.splice(originalIndex, 1)
+                  clonedList.splice(destIndex, 0, result.draggableId)
+                  updateItems(clonedList)
+                }
+              }}
+            >
+              <Droppable droppableId="test">
+                {provided => {
+                  return (
+                    <div {...provided.droppableProps} ref={provided.innerRef}>
+                      {items.map((value: string, index: number) => {
+                        const labelId = `transfer-list-all-item-${value}-label`
+                        const alias = TypedMetacardDefs.getAlias({
+                          attr: value,
+                        })
+                        const isReadonly = checkIsReadOnly(value)
+                        const isFiltered =
+                          filter !== ''
+                            ? !alias
+                                .toLowerCase()
+                                .includes(filter.toLowerCase())
+                            : false
+
+                        return isFiltered ? null : (
+                          <Draggable
+                            draggableId={value}
+                            index={index}
+                            key={value}
+                            isDragDisabled={!isDnD}
+                          >
+                            {provided => {
+                              return (
+                                //@ts-ignore
+                                <div
+                                  ref={provided.innerRef}
+                                  {...provided.draggableProps}
+                                  {...provided.dragHandleProps}
+                                >
+                                  <ListItem
+                                    key={value}
+                                    role="listitem"
+                                    button
+                                    onClick={handleToggle(value)}
+                                  >
+                                    <ListItemIcon>
+                                      <Checkbox
+                                        checked={checked.indexOf(value) !== -1}
+                                        tabIndex={-1}
+                                        disableRipple
+                                        inputProps={{
+                                          'aria-labelledby': labelId,
+                                        }}
+                                      />
+                                    </ListItemIcon>
+                                    <ListItemText
+                                      id={labelId}
+                                      primary={alias}
+                                    />
+                                    {!isReadonly && (
+                                      <Button
+                                        style={{
+                                          pointerEvents: 'all',
+                                          height: '100%',
+                                        }}
+                                        onClick={() => {
+                                          dialogContext.setProps({
+                                            PaperProps: {
+                                              style: {
+                                                minWidth: 'none',
+                                              },
+                                            },
+                                            open: true,
+                                            children: (
+                                              <div
+                                                style={{
+                                                  padding: '10px',
+                                                  minHeight: '30em',
+                                                  minWidth: '60vh',
+                                                }}
+                                              >
+                                                <Editor
+                                                  attr={value}
+                                                  lazyResult={lazyResult}
+                                                  /* Re-open this modal again but with the current state
+                                              This maintains the state so that if we haven't saved,
+                                              we can come back to where we were working */
+                                                  goBack={() => {
+                                                    dialogContext.setProps({
+                                                      open: true,
+                                                      children: (
+                                                        <TransferList
+                                                          startingLeft={left}
+                                                          startingRight={right}
+                                                          updateActive={
+                                                            updateActive
+                                                          }
+                                                          lazyResult={
+                                                            lazyResult
+                                                          }
+                                                          onSave={onSave}
+                                                        />
+                                                      ),
+                                                    })
+                                                  }}
+                                                  onCancel={() => {
+                                                    dialogContext.setProps({
+                                                      open: true,
+                                                      children: (
+                                                        <TransferList
+                                                          startingLeft={left}
+                                                          startingRight={right}
+                                                          updateActive={
+                                                            updateActive
+                                                          }
+                                                          lazyResult={
+                                                            lazyResult
+                                                          }
+                                                          onSave={onSave}
+                                                        />
+                                                      ),
+                                                    })
+                                                  }}
+                                                  onSave={() => {
+                                                    dialogContext.setProps({
+                                                      open: true,
+                                                      children: (
+                                                        <TransferList
+                                                          startingLeft={left}
+                                                          startingRight={right}
+                                                          updateActive={
+                                                            updateActive
+                                                          }
+                                                          lazyResult={
+                                                            lazyResult
+                                                          }
+                                                          onSave={onSave}
+                                                        />
+                                                      ),
+                                                    })
+                                                  }}
+                                                />
+                                              </div>
+                                            ),
+                                          })
+                                        }}
+                                      >
+                                        <EditIcon />
+                                      </Button>
+                                    )}
+                                  </ListItem>
+                                </div>
+                              )
+                            }}
+                          </Draggable>
+                        )
+                      })}
+                      {provided.placeholder}
+                    </div>
+                  )
+                }}
+              </Droppable>
+            </DragDropContext>
+          </List>
+        )}
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <DialogTitle style={{ textAlign: 'center' }}>
+        Manage Attributes
+      </DialogTitle>
+      <Divider />
+      <DialogContent>
+        <Grid
+          container
+          spacing={2}
+          justify="center"
+          alignItems="center"
+          className={classes.root}
+        >
+          <Grid item>
+            {customList('Active', left, lazyResult, setLeft, true)}
+          </Grid>
+          <Grid item>
+            <Grid container direction="column" alignItems="center">
+              <Button
+                variant="outlined"
+                size="small"
+                className={classes.button}
+                onClick={handleCheckedRight}
+                disabled={leftChecked.length === 0}
+                aria-label="move selected right"
+              >
+                &gt;
+              </Button>
+              <Button
+                variant="outlined"
+                size="small"
+                className={classes.button}
+                onClick={handleCheckedLeft}
+                disabled={rightChecked.length === 0}
+                aria-label="move selected left"
+              >
+                &lt;
+              </Button>
+            </Grid>
+          </Grid>
+          <Grid item>
+            {customList('Hidden', right, lazyResult, setRight, false)}
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <Divider />
+      <DialogActions>
+        <Button
+          disabled={mode === 'saving'}
+          onClick={() => {
+            setMode('saving')
+            updateActive(left)
+            onSave()
+            dialogContext.setProps({
+              open: false,
+              children: null,
+            })
+          }}
+          variant="contained"
+          color="primary"
+        >
+          Save
+        </Button>
+      </DialogActions>
+      {mode === 'saving' ? (
+        <LinearProgress
+          style={{
+            width: '100%',
+            height: '10px',
+            position: 'absolute',
+            left: '0px',
+            bottom: '0%',
+          }}
+          variant="indeterminate"
+        />
+      ) : null}
+    </>
+  )
+}
+
+export default hot(module)(TransferList)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -23,6 +23,20 @@ export type ExtensionPointsType = {
   providers: SFC<ProviderProps>
   metacardInteractions: any[]
   customFilterInput: (props: Props) => React.ReactNode | undefined
+  customCanWritePermission: (
+    {
+      attribute,
+      lazyResult,
+      user,
+      editableAttributes,
+    }: {
+      attribute: string
+      lazyResult: LazyQueryResult
+      user: any
+      editableAttributes: string[]
+    }
+  ) => boolean | undefined
+  customEditableAttributes: () => string[]
   resultItemTitleAddOn: (
     { lazyResult }: { lazyResult: LazyQueryResult }
   ) => JSX.Element | null
@@ -35,6 +49,8 @@ const ExtensionPoints: ExtensionPointsType = {
   providers,
   metacardInteractions,
   customFilterInput: () => undefined,
+  customCanWritePermission: () => undefined,
+  customEditableAttributes: () => [],
   resultItemTitleAddOn: () => null,
   resultItemRowAddOn: () => null,
 }


### PR DESCRIPTION
**Updates:**
-Updates management to transfer list modal
-Cleans up and fixes bugs
-Allows for extensions for great control over read only access
-Updates patch endpoint to optionally take storeIds

**To test:**
Configure some attribute aliases via the admin ui (Using Kanri, search: "alias")
Ingest some data and find it in the search. 
Click Manage Attributes for a record-
- Verify you see the attributes
- Verify you can edit some attributes
- Verify you can move attributes between lists
- Verify you can go back from the edit modal and get back to the list management view
- Verifying that saving updates the summary view as you'd expect

![Screen Shot 2020-08-18 at 10 54 57](https://user-images.githubusercontent.com/9013407/90548100-50074900-e141-11ea-8b1e-98c4c83bcae8.png)
![Screen Shot 2020-08-18 at 10 54 48](https://user-images.githubusercontent.com/9013407/90548108-5269a300-e141-11ea-8e31-f966a6f1e3f4.png)
![Screen Shot 2020-08-18 at 10 54 35](https://user-images.githubusercontent.com/9013407/90548109-5269a300-e141-11ea-89f4-d698cb0307ad.png)
![Screen Shot 2020-08-18 at 10 54 30](https://user-images.githubusercontent.com/9013407/90548111-539ad000-e141-11ea-9dd4-c15b619ba3a9.png)
