### PR TITLE
[3.6.x] DDF-333 Provide an audio player in inspector's summary tab

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -513,6 +513,16 @@ const AttributeComponent = ({
                       ) : null}
                       <div>
                         {(() => {
+                          if (attr === 'ext.audio-snippet') {
+                            const mimetype =
+                              lazyResult.plain.metacard.properties[
+                                'ext.audio-snippet-mimetype'
+                              ]
+                            const src = `data:${mimetype};base64,${val}`
+
+                            return <audio controls src={src} />
+                          }
+
                           switch (TypedMetacardDefs.getType({ attr })) {
                             case 'DATE':
                               return (


### PR DESCRIPTION
#### What does this PR do?
Adds an audio player into the inspector's summary tab. If the attribute `ext.audio-snippet` is not empty then it will display an audio player based on the base64 encoded string that is stored on the metacard. 

#### Who is reviewing it? 
@codice/docs 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@vinamartin 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
This will be tested downstream. 

#### Any background context you want to provide?
None

#### What are the relevant tickets?
For GH Issues:
Fixes: #333

#### Screenshots
<img width="589" alt="Screen Shot 2020-08-19 at 10 52 00 AM" src="https://user-images.githubusercontent.com/7646577/90682285-f9257080-e221-11ea-86c9-618f691822a1.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.