### PR TITLE
[3.6.x] Retype highlights to allow for multiple highlights per attribute

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
@@ -601,7 +601,8 @@ export const ResultItem = ({
                       {lazyResult.highlights[detail.label] ? (
                         <span
                           dangerouslySetInnerHTML={{
-                            __html: lazyResult.highlights[detail.label][0].highlight
+                            __html:
+                              lazyResult.highlights[detail.label][0].highlight,
                           }}
                         />
                       ) : (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
@@ -550,7 +550,7 @@ export const ResultItem = ({
                 {lazyResult.highlights['title'] ? (
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: lazyResult.highlights['title'].highlight,
+                      __html: lazyResult.highlights['title'][0].highlight,
                     }}
                   />
                 ) : (
@@ -597,11 +597,11 @@ export const ResultItem = ({
                     })}: ${detail.value}`}
                   >
                     <span>
+                      {/* It's okay to use the first one here since we only ever want to display one, normally you'd want to map over this list */}
                       {lazyResult.highlights[detail.label] ? (
                         <span
                           dangerouslySetInnerHTML={{
-                            __html:
-                              lazyResult.highlights[detail.label].highlight,
+                            __html: lazyResult.highlights[detail.label][0].highlight
                           }}
                         />
                       ) : (
@@ -621,7 +621,7 @@ export const ResultItem = ({
                 )
                 .map(extraHighlight => {
                   const relevantHighlight =
-                    lazyResult.highlights[extraHighlight]
+                    lazyResult.highlights[extraHighlight][0]
                   return (
                     <PropertyComponent
                       key={relevantHighlight.attribute}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import Typography from '@material-ui/core/Typography'
+import { AttributeHighlight } from '../../../js/model/LazyQueryResult/LazyQueryResults'
+
+const comparator = (a: AttributeHighlight, b: AttributeHighlight) => {
+  const aIndex = parseInt(a.startIndex)
+  const bIndex = parseInt(b.startIndex)
+  if (aIndex < bIndex) {
+    return -1
+  } else if (aIndex === bIndex) {
+    return 0
+  } else if (aIndex > bIndex) {
+    return 1
+  }
+  return 0
+}
+
+export const displayHighlightedAttrInFull = (
+  highlights: Array<AttributeHighlight>,
+  text: String
+) => {
+  //sort these in the order in which they appear
+  highlights.sort(comparator)
+  let textArray = []
+  let currentIndex = 0
+  highlights.forEach((highlight, index) => {
+    const highlightStart = parseInt(highlight.startIndex)
+    const highlightEnd = parseInt(highlight.endIndex)
+    const beforeText = (
+      <span
+        dangerouslySetInnerHTML={{
+          __html: text.substring(currentIndex, highlightStart),
+        }}
+      />
+    )
+    const highlightText = (
+      <span className="highlight" data-id={index}>
+        {text.substring(highlightStart, highlightEnd)}
+      </span>
+    )
+    currentIndex = highlightEnd
+    textArray.push(beforeText)
+    textArray.push(highlightText)
+  })
+  const afterText = (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: text.substring(currentIndex),
+      }}
+    />
+  )
+  textArray.push(afterText)
+  return <Typography>{textArray}</Typography>
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -567,7 +567,6 @@ const AttributeComponent = ({
                                     <Typography>
                                       <span
                                         dangerouslySetInnerHTML={{
-                                          //@ts-ignore Ignore possible undefined as we null check above
                                           __html: lazyResult.highlights[attr][0].highlight
                                         }}
                                       />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -34,6 +34,7 @@ import AddIcon from '@material-ui/icons/Add'
 import Box from '@material-ui/core/Box'
 import { Elevations, dark, light } from '../../theme/theme'
 import { DarkDivider } from '../../dark-divider/dark-divider'
+import { displayHighlightedAttrInFull } from './highlightUtil'
 //metacardDefinitions.metacardTypes[attribute].type
 //metacardDefinitions.metacardTypes[attribute].multivalued
 //properties.isReadOnly(attribute)
@@ -557,7 +558,29 @@ const AttributeComponent = ({
                                 </Typography>
                               )
                             default:
-                              return <Typography>{val}</Typography>
+                              if (
+                                lazyResult.highlights[attr]
+                              ) {
+                                if (attr === 'title') {
+                                  //Special case, title highlights don't get truncated
+                                  return (
+                                    <Typography>
+                                      <span
+                                        dangerouslySetInnerHTML={{
+                                          //@ts-ignore Ignore possible undefined as we null check above
+                                          __html: lazyResult.highlights[attr][0].highlight
+                                        }}
+                                      />
+                                    </Typography>
+                                  )
+                                }
+                                return displayHighlightedAttrInFull(
+                                  lazyResult.highlights[attr],
+                                  val
+                                )
+                              } else {
+                                return <Typography>{val}</Typography>
+                              }
                           }
                         })()}
                       </div>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -558,16 +558,16 @@ const AttributeComponent = ({
                                 </Typography>
                               )
                             default:
-                              if (
-                                lazyResult.highlights[attr]
-                              ) {
+                              if (lazyResult.highlights[attr]) {
                                 if (attr === 'title') {
                                   //Special case, title highlights don't get truncated
                                   return (
                                     <Typography>
                                       <span
                                         dangerouslySetInnerHTML={{
-                                          __html: lazyResult.highlights[attr][0].highlight
+                                          __html:
+                                            lazyResult.highlights[attr][0]
+                                              .highlight,
                                         }}
                                       />
                                     </Typography>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -83,7 +83,6 @@ const GlobalStyles = createGlobalStyle<ThemeInterface>`
       }
       span.highlight {
         font-weight: bolder;
-        border-bottom: 1px solid;
       }
       .MuiToolbar-root a,
       .MuiToolbar-root .MuiBreadcrumbs-separator {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -337,7 +337,6 @@ export class LazyQueryResults {
       },
       {} as TransformedHighlightsType
     )
-
     results.forEach(result => {
       const lazyResult = new LazyQueryResult(
         result,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -35,7 +35,7 @@ export type AttributeHighlight = {
 }
 
 export type AttributeHighlights = {
-  [key: string]: AttributeHighlight
+  [key: string]: Array<AttributeHighlight>
 }
 
 export type ResponseHighlightType = Array<{
@@ -328,15 +328,16 @@ export class LazyQueryResults {
       (blob, highlight) => {
         blob[highlight.id] = highlight.highlights.reduce(
           (innerblob, subhighlight) => {
-            innerblob[subhighlight.attribute] = subhighlight
+            innerblob[subhighlight.attribute] = highlight.highlights.filter(hl => hl.attribute === subhighlight.attribute)
             return innerblob
           },
-          {} as { [key: string]: AttributeHighlight }
+          {} as { [key: string]: Array<AttributeHighlight> }
         )
         return blob
       },
       {} as TransformedHighlightsType
     )
+
     results.forEach(result => {
       const lazyResult = new LazyQueryResult(
         result,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -328,7 +328,9 @@ export class LazyQueryResults {
       (blob, highlight) => {
         blob[highlight.id] = highlight.highlights.reduce(
           (innerblob, subhighlight) => {
-            innerblob[subhighlight.attribute] = highlight.highlights.filter(hl => hl.attribute === subhighlight.attribute)
+            innerblob[subhighlight.attribute] = highlight.highlights.filter(
+              hl => hl.attribute === subhighlight.attribute
+            )
             return innerblob
           },
           {} as { [key: string]: Array<AttributeHighlight> }


### PR DESCRIPTION
- Updates highlights types
- Updates summary/details view to show highlights

@lifenouveau Does this styling still check out?

![Screen Shot 2020-09-01 at 15 28 37](https://user-images.githubusercontent.com/9013407/91912471-0dc52800-ec68-11ea-8ba6-3d0f1198c313.png)
