### PR TITLE
Upgrade vulnerable dependencies and remove custom gzip logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,39 @@
     <!--Backend properties-->
     <ddf.version>2.26.0</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
+    <antlr.version>4.3</antlr.version>
+    <c3p0.version>0.9.5.4</c3p0.version>
     <camel.version>2.24.2</camel.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
+    <commons-lang.version>2.6</commons-lang.version>
+    <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <gson.version>2.8.5</gson.version>
+    <guava.version>28.1-jre</guava.version>
+    <httpclient.version>4.5.12</httpclient.version>
+    <httpcore.version>4.4.10</httpcore.version>
     <jackson.version>2.11.0</jackson.version>
+    <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+    <javax.ws.rs.version>2.1</javax.ws.rs.version>
+    <jaxb.version>2.2.11</jaxb.version>
+    <jsr305.version>3.0.2_1</jsr305.version>
+    <jvnet.jaxb2.version>0.11.0</jvnet.jaxb2.version>
+    <jvnet-ogc.version>2.6.1</jvnet-ogc.version>
     <karaf.version>4.2.9</karaf.version>
     <nimbus.version>8.14.1</nimbus.version>
     <nimbus.oidc.version>8.3</nimbus.oidc.version>
+    <org.geotools.version>20.1</org.geotools.version>
+    <org.geotools.bundle.version>${org.geotools.version}_2</org.geotools.bundle.version>
+    <osgi.version>5.0.0</osgi.version>
+    <owasp-html-sanitizer.version>20191001.1</owasp-html-sanitizer.version>
+    <ows-v_1_0_0-schema.version>1.1.0</ows-v_1_0_0-schema.version>
     <pac4j.version>4.0.1</pac4j.version>
-    <opengis.version>20.1</opengis.version>
-    <spark.version>2.5.5</spark.version>
+    <pax.web.jsp.version>7.2.18</pax.web.jsp.version>
+    <quartz.version>2.3.2</quartz.version>
+    <spark.version>2.9.2</spark.version>
+    <spatial4j.version>0.7</spatial4j.version>
     <tika.version>1.24.1</tika.version>
+    <usng4j.version>0.4</usng4j.version>
 
     <!-- Command line argument properties for the maven-surefire-plugin -->
     <codice-test.version>0.3</codice-test.version>
@@ -99,11 +121,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
-      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>

