### PR TITLE
[3.6.x] Pass in layoutResult and editLayoutRef for use by extension

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
@@ -51,6 +51,8 @@ export const GoldenLayout = ({ selectionInterface }: Props) => {
             selectionInterface={selectionInterface}
             model={selectionInterface.getCurrentQuery()}
             goldenLayoutViewInstance={goldenlayoutInstance}
+            layoutResult={goldenlayoutInstance.options.layoutResult}
+            editLayoutRef={goldenlayoutInstance.options.editLayoutRef}
           />
         </Paper>
       </Grid>


### PR DESCRIPTION
Layout Extension uses layoutResult and editLayoutRef but it wasn't passed in by golden layout.
@stevenmalmgren @jordanwilking @andrewkfiedler 