--- a/ui-backend/catalog-ui-enumeration/pom.xml
+++ b/ui-backend/catalog-ui-enumeration/pom.xml
@@ -43,12 +43,12 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <version>${commons-lang.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-            <version>3.0.2_1</version>
+            <version>${jsr305.version}</version>
         </dependency>
     </dependencies>
 

--- a/ui-backend/catalog-ui-oauth/pom.xml
+++ b/ui-backend/catalog-ui-oauth/pom.xml
@@ -75,17 +75,17 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.10</version>
+            <version>${httpcore.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <version>${javax.ws.rs.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
+++ b/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.catalog.ui;
 
-import static spark.Spark.after;
-
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
@@ -130,25 +128,6 @@ public class SparkServlet extends HttpServlet {
             ExceptionMapper.getServletInstance(),
             false,
             false);
-
-    after(
-        (request, response) -> {
-          if (response.raw().containsHeader("Content-Encoding")) {
-            return;
-          }
-
-          String acceptEncoding = request.headers("Accept-Encoding");
-
-          boolean shouldGzip =
-              StringUtils.isNotBlank(acceptEncoding)
-                  && acceptEncoding.toLowerCase().contains("gzip");
-
-          if (!shouldGzip) {
-            return;
-          }
-
-          response.header("Content-Encoding", "gzip");
-        });
   }
 
   @Override

--- a/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
+++ b/ui-backend/catalog-ui-oauth/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spark.ExceptionMapper;
 import spark.globalstate.ServletFlag;
 import spark.http.matching.MatcherFilter;
 import spark.route.ServletRoutes;
@@ -124,7 +125,11 @@ public class SparkServlet extends HttpServlet {
     filterPath = getConfigPath(filterMappingPattern, config);
     matcherFilter =
         new MatcherFilter(
-            ServletRoutes.get(), StaticFilesConfiguration.servletInstance, false, false);
+            ServletRoutes.get(),
+            StaticFilesConfiguration.servletInstance,
+            ExceptionMapper.getServletInstance(),
+            false,
+            false);
 
     after(
         (request, response) -> {

--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -27,32 +27,32 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.2.11</version>
+            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.2.11</version>
+            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.2.11</version>
+            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.ogc</groupId>
             <artifactId>filter-v_2_0</artifactId>
-            <version>2.6.1</version>
+            <version>${jvnet-ogc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.ogc</groupId>
             <artifactId>ows-v_1_1_0-schema</artifactId>
-            <version>1.1.0</version>
+            <version>${ows-v_1_0_0-schema.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
-            <version>0.11.0</version>
+            <version>${jvnet.jaxb2.version}</version>
         </dependency>
 
         <dependency>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <version>${javax.ws.rs.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.lib</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>5.0.0</version>
+            <version>${osgi.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>${javax.servlet-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.httpproxy</groupId>
@@ -123,12 +123,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
+            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
@@ -138,12 +138,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.10</version>
+            <version>${httpcore.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>
@@ -153,17 +153,17 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-            <version>3.0.2_1</version>
+            <version>${jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-opengis</artifactId>
-            <version>20.1</version>
+            <version>${org.geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-cql</artifactId>
-            <version>20.1</version>
+            <version>${org.geotools.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jai_core</artifactId>
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.codice.thirdparty</groupId>
             <artifactId>geotools-suite</artifactId>
-            <version>20.1_2</version>
+            <version>${org.geotools.bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.transformer</groupId>
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>org.locationtech.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
-            <version>0.7</version>
+            <version>${spatial4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -209,17 +209,17 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.2.3</version>
+            <version>${quartz.version}</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz-jobs</artifactId>
-            <version>2.2.3</version>
+            <version>${quartz.version}</version>
         </dependency>
         <dependency>
-            <groupId>c3p0</groupId>
+            <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
-            <version>0.9.1.1</version>
+            <version>${c3p0.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.persistence.core</groupId>
@@ -255,12 +255,12 @@
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
-            <version>2.0.0</version>
+            <version>${jknack.handlebars.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.3</version>
+            <version>${antlr.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.abego.treelayout</groupId>
@@ -342,7 +342,7 @@
         <dependency>
             <groupId>org.codice.usng4j</groupId>
             <artifactId>usng4j-impl</artifactId>
-            <version>0.4</version>
+            <version>${usng4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -364,7 +364,7 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20171016.1</version>
+            <version>${owasp-html-sanitizer.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.rest</groupId>
@@ -374,7 +374,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.ddf.search</groupId>
@@ -390,7 +390,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.4.1</version>
+            <version>${commons-math3.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.security.servlet</groupId>

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.catalog.ui;
 
-import static spark.Spark.after;
-
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
@@ -126,25 +124,6 @@ public class SparkServlet extends HttpServlet {
             ExceptionMapper.getServletInstance(),
             false,
             false);
-
-    after(
-        (request, response) -> {
-          if (response.raw().containsHeader("Content-Encoding")) {
-            return;
-          }
-
-          String acceptEncoding = request.headers("Accept-Encoding");
-
-          boolean shouldGzip =
-              StringUtils.isNotBlank(acceptEncoding)
-                  && acceptEncoding.toLowerCase().contains("gzip");
-
-          if (!shouldGzip) {
-            return;
-          }
-
-          response.header("Content-Encoding", "gzip");
-        });
   }
 
   @Override

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spark.ExceptionMapper;
 import spark.globalstate.ServletFlag;
 import spark.http.matching.MatcherFilter;
 import spark.route.ServletRoutes;
@@ -120,7 +121,11 @@ public class SparkServlet extends HttpServlet {
     filterPath = getConfigPath(filterMappingPattern, config);
     matcherFilter =
         new MatcherFilter(
-            ServletRoutes.get(), StaticFilesConfiguration.servletInstance, false, false);
+            ServletRoutes.get(),
+            StaticFilesConfiguration.servletInstance,
+            ExceptionMapper.getServletInstance(),
+            false,
+            false);
 
     after(
         (request, response) -> {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/FeedbackApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/FeedbackApplication.java
@@ -15,7 +15,6 @@ package org.codice.ddf.catalog.ui.query;
 
 import static spark.Spark.exception;
 import static spark.Spark.post;
-import static spark.route.RouteOverview.enableRouteOverview;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
@@ -118,8 +117,6 @@ public class FeedbackApplication implements SparkApplication {
           response.body("Error submitting feedback");
           LOGGER.debug("Feedback submission failed", e);
         });
-
-    enableRouteOverview();
   }
 
   public void setConfigurationApplication(ConfigurationApplication configurationApplication) {

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.query.handlers;
 
-import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -77,8 +76,6 @@ public class CqlTransformHandlerTest {
           .registerTypeAdapterFactory(LongDoubleTypeAdapter.FACTORY)
           .create();
 
-  private static final String GZIP = "gzip";
-  private static final String NO_GZIP = "";
   private static final String QUERY_PARAM = ":transformerId";
   private static final String RETURN_ID = "kml";
   private static final String OTHER_RETURN_ID = "xml";
@@ -189,9 +186,7 @@ public class CqlTransformHandlerTest {
   }
 
   @Test
-  public void testServiceFoundWithValidResponseAndGzip() throws Exception {
-    when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(GZIP);
-
+  public void testServiceFoundWithValidResponse() throws Exception {
     when(mockRequest.params(QUERY_PARAM)).thenReturn(RETURN_ID);
 
     String res = GSON.toJson(cqlTransformHandler.handle(mockRequest, mockResponse));
@@ -201,24 +196,6 @@ public class CqlTransformHandlerTest {
     assertThat(
         mockResponse.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION),
         matchesPattern(ATTACHMENT_REGEX));
-    assertThat(mockResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING), is(GZIP));
-    assertThat(mockResponse.type(), is(MIME_TYPE));
-  }
-
-  @Test
-  public void testServiceFoundWithValidResponseNoGzip() throws Exception {
-    when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(NO_GZIP);
-
-    when(mockRequest.params(QUERY_PARAM)).thenReturn(RETURN_ID);
-
-    String res = GSON.toJson(cqlTransformHandler.handle(mockRequest, mockResponse));
-
-    assertThat(res, is(SERVICE_SUCCESS));
-    assertThat(mockResponse.status(), is(HttpStatus.OK_200));
-    assertThat(
-        mockResponse.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION),
-        matchesPattern(ATTACHMENT_REGEX));
-    assertNull(mockResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING));
     assertThat(mockResponse.type(), is(MIME_TYPE));
   }
 }

--- a/ui-backend/intrigue-ui-app/pom.xml
+++ b/ui-backend/intrigue-ui-app/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-jsp</artifactId>
-            <version>7.2.11</version>
+            <version>${pax.web.jsp.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Description
This is the counterpart to this DDF PR: https://github.com/codice/ddf/pull/6257

This PR upgrades a similar set of vulnerable dependencies to match the versions used by DDF. It also moves a bunch of versions to the parent pom so they're all located in a single place.

Also, the DDF PR enabled gzip compression for all responses via the Jetty GzipHandler. There are a few places where Intrigue was gzipping responses itself. This PR removes that logic as gzipping will now happen automatically

### Reviewers
@blen-desta @bakejeyner @emmberk @garrettfreibott @stustison 

### Teams
@codice/security 
@codice/ui

### Testing
1. Download and install [DDF 2.26.0](https://github.com/codice/ddf/releases/download/ddf-2.26.0/ddf-2.26.0.zip)
2. Build and install PR changes:
```
feature:repo-add mvn:org.codice.ddf.search/intrigue-ui-app/3.6.3-SNAPSHOT/xml/features
feature:install catalog-ui-app
feature:repo-add mvn:org.codice.ddf.search/ui-frontend/3.6.3-SNAPSHOT/xml/features
feature:install ui-frontend
```
3. Verify
* Gzip compression is applied to Intrigue responses. Check the Content-Encoding in the response headers in your browser devtools. Some things, like images, non-2XX responses, etc, won't be gzipped, but most plain-text responses will be. See https://www.eclipse.org/jetty/documentation/current/gzip-filter.html#gzip-filter-rules
* The spark servlets still work:
  * /search/catalog/internal/*: Quick test of Intrigue functionality should be sufficient
  * /search/catalog/internal/oauth/*: This is a little more involved. You'll need to connect to an OAuth provider, enable OIDC authentication for Intrigue, create a loopback source using OAuth authentication, create a search in Intrigue that queries that loopback source. You should see a popup requesting that you need to provide authorization. The link in that popup is what will hit this endpoint.