### PR TITLE
[3.6.x] DDF-UI-359 Eliminate/ignore existing ts errors

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/exports/multi-select-actions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/exports/multi-select-actions.tsx
@@ -13,5 +13,5 @@
  *
  **/
 export {
-  MultiSelectAction,
+  MultiSelectAction, // @ts-expect-error ts-migrate(2307) FIXME: Cannot find module '../src/main/webapp/react-compo... Remove this comment to see the full error message
 } from '../src/main/webapp/react-component/multi-select-actions/presentation'

--- a/ui-frontend/packages/catalog-ui-search/exports/sharing.tsx
+++ b/ui-frontend/packages/catalog-ui-search/exports/sharing.tsx
@@ -15,5 +15,5 @@
 export {
   Sharing,
   Item,
-  Category,
+  Category, // @ts-expect-error ts-migrate(2307) FIXME: Cannot find module '../src/main/webapp/react-compo... Remove this comment to see the full error message
 } from '../src/main/webapp/react-component/sharing'

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -14,7 +14,8 @@
     "test": "ace test",
     "start:test": "ace start --env=test",
     "storybook": "ace storybook",
-    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
+    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle",
+    "build:transpile": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
     "postbuild": "ace package",
     "m2": "yarn install:m2",
     "install:m2": "ace clean && ace bundle --tsTranspileOnly true && ace package && ace install"

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -27,9 +27,9 @@
     "node": ">=0.10.5"
   },
   "peerDependencies": {
-    "@connexta/atlas": ">=0.0.60",
     "@blueprintjs/core": ">3.0.0",
     "@blueprintjs/datetime": ">3.0.0",
+    "@connexta/atlas": ">=0.0.60",
     "@material-ui/core": ">=4.8.3",
     "@material-ui/icons": ">=4.4.3",
     "@material-ui/lab": ">=4.0.0-alpha.39",
@@ -44,7 +44,6 @@
     "tailwindcss": ">=1.4.0"
   },
   "devDependencies": {
-    "@welldone-software/why-did-you-render": "4.2.2",
     "@blueprintjs/core": "3.29.0",
     "@blueprintjs/datetime": "3.18.3",
     "@connexta/ace": "git://github.com/connexta/ace.git#7c2dee5cb3013a4c1b95c9b92acd44e38301b611",
@@ -62,6 +61,7 @@
     "@types/react-virtualized-auto-sizer": "1.0.0",
     "@types/react-window": "^1.8.1",
     "@types/styled-components": "4.0.3",
+    "@welldone-software/why-did-you-render": "4.2.2",
     "chai": "4.1.1",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.5.0",
@@ -78,6 +78,9 @@
     "react-router-dom": "5.2.0",
     "sinon": "5.0.7",
     "styled-components": "4.3.2",
+    "ts-migrate": "^0.1.2",
+    "ts-migrate-plugins": "^0.1.0",
+    "ts-migrate-server": "^0.1.0",
     "utility-types": "3.10.0"
   },
   "dependencies": {
@@ -135,12 +138,12 @@
     "react-redux": "5.0.7",
     "react-spring": "8.0.27",
     "react-text-mask": "5.4.1",
-    "redux": "3.5.2",
-    "redux-thunk": "2.1.0",
     "react-use": "15.1.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "git://github.com/andrewkfiedler/react-window#8a68a2508c79044be33f6f743261b069d7fd9cc1",
     "react-window-components": "0.0.2",
+    "redux": "3.5.2",
+    "redux-thunk": "2.1.0",
     "rpc-websockets": "4.0.0",
     "sanitize-html": "1.15.0",
     "scroll-into-view-if-needed": "^2.2.25",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
@@ -21,6 +21,7 @@ import ExpandingButton from '../button/expanding-button'
 import Divider from '@material-ui/core/Divider'
 import IconButton from '@material-ui/core/IconButton'
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
+// @ts-expect-error ts-migrate(6133) FIXME: 'ListItem' is declared but its value is never read... Remove this comment to see the full error message
 import ListItem from '@material-ui/core/ListItem'
 import MenuIcon from '@material-ui/icons/Menu'
 import SettingsIcon from '@material-ui/icons/Settings'
@@ -346,6 +347,7 @@ const App = ({
                       return (
                         <ExpandingButton
                           key={routeInfo.linkProps.to.toString()}
+                          // @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'string | nu... Remove this comment to see the full error message
                           component={Link}
                           to={routeInfo.linkProps.to}
                           className={`group-hover:opacity-100 ${
@@ -387,6 +389,7 @@ const App = ({
                   >
                     {/** The song and dance around 'a' vs Link has to do with react router not supporting these outside links */}
                     <ExpandingButton
+                      // @ts-expect-error ts-migrate(2322) FIXME: Type 'ForwardRefExoticComponent<LinkProps<UnknownF... Remove this comment to see the full error message
                       component={properties.helpUrl ? 'a' : Link}
                       href={properties.helpUrl}
                       to={
@@ -414,6 +417,7 @@ const App = ({
                       return (
                         <>
                           <ExpandingButton
+                            // @ts-expect-error ts-migrate(2322) FIXME: Type 'ForwardRefExoticComponent<LinkProps<UnknownF... Remove this comment to see the full error message
                             component={Link}
                             to={{
                               pathname: `${location.pathname}`,
@@ -465,6 +469,7 @@ const App = ({
                             }
                           >
                             <ExpandingButton
+                              // @ts-expect-error ts-migrate(2322) FIXME: Type 'ForwardRefExoticComponent<LinkProps<UnknownF... Remove this comment to see the full error message
                               component={Link}
                               to={{
                                 pathname: `${location.pathname}`,
@@ -511,6 +516,7 @@ const App = ({
                       return (
                         <>
                           <ExpandingButton
+                            // @ts-expect-error ts-migrate(2322) FIXME: Type 'ForwardRefExoticComponent<LinkProps<UnknownF... Remove this comment to see the full error message
                             component={Link}
                             to={{
                               pathname: `${location.pathname}`,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -14,7 +14,8 @@
  **/
 import * as React from 'react'
 import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
-//@ts-ignore
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
 import user from '../singletons/user-instance'
 
 export const getTimeZone = () => {
@@ -31,6 +32,7 @@ export const getDateFormat = () => {
     .get('dateTimeFormat')['datetimefmt'] as string
 }
 
+// @ts-ignore Can't find type declarations, but they exist
 import moment from 'moment-timezone'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-branch.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-branch.tsx
@@ -44,6 +44,7 @@ const ChildFilter = ({
   setFilter,
   index,
   isFirst,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'isLast' is declared but its value is never read.
   isLast,
 }: ChildFilterProps) => {
   return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.tsx
@@ -14,7 +14,8 @@
  **/
 import * as React from 'react'
 const cql = require('../../js/cql.js')
-// @ts-ignore
+
+// @ts-expect-error ts-migrate(6192) FIXME: All imports in import declaration are unused.
 import { serialize, deserialize } from './filter-serialization'
 import FilterBranch from './filter-branch'
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -12,11 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+// @ts-ignore Can't find type declarations, but they exist
 import moment from 'moment-timezone'
 import { ValuesType } from 'utility-types'
+// @ts-expect-error ts-migrate(6133) FIXME: 'locationSerialize' is declared but its value is n... Remove this comment to see the full error message
 import { serialize as locationSerialize } from '../location-old/location-serialization'
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../.... Remove this comment to see the full error message
 import CQLUtils from '../../js/CQLUtils'
 
+// @ts-expect-error ts-migrate(6133) FIXME: 'comparatorToCQL' is declared but its value is nev... Remove this comment to see the full error message
 const comparatorToCQL = {
   BEFORE: 'BEFORE',
   AFTER: 'AFTER',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
@@ -12,6 +12,7 @@ type Props = {
 }
 
 export const GoldenLayout = ({ selectionInterface }: Props) => {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'setGoldenlayoutInstance' is declared but its valu... Remove this comment to see the full error message
   const [goldenlayoutInstance, setGoldenlayoutInstance] = React.useState(
     new GoldenLayoutView({
       selectionInterface,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -19,6 +19,7 @@ const _merge = require('lodash/merge')
 const _debounce = require('lodash/debounce')
 const $ = require('jquery')
 const wreqr = require('../../js/wreqr.js')
+// @ts-expect-error ts-migrate(6133) FIXME: 'template' is declared but its value is never read... Remove this comment to see the full error message
 const template = require('./golden-layout.hbs')
 const Marionette = require('marionette')
 const CustomElements = require('../../js/CustomElements.js')
@@ -35,25 +36,32 @@ import CloseIcon from '@material-ui/icons/Close'
 import { providers as Providers } from '../../extension-points/providers'
 import { Visualizations } from '../visualization/visualizations'
 
-const treeMap = (obj, fn, path = []) => {
+// @ts-expect-error ts-migrate(7024) FIXME: Function implicitly has return type 'any' because ... Remove this comment to see the full error message
+const treeMap = (obj: any, fn: any, path = []) => {
   if (Array.isArray(obj)) {
+    // @ts-expect-error ts-migrate(2769) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
     return obj.map((v, i) => treeMap(v, fn, path.concat(i)))
   }
 
   if (obj !== null && typeof obj === 'object') {
-    return Object.keys(obj)
-      .map(k => [k, treeMap(obj[k], fn, path.concat(k))])
-      .reduce((o, [k, v]) => {
-        o[k] = v
-        return o
-      }, {})
+    return (
+      Object.keys(obj)
+        // @ts-expect-error ts-migrate(2769) FIXME: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
+        .map(k => [k, treeMap(obj[k], fn, path.concat(k))])
+        .reduce((o, [k, v]) => {
+          // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+          o[k] = v
+          return o
+        }, {})
+    )
   }
 
   return fn(obj, path)
 }
 
-const sanitizeTree = tree =>
-  treeMap(tree, obj => {
+// @ts-expect-error ts-migrate(6133) FIXME: 'sanitizeTree' is declared but its value is never ... Remove this comment to see the full error message
+const sanitizeTree = (tree: any) =>
+  treeMap(tree, (obj: any) => {
     if (typeof obj === 'string') {
       return sanitize(obj, {
         allowedTags: [],
@@ -102,16 +110,16 @@ function getGoldenLayoutSettings() {
 // see https://github.com/deepstreamIO/golden-layout/issues/239 for details on why the setTimeout is necessary
 // The short answer is it mostly has to do with making sure these ComponentViews are able to function normally (set up events, etc.)
 function registerComponent(
-  marionetteView,
-  name,
-  ComponentView,
-  componentOptions,
-  viz
+  marionetteView: any,
+  name: any,
+  ComponentView: any,
+  componentOptions: any,
+  viz: any
 ) {
   const options = _.extend({}, marionetteView.options, componentOptions)
   marionetteView.goldenLayout.registerComponent(
     name,
-    (container, componentState) => {
+    (container: any, componentState: any) => {
       container.on('open', () => {
         setTimeout(() => {
           const componentView = new ComponentView(
@@ -133,8 +141,8 @@ function registerComponent(
           container.parent.parent.element.removeClass('is-minimized')
         }
       })
-      container.on('tab', tab => {
-        tab.closeElement.off('click').on('click', event => {
+      container.on('tab', (tab: any) => {
+        tab.closeElement.off('click').on('click', (event: any) => {
           if (
             tab.header.parent.isMaximised &&
             tab.header.parent.contentItems.length === 1
@@ -203,7 +211,7 @@ function registerComponent(
   )
 }
 
-function isMaximised(contentItem) {
+function isMaximised(contentItem: any) {
   if (contentItem.isMaximised) {
     return true
   } else if (contentItem.contentItems.length === 0) {
@@ -213,7 +221,7 @@ function isMaximised(contentItem) {
   }
 }
 
-function removeActiveTabInformation(config) {
+function removeActiveTabInformation(config: any) {
   if (config.activeItemIndex !== undefined) {
     config.activeItemIndex = 0
   }
@@ -224,11 +232,11 @@ function removeActiveTabInformation(config) {
   }
 }
 
-function removeMaximisedInformation(config) {
+function removeMaximisedInformation(config: any) {
   delete config.maximisedItemId
 }
 
-function removeEphemeralState(config) {
+function removeEphemeralState(config: any) {
   removeMaximisedInformation(config)
   removeActiveTabInformation(config)
   return config
@@ -363,11 +371,12 @@ export default Marionette.LayoutView.extend({
     this.detectIfGoldenLayoutMaximised()
     this.detectIfGoldenLayoutEmpty()
   },
-  handleGoldenLayoutStackCreated(stack) {
+  handleGoldenLayoutStackCreated(stack: any) {
     stack.header.controlsContainer
       .find('.lm_close')
       .off('click')
-      .on('click', event => {
+      // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
+      .on('click', (event: any) => {
         if (stack.isMaximised) {
           stack.toggleMaximise()
         }
@@ -383,6 +392,7 @@ export default Marionette.LayoutView.extend({
               <Grid item>
                 <Button
                   data-id="maximise-tab-button"
+                  // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
                   onClick={e => {
                     const prevWidth = stack.config.prevWidth || 500
                     const prevHeight = stack.config.prevHeight || 500
@@ -398,6 +408,7 @@ export default Marionette.LayoutView.extend({
               <Grid item>
                 <Button
                   data-id="minimise-layout-button"
+                  // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
                   onClick={e => {
                     stack.config.prevWidth = stack.getActiveContentItem().container.width
                     stack.config.prevHeight = stack.getActiveContentItem().container.height
@@ -410,6 +421,7 @@ export default Marionette.LayoutView.extend({
               <Grid item>
                 <Button
                   data-id="maximise-layout-button"
+                  // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
                   onClick={e => {
                     stack.toggleMaximise()
                   }}
@@ -421,6 +433,7 @@ export default Marionette.LayoutView.extend({
                 {stack.header._isClosable() ? (
                   <Button
                     data-id="close-layout-button"
+                    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
                     onClick={e => {
                       if (stack.isMaximised) {
                         stack.toggleMaximise()
@@ -440,7 +453,8 @@ export default Marionette.LayoutView.extend({
       } catch (err) {}
     }, 100)
   },
-  handleGoldenLayoutStateChange(event) {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
+  handleGoldenLayoutStateChange(event: any) {
     if (this.isDestroyed) {
       return
     }
@@ -514,7 +528,8 @@ export default Marionette.LayoutView.extend({
     $(window).on(
       'resize.' + this.cid,
       _debounce(
-        event => {
+        // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
+        (event: any) => {
           this.updateSize()
         },
         100,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.view.tsx
@@ -136,27 +136,30 @@ module.exports = InputView.extend({
       this.enumRegion.currentView.model,
       'change:value',
       function() {
-        // @ts-ignore
+        // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
         const value = this.enumRegion.currentView.model.get('value')[0]
         switch (value) {
           case 'bulkDefault':
-            // @ts-ignore
+            // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
             this.model.revert()
             break
           case 'bulkCustom':
-            // @ts-ignore
+            // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
             this.model.setValue(this.otherInput.currentView.model.getValue())
-            // @ts-ignore
+
+            // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
             this.model.set('hasChanged', true)
             break
           default:
-            // @ts-ignore
+            // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
             this.model.setValue(value)
-            // @ts-ignore
+
+            // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
             this.model.set('hasChanged', true)
             break
         }
-        // @ts-ignore
+
+        // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
         this.handleChange()
       }
     )
@@ -164,14 +167,16 @@ module.exports = InputView.extend({
       this.otherInput.currentView.model,
       'change:value',
       function() {
-        // @ts-ignore
+        // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
         this.model.setValue(this.otherInput.currentView.model.getValue())
-        // @ts-ignore
+
+        // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
         if (!this.model.isHomogeneous()) {
-          // @ts-ignore
+          // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
           this.model.set('hasChanged', true)
         }
-        // @ts-ignore
+
+        // @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
         this.handleChange()
       }
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/home.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/home.tsx
@@ -23,6 +23,7 @@ import Divider from '@material-ui/core/Divider'
 import { Elevations } from '../theme/theme'
 import SearchIcon from '@material-ui/icons/SearchTwoTone'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
+// @ts-expect-error ts-migrate(6133) FIXME: 'useParams' is declared but its value is never rea... Remove this comment to see the full error message
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 
 const LeftTop = ({ selectionInterface }: { selectionInterface: any }) => {
@@ -216,6 +217,7 @@ export const HomePage = () => {
       urlBasedQuery = ''
     }
   }
+  // @ts-expect-error ts-migrate(6133) FIXME: 'setQueryModel' is declared but its value is never... Remove this comment to see the full error message
   const [queryModel, setQueryModel] = React.useState(
     urlBasedQuery || new Query.Model()
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/metacard-nav.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/metacard-nav.tsx
@@ -5,6 +5,7 @@ import { useLazyResultsFromSelectionInterface } from '../selection-interface/hoo
 import { useStatusOfLazyResults } from '../../js/model/LazyQueryResult/hooks'
 import CircularProgress from '@material-ui/core/CircularProgress'
 const Query = require('../../js/model/Query.js')
+// @ts-expect-error ts-migrate(6133) FIXME: 'cql' is declared but its value is never read.
 const cql = require('../../js/cql')
 const SelectionInterfaceModel = require('../selection-interface/selection-interface.model.js')
 const Backbone = require('backbone')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/metacard.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/metacard.tsx
@@ -102,6 +102,7 @@ const MetacardRoute = () => {
   )
 
   React.useEffect(
+    // @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
     () => {
       if (id) {
         query.set('filterTree', getFilterTreeForId({ id }))

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.tsx
@@ -15,8 +15,11 @@
 
 import * as React from 'react'
 const Marionette = require('marionette')
+// @ts-expect-error ts-migrate(6133) FIXME: 'Query' is declared but its value is never read.
 const Query = require('../../js/model/Query.js')
+// @ts-expect-error ts-migrate(6133) FIXME: 'user' is declared but its value is never read.
 const user = require('../singletons/user-instance.js')
+// @ts-expect-error ts-migrate(6133) FIXME: 'Grid' is declared but its value is never read.
 import Grid from '@material-ui/core/Grid'
 import QueryBasic from '../../component/query-basic/query-basic.view'
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
@@ -96,7 +96,7 @@ function getAllValidValuesForMatchTypeAttribute() {
 function getPredefinedMatchTypes() {
   const matchTypesMap = sources
     .toJSON()
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'flatMap' does not exist on type '{ avail... Remove this comment to see the full error message
     .flatMap((source: any) => source.contentTypes)
     .reduce((enumMap: any, contentType: any) => {
       if (contentType.value && !enumMap[contentType.value]) {
@@ -383,6 +383,7 @@ export default Marionette.LayoutView.extend({
     const currentValue = this.getCurrentSpecificTypesValue()
     getMatchTypes()
       .then(enums => this.showBasicTypeSpecific(enums, [currentValue]))
+      // @ts-expect-error ts-migrate(6133) FIXME: 'error' is declared but its value is never read.
       .catch(error => this.showBasicTypeSpecific())
   },
   showBasicTypeSpecific(enums = [], currentValue = [[]]) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/source-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/source-selector.tsx
@@ -13,6 +13,7 @@ import WarningIcon from '@material-ui/icons/Warning'
 import Box from '@material-ui/core/Box'
 import CheckIcon from '@material-ui/icons/Check'
 import Chip from '@material-ui/core/Chip'
+// @ts-expect-error ts-migrate(6133) FIXME: 'Divider' is declared but its value is never read.
 import Divider from '@material-ui/core/Divider'
 import _ from 'lodash'
 type Props = {
@@ -88,7 +89,9 @@ const shouldBeSelected = ({
  * If it includes 'remote', that that means everything remote.  All other values are singular selections of a source.
  */
 const SourceSelector = ({ search }: Props) => {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'inputRef' is declared but its value is never read... Remove this comment to see the full error message
   const inputRef = React.useRef()
+  // @ts-expect-error ts-migrate(6133) FIXME: 'federation' is declared but its value is never re... Remove this comment to see the full error message
   const [federation, setFederation] = React.useState(search.get(
     'federation'
   ) as 'enterprise' | 'selected' | 'local')
@@ -100,6 +103,7 @@ const SourceSelector = ({ search }: Props) => {
   const defaultSources = search.get('sources') as string[]
   const validDefaultSources =
     defaultSources && defaultSources.filter(src => sourceIds.includes(src))
+  // @ts-expect-error ts-migrate(6133) FIXME: 'hasValidDefaultSources' is declared but its value... Remove this comment to see the full error message
   const hasValidDefaultSources =
     validDefaultSources && validDefaultSources.length
   const { listenTo } = useBackbone()
@@ -142,12 +146,14 @@ const SourceSelector = ({ search }: Props) => {
                   .sort((a, b) => {
                     return a.toLowerCase().localeCompare(b.toLowerCase()) // case insensitive sort
                   })
+                  // @ts-expect-error ts-migrate(6133) FIXME: 'b' is declared but its value is never read.
                   .sort((a, b) => {
                     if (a === 'local' || a === 'remote') {
                       return -1 // move these subcategories upwards to front
                     }
                     return 0
                   })
+                  // @ts-expect-error ts-migrate(6133) FIXME: 'index' is declared but its value is never read.
                   .map((src, index) => {
                     return (
                       <Grid item key={src} className="mr-2">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/resizable-grid/resizable-grid.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/resizable-grid/resizable-grid.tsx
@@ -122,6 +122,7 @@ type SplitPaneProps = {
 }
 
 export const SplitPane = ({
+  // @ts-expect-error ts-migrate(6133) FIXME: 'firstStyle' is declared but its value is never re... Remove this comment to see the full error message
   firstStyle,
   secondStyle,
   variant,
@@ -215,6 +216,7 @@ export const SplitPane = ({
           style={{
             flexShrink: 0,
           }}
+          // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
           onResizeStop={e => {
             setDragging(false)
           }}
@@ -225,11 +227,13 @@ export const SplitPane = ({
             switch (variant) {
               case 'horizontal':
                 setLength(
+                  // @ts-expect-error ts-migrate(2339) FIXME: Property 'clientX' does not exist on type 'TouchEv... Remove this comment to see the full error message
                   e.clientX - e.target.parentElement.getBoundingClientRect().x
                 )
                 break
               case 'vertical':
                 setLength(
+                  // @ts-expect-error ts-migrate(2339) FIXME: Property 'clientY' does not exist on type 'TouchEv... Remove this comment to see the full error message
                   e.clientY - e.target.parentElement.getBoundingClientRect().y
                 )
                 break

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -4,6 +4,7 @@ import { Dropdown } from '@connexta/atlas/atoms/dropdown'
 import Paper from '@material-ui/core/Paper'
 import { BetterClickAwayListener } from '../better-click-away-listener/better-click-away-listener'
 const moment = require('moment')
+// @ts-expect-error ts-migrate(6133) FIXME: 'user' is declared but its value is never read.
 const user = require('../singletons/user-instance')
 
 import styled from 'styled-components'
@@ -86,7 +87,7 @@ const QueryStatusRow = ({ status, query }: { status: Status; query: any }) => {
   let successful = status.successful
   let message = status.message
 
-  //@ts-ignore
+  // @ts-expect-error ts-migrate(2339) FIXME: Property 'warnings' does not exist on type 'Status... Remove this comment to see the full error message
   let warnings = status.warnings
   let id = status.id
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
@@ -10,6 +10,7 @@ import Paper from '@material-ui/core/Paper'
 import { BetterClickAwayListener } from '../better-click-away-listener/better-click-away-listener'
 import Button from '@material-ui/core/Button'
 import FilterListIcon from '@material-ui/icons/FilterList'
+// @ts-expect-error ts-migrate(6133) FIXME: 'SortIcon' is declared but its value is never read... Remove this comment to see the full error message
 import SortIcon from '@material-ui/icons/Sort'
 import ResultFilter from '../result-filter/result-filter'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
@@ -19,7 +20,8 @@ import {
   useLazyResultsSelectedResultsFromSelectionInterface,
 } from '../selection-interface/hooks'
 import Box from '@material-ui/core/Box'
-//@ts-ignore
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../.... Remove this comment to see the full error message
 import VisualizationSelector from '../../react-component/visualization-selector/visualization-selector'
 import ViewCompactIcon from '@material-ui/icons/ViewCompact'
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
@@ -14,10 +14,12 @@
  **/
 import Button from '@material-ui/core/Button'
 import Grid from '@material-ui/core/Grid'
+// @ts-expect-error ts-migrate(6133) FIXME: 'useTheme' is declared but its value is never read... Remove this comment to see the full error message
 import useTheme from '@material-ui/core/styles/useTheme'
 import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import { CellComponent } from './table-header'
+// @ts-expect-error ts-migrate(6133) FIXME: 'styled' is declared but its value is never read.
 import styled from 'styled-components'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
 import { useSelectionOfLazyResult } from '../../js/model/LazyQueryResult/hooks'
@@ -29,6 +31,7 @@ import TypedMetacardDefs from '../tabs/metacard/metacardDefinitions'
 import Box from '@material-ui/core/Box'
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@material-ui/icons/CheckBox'
+// @ts-expect-error ts-migrate(6133) FIXME: 'CheckIcon' is declared but its value is never rea... Remove this comment to see the full error message
 import CheckIcon from '@material-ui/icons/Check'
 import Divider from '@material-ui/core/Divider'
 type Property = {
@@ -50,22 +53,22 @@ type ResultItemFullProps = ResultItemBasicProps & {
 
 export function clearSelection() {
   if (window.getSelection) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     window.getSelection().removeAllRanges()
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'selection' does not exist on type 'Docum... Remove this comment to see the full error message
   } else if (document.selection) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'selection' does not exist on type 'Docum... Remove this comment to see the full error message
     document.selection.empty()
   }
 }
 
 export function hasSelection(): boolean {
   if (window.getSelection) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     return window.getSelection().toString() !== ''
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'selection' does not exist on type 'Docum... Remove this comment to see the full error message
   } else if (document.selection) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'selection' does not exist on type 'Docum... Remove this comment to see the full error message
     return document.selection.toString() !== ''
   } else {
     return false
@@ -76,6 +79,7 @@ const RowComponent = ({
   lazyResult,
   visibleHeaders,
   measure,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'index' is declared but its value is never read.
   index,
 }: ResultItemFullProps) => {
   const isSelected = useSelectionOfLazyResult({ lazyResult })
@@ -220,6 +224,7 @@ const RowComponent = ({
                   width: visibleProperties.length * 200 + 'px',
                 }}
               >
+                {/* @ts-expect-error ts-migrate(6133) FIXME: 'index' is declared but its value is never read. */}
                 {visibleProperties.map((property, index) => {
                   const alias = TypedMetacardDefs.getAlias({
                     attr: property.property,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.collection.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.collection.tsx
@@ -20,10 +20,13 @@ import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
+// @ts-expect-error ts-migrate(6133) FIXME: 'LazyQueryResults' is declared but its value is ne... Remove this comment to see the full error message
 import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResults'
+// @ts-expect-error ts-migrate(6133) FIXME: 'Divider' is declared but its value is never read.
 import Divider from '@material-ui/core/Divider'
 import Box from '@material-ui/core/Box'
 import Paper from '@material-ui/core/Paper'
+// @ts-expect-error ts-migrate(6133) FIXME: 'dark' is declared but its value is never read.
 import { Elevations, dark, light } from '../theme/theme'
 import { useLazyResultsFromSelectionInterface } from '../selection-interface/hooks'
 import { useStatusOfLazyResults } from '../../js/model/LazyQueryResult/hooks'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
@@ -28,8 +28,10 @@ import GetAppIcon from '@material-ui/icons/GetApp'
 import Grid from '@material-ui/core/Grid'
 const Common = require('../../js/Common.js')
 import { hot } from 'react-hot-loader'
+// @ts-expect-error ts-migrate(6133) FIXME: 'useTheme' is declared but its value is never read... Remove this comment to see the full error message
 import useTheme from '@material-ui/core/styles/useTheme'
 import Paper from '@material-ui/core/Paper'
+// @ts-expect-error ts-migrate(6133) FIXME: 'Divider' is declared but its value is never read.
 import Divider from '@material-ui/core/Divider'
 import Box from '@material-ui/core/Box'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -46,6 +48,7 @@ import { useSelectionOfLazyResult } from '../../js/model/LazyQueryResult/hooks'
 import Extensions from '../../extension-points'
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
 import CheckIcon from '@material-ui/icons/Check'
+// @ts-expect-error ts-migrate(6133) FIXME: 'DoneOutlineIcon' is declared but its value is nev... Remove this comment to see the full error message
 import DoneOutlineIcon from '@material-ui/icons/DoneOutline'
 import CheckBoxIcon from '@material-ui/icons/CheckBox'
 import { Elevations } from '../theme/theme'
@@ -180,6 +183,7 @@ const getIconClassName = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
   return ''
 }
 
+// @ts-expect-error ts-migrate(6133) FIXME: 'MultiSelectActions' is declared but its value is ... Remove this comment to see the full error message
 const MultiSelectActions = ({
   selectionInterface,
 }: {
@@ -249,8 +253,11 @@ const fakeEvent = {
 export const ResultItem = ({
   lazyResult,
   measure,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'index' is declared but its value is never read.
   index,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'selectionInterface' is declared but its value is ... Remove this comment to see the full error message
   selectionInterface,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'lazyResults' is declared but its value is never r... Remove this comment to see the full error message
   lazyResults,
 }: ResultItemFullProps) => {
   // console.log(`rendered: ${index}`)
@@ -417,7 +424,7 @@ export const ResultItem = ({
     <Button
       data-id="result-item-container-button"
       component="div" // we have to use a div since there are buttons inside this (invalid to nest buttons)
-      onMouseDown={event => {
+      onMouseDown={(event: any) => {
         /**
          * Shift key can cause selections since we set the class to allow text selection,
          * so the only scenario we want to prevent that in is when shift clicking
@@ -434,7 +441,7 @@ export const ResultItem = ({
           }
         }, 0)
       }}
-      onClick={event => {
+      onClick={(event: any) => {
         if (hasSelection()) {
           return
         }
@@ -456,18 +463,18 @@ export const ResultItem = ({
       }}
       onMouseLeave={() => {
         try {
-          //@ts-ignore
+          // @ts-expect-error ts-migrate(2339) FIXME: Property 'blur' does not exist on type 'Element'.
           if (document.activeElement) document.activeElement.blur()
         } catch (err) {
           console.log(err)
         }
       }}
-      onFocus={e => {
+      onFocus={(e: any) => {
         if (e.target === e.currentTarget && rippleRef.current) {
           rippleRef.current.pulsate()
         }
       }}
-      onBlur={e => {
+      onBlur={(e: any) => {
         if (rippleRef.current) {
           rippleRef.current.stop(e)
         }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/results-visual.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/results-visual.tsx
@@ -3,8 +3,11 @@ import { hot } from 'react-hot-loader'
 import ResultItemCollection from './result-item.collection'
 import Grid from '@material-ui/core/Grid'
 import TableVisual from './table'
+// @ts-expect-error ts-migrate(6133) FIXME: 'CircularProgress' is declared but its value is ne... Remove this comment to see the full error message
 import CircularProgress from '@material-ui/core/CircularProgress'
+// @ts-expect-error ts-migrate(6133) FIXME: 'useLazyResultsFromSelectionInterface' is declared... Remove this comment to see the full error message
 import { useLazyResultsFromSelectionInterface } from '../selection-interface/hooks'
+// @ts-expect-error ts-migrate(6133) FIXME: 'useStatusOfLazyResults' is declared but its value... Remove this comment to see the full error message
 import { useStatusOfLazyResults } from '../../js/model/LazyQueryResult/hooks'
 
 type Props = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/table-header.tsx
@@ -17,6 +17,7 @@ import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResults'
 const _ = require('underscore')
+// @ts-expect-error ts-migrate(6133) FIXME: '$' is declared but its value is never read.
 const $ = require('jquery')
 const user = require('../singletons/user-instance.js')
 require('jquery-ui/ui/widgets/resizable')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/table.tsx
@@ -303,6 +303,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                 outerElementProps={{
                   onScroll: e => {
                     if (headerRef.current) {
+                      // @ts-expect-error ts-migrate(2339) FIXME: Property 'scrollLeft' does not exist on type 'Even... Remove this comment to see the full error message
                       headerRef.current.scrollLeft = e.target.scrollLeft
                     }
                   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/hooks.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/hooks.tsx
@@ -55,7 +55,8 @@ export const useLazyResultsFromSelectionInterface = ({
   selectionInterface,
 }: useLazyResultsProps) => {
   const { listenToOnce, stopListening } = useBackbone()
-  //@ts-ignore
+
+  // @ts-expect-error ts-migrate(6133) FIXME: 'forceRender' is declared but its value is never r... Remove this comment to see the full error message
   const [forceRender, setForceRender] = React.useState(Math.random())
   const [lazyResults, setLazyResults] = React.useState(
     getLazyResultsFromSelectionInterface({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/snack/snack.provider.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/snack/snack.provider.tsx
@@ -63,6 +63,7 @@ export function SnackProvider({ children }: any) {
     [currentSnack]
   )
 
+  // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
   const handleClose = (e: any, reason: string) => {
     if (reason === 'clickaway' && currentSnack.clickawayCloseable) {
       removeCurrentSnack()
@@ -123,6 +124,7 @@ export function SnackProvider({ children }: any) {
                     </Button>
                   )}
                   {closeable && (
+                    // @ts-expect-error ts-migrate(2769) FIXME: Type '(e: any, reason: string) => void' is not ass... Remove this comment to see the full error message
                     <IconButton
                       style={{ padding: '3px' }}
                       color="inherit"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.tsx
@@ -82,7 +82,7 @@ const SystemUsageModal = () => {
                   properties.ui.systemUsageOncePerSession
                 ) {
                   const systemUsage = JSON.parse(
-                    //@ts-ignore
+                    // @ts-expect-error ts-migrate(2345) FIXME: Type 'null' is not assignable to type 'string'.
                     window.sessionStorage.getItem('systemUsage')
                   )
                   systemUsage[user.get('user').get('username')] = 'true'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -48,10 +48,13 @@ type Source = {
 }
 
 export function getStartIndex(
+  // @ts-expect-error ts-migrate(6133) FIXME: 'src' is declared but its value is never read.
   src: any,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'exportSize' is declared but its value is never re... Remove this comment to see the full error message
   exportSize: any,
   selectionInterface: any
 ) {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'result' is declared but its value is never read.
   const result = selectionInterface.getCurrentQuery().get('result')
   return 1
   //todo fix this

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -22,6 +22,7 @@ import LinearProgress from '@material-ui/core/LinearProgress'
 const $ = require('jquery')
 const ResultUtils = require('../../../js/ResultUtils.js')
 import PublishIcon from '@material-ui/icons/Publish'
+// @ts-expect-error ts-migrate(6133) FIXME: 'AutoSizer' is declared but its value is never rea... Remove this comment to see the full error message
 import AutoSizer from 'react-virtualized-auto-sizer'
 import Paper from '@material-ui/core/Paper'
 import useTheme from '@material-ui/core/styles/useTheme'
@@ -32,6 +33,7 @@ import TransferList from './transfer-list'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
 import AddIcon from '@material-ui/icons/Add'
 import Box from '@material-ui/core/Box'
+// @ts-expect-error ts-migrate(6133) FIXME: 'dark' is declared but its value is never read.
 import { Elevations, dark, light } from '../../theme/theme'
 import { DarkDivider } from '../../dark-divider/dark-divider'
 //metacardDefinitions.metacardTypes[attribute].type
@@ -147,7 +149,7 @@ const ThumbnailInput = ({
             const reader = new FileReader()
             reader.onload = function(event) {
               try {
-                //@ts-ignore
+                // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
                 onChange(event.target.result)
               } catch (err) {
                 console.log('something wrong with file type')
@@ -156,7 +158,8 @@ const ThumbnailInput = ({
             reader.onerror = () => {
               console.log('error')
             }
-            //@ts-ignore
+
+            // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
             reader.readAsDataURL(e.target.files[0])
           }}
         />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -2,24 +2,30 @@
 import { hot } from 'react-hot-loader'
 import React from 'react'
 import makeStyles from '@material-ui/core/styles/makeStyles'
+// @ts-expect-error ts-migrate(2307) FIXME: Cannot find module '@material-ui/core/styles/Theme... Remove this comment to see the full error message
 import Theme from '@material-ui/core/styles/Theme'
 import createStyles from '@material-ui/core/styles/createStyles'
 import Grid from '@material-ui/core/Grid'
 import List from '@material-ui/core/List'
+// @ts-expect-error ts-migrate(6133) FIXME: 'Card' is declared but its value is never read.
 import Card from '@material-ui/core/Card'
+// @ts-expect-error ts-migrate(6133) FIXME: 'CardHeader' is declared but its value is never re... Remove this comment to see the full error message
 import CardHeader from '@material-ui/core/CardHeader'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import Checkbox from '@material-ui/core/Checkbox'
 import Button from '@material-ui/core/Button'
+// @ts-expect-error ts-migrate(6133) FIXME: 'Divider' is declared but its value is never read.
 import Divider from '@material-ui/core/Divider'
 import {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'DialogTitle' is declared but its value is never r... Remove this comment to see the full error message
   DialogTitle,
   DialogContent,
   DialogActions,
   TextField,
   useTheme,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'Typography' is declared but its value is never re... Remove this comment to see the full error message
   Typography,
   LinearProgress,
   CircularProgress,
@@ -38,6 +44,7 @@ import {
   Draggable,
 } from 'react-beautiful-dnd'
 import extension from '../../../extension-points'
+// @ts-expect-error ts-migrate(6133) FIXME: 'dark' is declared but its value is never read.
 import { dark, light, Elevations } from '../../theme/theme'
 import { DarkDivider } from '../../dark-divider/dark-divider'
 import LeftArrowIcon from '@material-ui/icons/ChevronLeft'
@@ -125,6 +132,7 @@ const CustomList = ({
     numberChecked === items.length && items.length !== 0
   return (
     <Paper
+      // @ts-expect-error ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
       data-id={`${title.toLowerCase()}-container`}
       elevation={Elevations.paper}
     >
@@ -137,6 +145,7 @@ const CustomList = ({
       >
         <Grid item className="absolute left-0 top-0 ml-2 mt-min">
           <Button
+            // @ts-expect-error ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
             data-id={`${title.toLowerCase()}-select-all-checkbox`}
             disabled={items.length === 0}
             onClick={handleToggleAll(items)}
@@ -247,7 +256,7 @@ const CustomList = ({
                         >
                           {provided => {
                             return (
-                              //@ts-ignore
+                              // @ts-ignore ts-migrate(2322) FIXME: Type 'DragEvent<HTMLDivElement>' is missing the fo... Remove this comment to see the full error message
                               <div
                                 ref={provided.innerRef}
                                 {...provided.draggableProps}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -3,6 +3,7 @@ import {
   createMuiTheme,
   MuiThemeProvider as ThemeProvider,
   darken,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'getContrastRatio' is declared but its value is ne... Remove this comment to see the full error message
   getContrastRatio,
   Theme as ThemeInterface,
   createStyles,
@@ -13,9 +14,12 @@ import {
 import { ThemeContext } from 'styled-components'
 import { createGlobalStyle } from 'styled-components'
 import {
+  // @ts-expect-error ts-migrate(6133) FIXME: 'polishedLighten' is declared but its value is nev... Remove this comment to see the full error message
   lighten as polishedLighten,
   meetsContrastGuidelines,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'mix' is declared but its value is never read.
   mix,
+  // @ts-expect-error ts-migrate(6133) FIXME: 'rgba' is declared but its value is never read.
   rgba,
 } from 'polished'
 
@@ -296,7 +300,10 @@ export const Provider = ({ children }: { children: any }) => {
     : darkMode
       ? dark.secondary
       : light.secondary
-  const primaryContrastScores = meetsContrastGuidelines(paperColor, primaryMain)
+  const primaryContrastScores = meetsContrastGuidelines(
+    paperColor,
+    primaryMain!
+  )
   const secondaryContrastScores = meetsContrastGuidelines(
     paperColor,
     secondaryMain

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
@@ -107,6 +107,7 @@ function findMatchesForAttributeValues(
   })
 }
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 function checkIfValueIsValid(values: any[], attribute: string, value: any) {
   if (value !== undefined) {
     switch (metacardDefinitions.metacardTypes[attribute].type) {
@@ -388,7 +389,8 @@ export const Histogram = ({ selectionInterface }: Props) => {
       $(histogramElement)
         .find('rect.drag')
         .off('mousedown')
-      //@ts-ignore
+
+      // @ts-expect-error ts-migrate(2339) FIXME: Property '_context' does not exist on type 'HTMLDi... Remove this comment to see the full error message
       if (histogramElement._context) {
         Plotly.Plots.resize(histogramElement)
       }
@@ -411,7 +413,8 @@ export const Histogram = ({ selectionInterface }: Props) => {
         results.length !== 0
       ) {
         const theme = getTheme(e.get('spacingMode'))
-        //@ts-ignore
+
+        // @ts-expect-error ts-migrate(2339) FIXME: Property 'layout' does not exist on type 'HTMLDivE... Remove this comment to see the full error message
         histogramElement.layout.margin = theme.margin
       }
     }
@@ -426,7 +429,7 @@ export const Histogram = ({ selectionInterface }: Props) => {
         attributeToBin &&
         results.length !== 0
       ) {
-        //@ts-ignore
+        // @ts-expect-error ts-migrate(2339) FIXME: Property 'layout' does not exist on type 'HTMLDivE... Remove this comment to see the full error message
         histogramElement.layout.font.size = e.get('fontSize')
       }
     }
@@ -525,11 +528,13 @@ export const Histogram = ({ selectionInterface }: Props) => {
     })
   }
 
+  // @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
   const retrieveCategoriesFromPlotlyForDates = () => {
     if (plotlyRef.current) {
       const histogramElement = plotlyRef.current
       const categories = []
-      //@ts-ignore
+
+      // @ts-expect-error ts-migrate(2339) FIXME: Property '_fullData' does not exist on type 'HTMLD... Remove this comment to see the full error message
       const xbins = histogramElement._fullData[0].xbins
       const min = xbins.start
       const max = xbins.end
@@ -565,7 +570,8 @@ export const Histogram = ({ selectionInterface }: Props) => {
   const retrieveCategoriesFromPlotly = () => {
     if (plotlyRef.current) {
       const histogramElement = plotlyRef.current
-      //@ts-ignore
+
+      // @ts-expect-error ts-migrate(2339) FIXME: Property '_fullLayout' does not exist on type 'HTM... Remove this comment to see the full error message
       const xaxis = histogramElement._fullLayout.xaxis
       switch (xaxis.type) {
         case 'category':
@@ -573,7 +579,7 @@ export const Histogram = ({ selectionInterface }: Props) => {
         case 'date':
           return retrieveCategoriesFromPlotlyForDates()
         default:
-          //@ts-ignore
+          // @ts-expect-error ts-migrate(2339) FIXME: Property '_fullData' does not exist on type 'HTMLD... Remove this comment to see the full error message
           const xbins = histogramElement._fullData[0].xbins
           const min = xbins.start
           const max = xbins.end
@@ -659,7 +665,8 @@ export const Histogram = ({ selectionInterface }: Props) => {
   const listenToHistogram = () => {
     if (plotlyRef.current) {
       const histogramElement = plotlyRef.current
-      //@ts-ignore
+
+      // @ts-expect-error ts-migrate(2339) FIXME: Property '_ev' does not exist on type 'HTMLDivElem... Remove this comment to see the full error message
       histogramElement._ev.addListener('plotly_click', plotlyClickHandler)
     }
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
@@ -144,7 +144,7 @@ const TimelineVisualization = (props: Props) => {
   React.useEffect(() => {
     props.listenTo(wreqr.vent, 'resize', () => {
       if (rootRef.current) {
-        //@ts-ignore
+        // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
         const rect = rootRef.current.getBoundingClientRect()
         setHeight(rect.height)
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -46,6 +46,7 @@ export type ExtensionPointsType = {
       editLayoutRef?: any
     }
   ) => JSX.Element | null
+  navigationRight: any[]
 }
 
 const ExtensionPoints: ExtensionPointsType = {
@@ -57,6 +58,7 @@ const ExtensionPoints: ExtensionPointsType = {
   resultItemTitleAddOn: () => null,
   resultItemRowAddOn: () => null,
   layoutDropdown: () => null,
+  navigationRight: [],
 }
 
 export default ExtensionPoints

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/metacard-interactions/metacard-interactions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/metacard-interactions/metacard-interactions.tsx
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+// @ts-expect-error ts-migrate(6133) FIXME: 'CreateLocationSearch' is declared but its value i... Remove this comment to see the full error message
 import CreateLocationSearch from '../../react-component/metacard-interactions/location-interaction'
 import ExpandMetacard from '../../react-component/metacard-interactions/expand-interaction'
 import DownloadProduct from '../../react-component/metacard-interactions/download-interaction'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.tsx
@@ -13,6 +13,7 @@
  *
  **/
 
+// @ts-expect-error ts-migrate(6133) FIXME: '$' is declared but its value is never read.
 const $ = require('jquery')
 import BaseApp from '../component/app/base-app'
 import * as React from 'react'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -97,15 +97,16 @@ export class LazyQueryResult {
     callback: () => void
   }) {
     const id = Math.random().toString()
-    // @ts-ignore
+
+    // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
     this[`subscriptionsToMe.${subscribableThing}`][id] = callback
     return () => {
-      // @ts-ignore
+      // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
       delete this[`subscriptionsToMe.${subscribableThing}`][id]
     }
   }
   _notifySubscribers(subscribableThing: SubscribableType) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
     const subscribers = this[
       `subscriptionsToMe.${subscribableThing}`
     ] as SubscriptionType

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -15,6 +15,7 @@
 import { ResultType } from '../Types'
 import { generateCompareFunction } from './sort'
 import { LazyQueryResult } from './LazyQueryResult'
+// @ts-expect-error ts-migrate(6133) FIXME: 'FilterType' is declared but its value is never re... Remove this comment to see the full error message
 import { QuerySortType, FilterType } from './types'
 import { Status } from './status'
 const _ = require('underscore')
@@ -76,15 +77,16 @@ export class LazyQueryResults {
     callback: () => void
   }) {
     const id = Math.random().toString()
-    // @ts-ignore
+
+    // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
     this[`subscriptionsToMe.${subscribableThing}`][id] = callback
     return () => {
-      // @ts-ignore
+      // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
       delete this[`subscriptionsToMe.${subscribableThing}`][id]
     }
   }
   _notifySubscribers(subscribableThing: SubscribableType) {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
     const subscribers = this[
       `subscriptionsToMe.${subscribableThing}`
     ] as SubscriptionType

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/sort.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/sort.tsx
@@ -89,7 +89,8 @@ export const generateCompareFunction = (sorting: QuerySortType[]) => {
           break
         case 'DISTANCE':
           // this says distance could be null, could be a bug we need to address
-          //@ts-ignore
+
+          // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
           sortValue = sortOrder * (a.plain.distance - b.plain.distance)
           break
         default:

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
@@ -45,7 +45,7 @@ export class Status {
     >
   ) {
     Object.keys(update).forEach(key => {
-      // @ts-ignore
+      // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
       this[key] = update[key]
     })
     this.hasReturned = true

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/workers/worker.base.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/workers/worker.base.tsx
@@ -30,7 +30,7 @@ export class BaseWorker {
   }
   onmessage(oEvent: any) {
     if (oEvent.data instanceof Object && oEvent.data.hasOwnProperty('method')) {
-      //@ts-ignore
+      // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       this[oEvent.data.method](oEvent.data)
     } else {
       this.defaultReply(oEvent.data)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/workers/worker.less.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/workers/worker.less.tsx
@@ -19,6 +19,7 @@ import { BaseWorker } from './worker.base'
     onReady: false,
   }
   global.window.document = {
+    // @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
     getElementsByTagName: function(tagName: any) {
       if (tagName === 'script') {
         return [

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/about/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/about/container.tsx
@@ -18,7 +18,7 @@ const properties = require('../../js/properties.js')
 const moment = require('moment')
 
 class AboutContainer extends React.Component {
-  constructor(props: {}) {
+  constructor(props: any) {
     super(props)
   }
   render() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/backbone-container/backbone-container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/backbone-container/backbone-container.tsx
@@ -41,7 +41,7 @@ const withListenTo = <P extends WithBackboneProps>(
     }
     render() {
       return (
-        // @ts-ignore
+        // @ts-expect-error ts-migrate(2322) FIXME: '{ listenTo: any; stopListening: any; listenToOnce... Remove this comment to see the full error message
         <Component
           listenTo={this.backbone.listenTo.bind(this.backbone)}
           stopListening={this.backbone.stopListening.bind(this.backbone)}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/button-behavior/button-behavior.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/button-behavior/button-behavior.tsx
@@ -66,11 +66,10 @@ const handleKeyUp = (event: any) => {
   }
 }
 
-// @ts-ignore
+// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'RefObject<H... Remove this comment to see the full error message
 const render: React.ComponentType<
   Props & Subtract<React.HTMLAttributes<HTMLDivElement>, Props>
 > = React.forwardRef(
-  // @ts-ignore
   (
     props: Props & Subtract<React.HTMLAttributes<HTMLDivElement>, Props>,
     ref?: React.Ref<HTMLDivElement>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/button/split-button/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/button/split-button/index.tsx
@@ -16,7 +16,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { hot } from 'react-hot-loader'
 
-type Props = {
+type OwnProps = {
   children: {
     label: any
     menu: any
@@ -68,6 +68,8 @@ const Icon = styled.button`
   margin: 0;
   margin-left: 0 !important;
 `
+
+type Props = OwnProps & typeof SplitButton.defaultProps
 
 class SplitButton extends React.Component<Props, State> {
   public static defaultProps = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/distance-info/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/distance-info/index.tsx
@@ -12,4 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { default } from './distance-info.tsx'
+export { default } from './distance-info'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.tsx
@@ -15,6 +15,7 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { getFilteredAttributeList } from './filterHelper'
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../i... Remove this comment to see the full error message
 import EnumInput from '../inputs/enum-input'
 const metacardDefinitions = require('../../component/singletons/metacard-definitions')
 
@@ -29,12 +30,13 @@ const FilterAttributeDropdown = ({
   includedAttributes,
   editing,
   value,
-}) => {
+}: any) => {
   return (
     <Root>
       {editing ? (
         <EnumInput
           value={value}
+          // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
           suggestions={getFilteredAttributeList(includedAttributes)}
           onChange={onChange}
         />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -100,6 +100,7 @@ const FilterInput = ({ filter, setFilter }: Props) => {
     case 'DATE':
       return <DateField onChange={onChange} value={value as string} />
     case 'LOCATION':
+      // @ts-expect-error ts-migrate(2769) FIXME: Property 'value' does not exist on type 'Intrinsic... Remove this comment to see the full error message
       return <LocationInput value={value} onChange={onChange} />
     case 'FLOAT':
       return (
@@ -118,10 +119,11 @@ const FilterInput = ({ filter, setFilter }: Props) => {
   if (enumForAttr) {
     return (
       <Autocomplete
+        // @ts-ignore fullWidth does exist on Autocomplete
         fullWidth
         size="small"
         options={enumForAttr}
-        onChange={(_e, newValue) => {
+        onChange={(_e: any, newValue: string) => {
           onChange(newValue)
         }}
         disableClearable

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.tsx
@@ -21,6 +21,8 @@ const CQLUtils = require('../../../js/CQLUtils.js')
 const wreqr = require('../../../js/wreqr.js')
 const wkx = require('wkx')
 import { Drawing } from '../../../component/singletons/drawing'
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../.... Remove this comment to see the full error message
 import { deserialize } from '../../../component/location-old/location-serialization'
 
 const typesToDisplays = {
@@ -31,7 +33,7 @@ const typesToDisplays = {
   LINE: 'linedisplay',
 }
 
-const filterToLocationOldModel = filter => {
+const filterToLocationOldModel = (filter: any) => {
   if (typeof filter.geojson === 'object') {
     return deserialize(filter.geojson)
   }
@@ -53,11 +55,15 @@ const filterToLocationOldModel = filter => {
   }
 }
 
+type State = any
+
 // may need to move some of this logic for deserliazing
-class LocationInput extends React.Component {
+class LocationInput extends React.Component<{}, State> {
+  // @ts-expect-error ts-migrate(7008) FIXME: Implicit any
   locationModel
-  constructor(props) {
+  constructor(props: {}) {
     super(props)
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type '{}'.
     this.locationModel = new LocationOldModel(props.value)
     this.state = this.locationModel.toJSON()
     // this.deserialize()
@@ -71,12 +77,15 @@ class LocationInput extends React.Component {
     this.locationModel.on('change', this.setModelState, this)
   }
   componentDidMount() {
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'listenTo' does not exist on type 'Readon... Remove this comment to see the full error message
     this.props.listenTo(
       this.locationModel,
       'change:mapNorth change:mapSouth change:mapEast change:mapWest',
       this.locationModel.setLatLon
     )
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'listenTo' does not exist on type 'Readon... Remove this comment to see the full error message
     this.props.listenTo(this.locationModel, 'change', this.updateMap)
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'listenTo' does not exist on type 'Readon... Remove this comment to see the full error message
     this.props.listenTo(this.locationModel, 'change:mode', () => {
       this.clearLocation()
     })
@@ -93,6 +102,7 @@ class LocationInput extends React.Component {
     }
   }
   deserialize = () => {
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'Readonly<... Remove this comment to see the full error message
     const filter = this.props.value
     if (!filter) {
       return
@@ -121,7 +131,10 @@ class LocationInput extends React.Component {
       // these cases are for when the model matches the location model
       default:
         wreqr.vent.trigger(
-          `search:${typesToDisplays[filter.type]}`,
+          `search:${
+            // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            typesToDisplays[filter.type]
+          }`,
           this.locationModel
         )
         break
@@ -167,11 +180,13 @@ class LocationInput extends React.Component {
   }
   onChange = () => {
     const value = this.getCurrentValue()
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'onChange' does not exist on type 'Readon... Remove this comment to see the full error message
     this.props.onChange(value)
   }
   render() {
     const options = {
-      onDraw: drawingType => {
+      // @ts-expect-error ts-migrate(6133) FIXME: 'drawingType' is declared but its value is never r... Remove this comment to see the full error message
+      onDraw: (drawingType: any) => {
         wreqr.vent.trigger(
           'search:draw' + this.locationModel.get('mode'),
           this.locationModel
@@ -182,10 +197,12 @@ class LocationInput extends React.Component {
       <LocationView
         state={this.state}
         options={options}
+        // @ts-expect-error ts-migrate(7019) FIXME: Rest parameter 'args' implicitly has an 'any[]' ty... Remove this comment to see the full error message
         setState={(...args) => this.locationModel.set(...args)}
       />
     )
   }
 }
 
+// @ts-expect-error ts-migrate(2345) FIXME: Type 'Readonly<{}> & Readonly<{ children?: ReactNo... Remove this comment to see the full error message
 export default withListenTo(LocationInput)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
@@ -41,11 +41,13 @@ const Filter = ({ filter, setFilter }: Props) => {
       <Grid item className="w-full pb-2">
         <Autocomplete
           data-id="filter-type-autocomplete"
+          // @ts-ignore fullWidth does exist on Autocomplete
           fullWidth
           size="small"
           options={attributeList}
           getOptionLabel={option => option.label}
           getOptionSelected={(option, value) => option.value === value.value}
+          // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
           onChange={(e, newValue) => {
             const newProperty = newValue.value as FilterClass['property']
             setFilter({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -12,9 +12,11 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-//@ts-ignore
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../.... Remove this comment to see the full error message
 import metacardDefinitions from '../../component/singletons/metacard-definitions.js'
-//@ts-ignore
+
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '../.... Remove this comment to see the full error message
 import properties from '../../js/properties.js'
 
 export const getFilteredAttributeList = () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/presentation/layer-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/presentation/layer-item.tsx
@@ -30,6 +30,7 @@ const Root = styled.div<PresentationProps>`
     if (!props.order.isTop) {
       return 'none'
     }
+    return
   }};
 `
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.tsx
@@ -145,7 +145,7 @@ export type GeoFeature = {
 const Gazetteer = (props: Props) => {
   const fetch = props.fetch || defaultFetch
 
-  const expandPoint = geo => {
+  const expandPoint = (geo: any) => {
     const offset = 0.1
     if (geo.length === 1) {
       const point = geo[0]
@@ -177,7 +177,10 @@ const Gazetteer = (props: Props) => {
       geometry: {
         type: 'Polygon',
         coordinates: [
-          expandPoint(suggestion.geo).map(coord => [coord.lon, coord.lat]),
+          expandPoint(suggestion.geo).map((coord: any) => [
+            coord.lon,
+            coord.lat,
+          ]),
         ],
       },
       properties: {},

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-info/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-info/presentation.tsx
@@ -84,6 +84,7 @@ const getDistanceText = (distance: number) => {
   return distanceText
 }
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 const distanceInfo = (props: Props) => {
   if (props.measurementState !== 'NONE') {
     return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/container.tsx
@@ -80,4 +80,3 @@ class MapSettings extends React.Component<WithBackboneProps, State> {
 }
 
 export default hot(module)(withListenTo(MapSettings))
-export const testComponent = withListenTo(MapSettings)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
@@ -39,12 +39,14 @@ const after = `
   }
 `
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 const background = (props: any) => {
   if (props.theme.backgroundDropdown !== undefined) {
     return rgba(readableColor(props.theme.backgroundDropdown), 0.1)
   }
 }
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 const foreground = (props: any) => {
   if (props.theme.backgroundDropdown !== undefined) {
     return readableColor(props.theme.backgroundDropdown)
@@ -191,7 +193,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
         break
     }
   }
-  componentDidUpdate(previousProps: any) {
+  componentDidUpdate(previousProps: MenuProps) {
     if (previousProps.children !== this.props.children) {
       this.setState({ active: this.chooseActive() })
     }
@@ -268,5 +270,4 @@ export const MenuItem = (props: MenuItemProps) => {
   )
 }
 
-// @ts-ignore
 MenuItem.displayName = 'MenuItem'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-archive/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-archive/presentation.tsx
@@ -25,6 +25,7 @@ type Props = {
   loading: boolean
 }
 
+// @ts-expect-error ts-migrate(6133) FIXME: 'SubText' is declared but its value is never read.
 const SubText = styled.span`
   display: block;
   font-size: ${props => props.theme.mediumFontSize};

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-history/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-history/presentation.tsx
@@ -52,6 +52,7 @@ const Root = styled.div`
         }
     `
     }
+    return
   }};
 `
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/index.tsx
@@ -15,6 +15,7 @@
 import * as React from 'react'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 import { hot } from 'react-hot-loader'
+// @ts-expect-error ts-migrate(6133) FIXME: 'user' is declared but its value is never read.
 const user = require('../../component/singletons/user-instance')
 import { Divider } from './metacard-interactions'
 import ExtensionPoints from '../../extension-points'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/buttons.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/buttons.tsx
@@ -14,12 +14,15 @@
  **/
 import * as React from 'react'
 import { Button, buttonTypeEnum } from '../presentation/button'
+// @ts-expect-error ts-migrate(6133) FIXME: 'UserNotifications' is declared but its value is n... Remove this comment to see the full error message
 import UserNotifications from '../user-notifications'
+// @ts-expect-error ts-migrate(6133) FIXME: 'UserView' is declared but its value is never read... Remove this comment to see the full error message
 import UserView from '../user'
 import styled from 'styled-components'
 import { transparentize } from 'polished'
 
 const HelpView = require('../../component/help/help.view.js')
+// @ts-expect-error ts-migrate(6133) FIXME: 'UserSettings' is declared but its value is never ... Remove this comment to see the full error message
 const UserSettings = require('../../component/user-settings/user-settings.view.js')
 const user = require('../../component/singletons/user-instance.js')
 export interface Props {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/presentation.tsx
@@ -23,9 +23,9 @@ export interface Props {
   isGuest: boolean
 }
 
-const unseenNotifications = keyframes`
+const unseenNotifications = (props: any) => keyframes`
   0% {
-    opacity: ${props => props.theme.minimumOpacity};
+    opacity: ${props.theme.minimumOpacity};
   }
   100% {
     opacity: 1;
@@ -75,6 +75,7 @@ const Root = styled.div<Props>`
         }
       `
     }
+    return
   }};
 `
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/popup-preview/popup-preview.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/popup-preview/popup-preview.tsx
@@ -177,6 +177,7 @@ const getPreviewText = ({
  * Get the pixel location from a metacard(s)
  * returns { left, top } relative to the map view
  */
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 const getLocation = (map: any, target: MetacardType[]) => {
   if (target) {
     const location = map.getWindowLocationsOfResults(target)
@@ -269,6 +270,7 @@ const HookPopupPreview = (props: Props) => {
 
   return (
     <Root style={{ left: getLeft(location), top: getTop(location) }}>
+      {/* @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value. */}
       {(function() {
         if (selectionInterface.getSelectedResults().length === 1) {
           const metacardJSON = selectionInterface

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/portal/portal.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/portal/portal.tsx
@@ -41,6 +41,8 @@ class Portal extends React.Component<{}, {}> {
   componentWillUnmount() {
     this.wrapper.remove()
   }
+
+  // @ts-ignore
   render() {
     return ReactDOM.createPortal(this.props.children, this.wrapper)
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/button/button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/button/button.tsx
@@ -168,6 +168,7 @@ const Root = styled.button<RootProps>`
               determineColorFromProps(props)
             )};`
           }
+          return
         }}
         background: repeating-linear-gradient(
                 45deg,
@@ -249,7 +250,6 @@ export const Button = ({
       inText={inText}
       buttonType={buttonType}
       className={`${className} ${rootClassName} old-button`}
-      // @ts-ignore
       style={rootStyle}
       {...otherProps as JSX.IntrinsicAttributes}
     >

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
@@ -125,7 +125,7 @@ export const withDropdown = <P extends withContext>(
     return (
       <DropdownContext.Consumer>
         {context => {
-          // @ts-ignore
+          // @ts-expect-error ts-migrate(2322) FIXME: 'Pick<P, Exclude<keyof P, "dropdownContext">> & { ... Remove this comment to see the full error message
           return <Component {...props} dropdownContext={context} />
         }}
       </DropdownContext.Consumer>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/sort-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/sort-item.tsx
@@ -13,8 +13,7 @@
  *
  **/
 import * as React from 'react'
-// @ts-ignore
-import EnumInput from '../inputs/enum-input'
+
 import { isDirectionalSort } from './sort-selection-helpers'
 import { SortItemType, Option } from './sort-selections'
 import TextField from '@material-ui/core/TextField'
@@ -50,13 +49,14 @@ const SortItem = ({
             <Autocomplete
               data-id="sort-type-autocomplete"
               size="small"
+              // @ts-ignore fullWidth does exist on Autocomplete
               fullWidth
               options={attributeOptions}
               getOptionLabel={option => option.label}
               getOptionSelected={(option, value) => {
                 return option.value === value.value
               }}
-              onChange={(e, newValue) => {
+              onChange={(_e: any, newValue: Option) => {
                 const newProperty = newValue.value
                 updateAttribute(newProperty)
               }}
@@ -95,13 +95,14 @@ const SortItem = ({
               <Autocomplete
                 data-id="sort-order-autocomplete"
                 size="small"
+                // @ts-ignore fullWidth does exist on Autocomplete
                 fullWidth
                 options={directionOptions}
                 getOptionLabel={option => option.label}
                 getOptionSelected={(option, value) =>
                   option.value === value.value
                 }
-                onChange={(e, newValue) => {
+                onChange={(_e: any, newValue: Option) => {
                   const newProperty = newValue.value
                   updateDirection(newProperty)
                 }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/result-sort/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/result-sort/presentation.tsx
@@ -29,6 +29,7 @@ type Props = {
 const render = ({ removeSort, saveSort, hasSort, collection }: Props) => {
   return (
     <div className="min-w-120">
+      {/* @ts-expect-error ts-migrate(2322) FIXME: Property 'collection' does not exist on type 'Intr... Remove this comment to see the full error message */}
       <SortSelections collection={collection} />
       <Grid container direction="row" alignItems="center" wrap="nowrap">
         {hasSort ? (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/session-timeout/session-timeout.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/session-timeout/session-timeout.tsx
@@ -45,7 +45,7 @@ const renewSession = () => {
 
 class SessionTimeout extends React.Component<{}, State> {
   interval: any
-  constructor(props: any) {
+  constructor(props: {}) {
     super(props)
     this.state = {
       timeLeft: sessionTimeoutModel.getIdleSeconds(),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sources/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/sources/container.tsx
@@ -34,9 +34,11 @@ class SourcesSummaryContainer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'filter' does not exist on type '{ getHar... Remove this comment to see the full error message
       amountDown: sources.filter(function(source: Backbone.Model) {
         return !source.get('available')
       }).length,
+      // @ts-expect-error ts-migrate(2322) FIXME: Property 'sourceActions' is missing in type '{ ava... Remove this comment to see the full error message
       sources: sources.toJSON(),
     }
   }
@@ -45,9 +47,11 @@ class SourcesSummaryContainer extends React.Component<Props, State> {
   }
   handleChange() {
     this.setState({
+      // @ts-expect-error ts-migrate(2339) FIXME: Property 'filter' does not exist on type '{ getHar... Remove this comment to see the full error message
       amountDown: sources.filter(function(source: Backbone.Model) {
         return !source.get('available')
       }).length,
+      // @ts-expect-error ts-migrate(2322) FIXME: Type '{ available: boolean; contentTypes: { name: ... Remove this comment to see the full error message
       sources: sources.toJSON(),
     })
   }
@@ -55,6 +59,7 @@ class SourcesSummaryContainer extends React.Component<Props, State> {
     return (
       <Sources
         sources={this.state.sources}
+        // @ts-expect-error ts-migrate(2339) FIXME: Property 'fetch' does not exist on type '{ getHarv... Remove this comment to see the full error message
         refreshSources={() => sources.fetch()}
         amountDown={this.state.amountDown}
       />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/color-tool.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/color-tool.tsx
@@ -161,7 +161,8 @@ function ColorTool(props: any) {
   const handleChangeHue = (name: string) => (event: any) => {
     const hue = event.target.value
     const shade = state[`${name}Shade` as 'primaryShade']
-    //@ts-ignore
+
+    // @ts-expect-error ts-migrate(7015) FIXME: Element implicitly has an 'any' type because index... Remove this comment to see the full error message
     const color = colors[hue][shades[shade]]
 
     setState({
@@ -176,7 +177,7 @@ function ColorTool(props: any) {
     _event: any,
     shade: string | number
   ) => {
-    //@ts-ignore
+    // @ts-expect-error ts-migrate(7053) FIXME: No index signature with a parameter of type 'strin... Remove this comment to see the full error message
     const color = colors[state[`${name}Hue`]][shades[shade]]
     setState({
       ...state,
@@ -282,7 +283,8 @@ function ColorTool(props: any) {
               intent === 'primary'
                 ? shades[state.primaryShade]
                 : shades[state.secondaryShade]
-            //@ts-ignore
+
+            // @ts-expect-error ts-migrate(7015) FIXME: Element implicitly has an 'any' type because index... Remove this comment to see the full error message
             const backgroundColor = colors[hue][shade] as string
 
             return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/theme-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/theme-settings.tsx
@@ -14,9 +14,13 @@
  **/
 /*global require*/
 import * as React from 'react'
+// @ts-expect-error ts-migrate(6133) FIXME: 'styled' is declared but its value is never read.
 import styled from 'styled-components'
+// @ts-expect-error ts-migrate(6133) FIXME: 'MarionetteRegionContainer' is declared but its va... Remove this comment to see the full error message
 import MarionetteRegionContainer from '../marionette-region-container'
+// @ts-expect-error ts-migrate(6133) FIXME: 'TextField' is declared but its value is never rea... Remove this comment to see the full error message
 import TextField from '@material-ui/core/TextField'
+// @ts-expect-error ts-migrate(6133) FIXME: 'MenuItem' is declared but its value is never read... Remove this comment to see the full error message
 import MenuItem from '@material-ui/core/MenuItem'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
@@ -25,6 +29,7 @@ const user = require('../../component/singletons/user-instance.js')
 import { hot } from 'react-hot-loader'
 import Grid from '@material-ui/core/Grid'
 import ColorTool from './color-tool'
+// @ts-expect-error ts-migrate(2339) FIXME: Property 'user' does not exist on type 'Window & t... Remove this comment to see the full error message
 window.user = user
 
 type ThemeType = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme/theme.tsx
@@ -114,6 +114,7 @@ type ThemesInterface = {
 }
 
 const themes: ThemesInterface = {
+  // @ts-expect-error Missing properties
   dark: {
     primaryColor: '#32a6ad',
     positiveColor: '#5b963e',
@@ -127,6 +128,7 @@ const themes: ThemesInterface = {
     backgroundModal: '#253540',
     backgroundSlideout: '#435059',
   },
+  // @ts-expect-error Missing properties
   sea: {
     primaryColor: '#32a6ad',
     positiveColor: '#154e7d',
@@ -140,6 +142,7 @@ const themes: ThemesInterface = {
     backgroundModal: '#e5e6e6',
     backgroundSlideout: '#e5e6e6',
   },
+  // @ts-expect-error Missing properties
   light: {
     primaryColor: '#3c6dd5',
     positiveColor: '#428442',
@@ -153,6 +156,7 @@ const themes: ThemesInterface = {
     backgroundModal: '#edf9fc',
     backgroundSlideout: '#edf9fc',
   },
+  // @ts-expect-error Missing properties
   custom: {
     primaryColor: '#3c6dd5',
     positiveColor: '#428442',
@@ -176,7 +180,7 @@ type UserTheme = {
 function updateTheme(userTheme: UserTheme) {
   let relevantColorTheme = themes[userTheme.theme]
   if (userTheme.theme === 'custom') {
-    // @ts-ignore
+    // @ts-expect-error ts-migrate(2769) FIXME: Property 'theme' is missing in type '{}' but requi... Remove this comment to see the full error message
     relevantColorTheme = Object.keys(relevantColorTheme).reduce(
       (newMap: UserTheme, key) => {
         newMap[key] =

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/fetch/fetch.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/fetch/fetch.tsx
@@ -22,7 +22,8 @@ type Options = {
 }
 
 const fetch = window.fetch
-// @ts-ignore
+
+// @ts-expect-error ts-migrate(2339) FIXME: Property '__global__fetch' does not exist on type ... Remove this comment to see the full error message
 window.__global__fetch = fetch
 
 // patch global fetch to warn about usage during development
@@ -37,7 +38,8 @@ if (process.env.NODE_ENV !== 'production') {
       ].join(' ')
     )
     console.warn(error)
-    // @ts-ignore
+
+    // @ts-expect-error ts-migrate(2556) FIXME: Expected 1-2 arguments, but got 0 or more.
     return fetch(...args)
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/save-file/save-file.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/save-file/save-file.tsx
@@ -14,6 +14,7 @@
  **/
 const $ = require('jquery')
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 export default function saveFile(name: string, type: string, data: any) {
   if (data != null && navigator.msSaveBlob)
     return navigator.msSaveBlob(new Blob([data], { type: type }), name)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+// @ts-expect-error ts-migrate(2307) FIXME: Cannot find module '../../sharing' or its correspo... Remove this comment to see the full error message
 import { Item } from '../../sharing'
 
 /**

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -67,6 +67,7 @@ export function getFilterErrors(filters: any) {
   return Array.from(errors)
 }
 
+// @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
 export function validateGeo(key: string, value: any) {
   switch (key) {
     case 'lat':

--- a/ui-frontend/packages/catalog-ui-search/typings/styled-components/index.d.tsx
+++ b/ui-frontend/packages/catalog-ui-search/typings/styled-components/index.d.tsx
@@ -25,5 +25,6 @@ declare module 'styled-components' {
     strings: TemplateStringsArray,
     ...interpolations: FlattenInterpolation<ThemeProps<ThemeInterface>>[]
   ): Keyframes
+  // @ts-ignore Cannot redeclare block-scoped variable
   export const ThemeContext: React.Context<DefaultTheme>
 }

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -106,6 +106,28 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.1.6":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.5.tgz#6ad96e2f71899ea3f9b651f0a911e85205d1ff6d"
+  integrity sha512-fsEANVOcZHzrsV6dMVWqpSeXClq3lNbYrfFGme6DE25FQWe7pyeYpXyx9guqUnpy466JLzZ8z4uwSr2iv60V5Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.5"
+    "@babel/helper-module-transforms" "^7.11.0"
+    "@babel/helpers" "^7.10.4"
+    "@babel/parser" "^7.11.5"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.11.5"
+    "@babel/types" "^7.11.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.6.1"
+
 "@babel/generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
@@ -125,6 +147,15 @@
     "@babel/types" "^7.11.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
+
+"@babel/generator@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.5.tgz#a5582773425a468e4ba269d9a1f701fbca6a7a82"
+  integrity sha512-9UqHWJ4IwRTy4l0o8gq2ef8ws8UPzvtMkVKjTLAiRmza9p9V6Z+OfuNd9fB1j5Q67F+dVJtPC2sZXI8NM9br4g==
+  dependencies:
+    "@babel/types" "^7.11.5"
+    jsesc "^2.5.1"
+    source-map "^0.6.1"
 
 "@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
@@ -384,6 +415,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.1.6", "@babel/parser@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
+  integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+
 "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.9.0":
   version "7.11.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
@@ -406,7 +442,7 @@
     "@babel/helper-create-class-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-proposal-class-properties@^7.10.4", "@babel/plugin-proposal-class-properties@^7.7.0":
+"@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.10.4", "@babel/plugin-proposal-class-properties@^7.7.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
   integrity sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
@@ -487,7 +523,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.11.0", "@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.9.0":
+"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.11.0", "@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.9.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz#bd81f95a1f746760ea43b6c2d3d62b11790ad0af"
   integrity sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
@@ -975,7 +1011,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-typescript@^7.9.0":
+"@babel/plugin-transform-typescript@^7.10.4", "@babel/plugin-transform-typescript@^7.9.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.11.0.tgz#2b4879676af37342ebb278216dd090ac67f13abb"
   integrity sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==
@@ -1060,6 +1096,80 @@
     "@babel/preset-modules" "^0.1.3"
     "@babel/types" "^7.9.0"
     browserslist "^4.9.1"
+    core-js-compat "^3.6.2"
+    invariant "^2.2.2"
+    levenary "^1.1.1"
+    semver "^5.5.0"
+
+"@babel/preset-env@^7.1.6":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.11.5.tgz#18cb4b9379e3e92ffea92c07471a99a2914e4272"
+  integrity sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==
+  dependencies:
+    "@babel/compat-data" "^7.11.0"
+    "@babel/helper-compilation-targets" "^7.10.4"
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-proposal-async-generator-functions" "^7.10.4"
+    "@babel/plugin-proposal-class-properties" "^7.10.4"
+    "@babel/plugin-proposal-dynamic-import" "^7.10.4"
+    "@babel/plugin-proposal-export-namespace-from" "^7.10.4"
+    "@babel/plugin-proposal-json-strings" "^7.10.4"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.11.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.10.4"
+    "@babel/plugin-proposal-numeric-separator" "^7.10.4"
+    "@babel/plugin-proposal-object-rest-spread" "^7.11.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.10.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.11.0"
+    "@babel/plugin-proposal-private-methods" "^7.10.4"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.10.4"
+    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-class-properties" "^7.10.4"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-top-level-await" "^7.10.4"
+    "@babel/plugin-transform-arrow-functions" "^7.10.4"
+    "@babel/plugin-transform-async-to-generator" "^7.10.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.10.4"
+    "@babel/plugin-transform-block-scoping" "^7.10.4"
+    "@babel/plugin-transform-classes" "^7.10.4"
+    "@babel/plugin-transform-computed-properties" "^7.10.4"
+    "@babel/plugin-transform-destructuring" "^7.10.4"
+    "@babel/plugin-transform-dotall-regex" "^7.10.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.10.4"
+    "@babel/plugin-transform-exponentiation-operator" "^7.10.4"
+    "@babel/plugin-transform-for-of" "^7.10.4"
+    "@babel/plugin-transform-function-name" "^7.10.4"
+    "@babel/plugin-transform-literals" "^7.10.4"
+    "@babel/plugin-transform-member-expression-literals" "^7.10.4"
+    "@babel/plugin-transform-modules-amd" "^7.10.4"
+    "@babel/plugin-transform-modules-commonjs" "^7.10.4"
+    "@babel/plugin-transform-modules-systemjs" "^7.10.4"
+    "@babel/plugin-transform-modules-umd" "^7.10.4"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.10.4"
+    "@babel/plugin-transform-new-target" "^7.10.4"
+    "@babel/plugin-transform-object-super" "^7.10.4"
+    "@babel/plugin-transform-parameters" "^7.10.4"
+    "@babel/plugin-transform-property-literals" "^7.10.4"
+    "@babel/plugin-transform-regenerator" "^7.10.4"
+    "@babel/plugin-transform-reserved-words" "^7.10.4"
+    "@babel/plugin-transform-shorthand-properties" "^7.10.4"
+    "@babel/plugin-transform-spread" "^7.11.0"
+    "@babel/plugin-transform-sticky-regex" "^7.10.4"
+    "@babel/plugin-transform-template-literals" "^7.10.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.10.4"
+    "@babel/plugin-transform-unicode-escapes" "^7.10.4"
+    "@babel/plugin-transform-unicode-regex" "^7.10.4"
+    "@babel/preset-modules" "^0.1.3"
+    "@babel/types" "^7.11.5"
+    browserslist "^4.12.0"
     core-js-compat "^3.6.2"
     invariant "^2.2.2"
     levenary "^1.1.1"
@@ -1191,6 +1301,25 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
+"@babel/preset-typescript@^7.1.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz#7d5d052e52a682480d6e2cc5aa31be61c8c25e36"
+  integrity sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-transform-typescript" "^7.10.4"
+
+"@babel/register@^7.0.0":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.11.5.tgz#79becf89e0ddd0fba8b92bc279bc0f5d2d7ce2ea"
+  integrity sha512-CAml0ioKX+kOAvBQDHa/+t1fgOt3qkTIz0TrRtRAT6XY0m5qYZXR85k6/sLCNPMGhYDlCFHCYuU0ybTJbvlC6w==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime-corejs2@^7.6.3":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz#700a03945ebad0d31ba6690fc8a6bcc9040faa47"
@@ -1263,6 +1392,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
+  integrity sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.11.5"
+    "@babel/types" "^7.11.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
@@ -1276,6 +1420,15 @@
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
   integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
+  integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -3581,7 +3734,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn-jsx@^5.0.1:
+acorn-jsx@^5.0.1, acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
@@ -3742,7 +3895,7 @@ ajv@^5.0.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.0.1, ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
+ajv@^6.0.1, ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
   version "6.12.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
   integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
@@ -3856,7 +4009,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -4296,15 +4449,30 @@ ast-types@0.11.5:
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.5.tgz#9890825d660c03c28339f315e9fa0a360e31ec28"
   integrity sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==
 
+ast-types@0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.7.tgz#f318bf44e339db6a320be0009ded64ec1471f46c"
+  integrity sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==
+
 ast-types@0.12.4:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.12.4.tgz#71ce6383800f24efc9a1a3308f3a6e420a0974d1"
   integrity sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==
 
+ast-types@0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
+  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
+
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
   integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 astroturf@0.10.4:
   version "0.10.4"
@@ -4508,6 +4676,11 @@ babel-core@^6.26.0:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-core@^7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-eslint@8.2.3:
   version "8.2.3"
@@ -7529,6 +7702,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-jest-runner@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/create-jest-runner/-/create-jest-runner-0.5.3.tgz#1387e2ce70b08e4c989ae55f677005b64f9ba97b"
+  integrity sha512-a9VY2doMBmzRollJB3Ft3/Y5fBceSWJ4gdyVsg4/d7nP1S4715VG939s2VnITDj79YBmRgKhjGjNRv1c+Kre1g==
+  dependencies:
+    chalk "^2.4.2"
+    jest-worker "^24.0.0"
+    throat "^4.1.0"
+
 create-react-context@0.3.0, create-react-context@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
@@ -8202,7 +8384,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -9295,7 +9477,22 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-visitor-keys@^1.0.0:
+eslint-scope@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
+  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -9344,6 +9541,49 @@ eslint@4.19.1:
     table "4.0.2"
     text-table "~0.2.0"
 
+eslint@^6.1.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.3"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
@@ -9351,6 +9591,15 @@ espree@^3.5.4:
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
+
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
 
 esprima-fb@^15001.1.0-dev-harmony-fb:
   version "15001.1.0-dev-harmony-fb"
@@ -9392,7 +9641,7 @@ espurify@^2.0.0, espurify@^2.0.1:
   resolved "https://registry.yarnpkg.com/espurify/-/espurify-2.0.1.tgz#c25b3bb613863daa142edcca052370a1a459f41d"
   integrity sha512-7w/dUrReI/QbJFHRwfomTlkQOXaB1NuCrBRn5Y26HXn5gvh18/19AgLbayVrNxXQfkckvgrJloWyvZDuJ7dhEA==
 
-esquery@^1.0.0:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
@@ -9875,6 +10124,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 file-loader@1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
@@ -9985,7 +10241,7 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
-find-cache-dir@^2.1.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -10055,10 +10311,29 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
 flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+flow-parser@0.*:
+  version "0.133.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.133.0.tgz#670c2b03fc26dc921efa685359addc6061a2337a"
+  integrity sha512-ONvDDUcQVY7bMQG4ht7Ti+2IYjBBPphkc7fGmHXZHrrNNjGG4tykLZjIrIx710/k77x2djaY9VKlHC342Luy3A==
 
 flow-parser@^0.*:
   version "0.131.0"
@@ -10881,7 +11156,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -10976,6 +11251,13 @@ globals@^11.0.1, globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -12030,7 +12312,7 @@ ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^4.0.0, ignore@^4.0.3:
+ignore@^4.0.0, ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
@@ -12070,7 +12352,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -12272,7 +12554,7 @@ inquirer@^6.2.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-inquirer@^7.1.0:
+inquirer@^7.0.0, inquirer@^7.1.0:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
   integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
@@ -13061,6 +13343,14 @@ jest-matcher-utils@^26.0.1:
     jest-get-type "^26.3.0"
     pretty-format "^26.4.0"
 
+jest-worker@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
+  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^6.1.0"
+
 jquery-mousewheel@~3.1.13:
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"
@@ -13181,6 +13471,54 @@ jscodeshift@^0.5.0:
     temp "^0.8.1"
     write-file-atomic "^1.2.0"
 
+jscodeshift@^0.6.3:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.6.4.tgz#e19ab86214edac86a75c4557fc88b3937d558a8e"
+  integrity sha512-+NF/tlNbc2WEhXUuc4WEJLsJumF84tnaMUZW2hyJw3jThKKRvsPX4sPJVgO1lPE28z0gNL+gwniLG9d8mYvQCQ==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/preset-env" "^7.1.6"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.16.1"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
+jscodeshift@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.7.1.tgz#0236ad475d6f0770ca998a0160925d62b57d2507"
+  integrity sha512-YMkZSyoc8zg5woZL23cmWlnFLPH/mHilonGA7Qbzs7H6M4v4PH0Qsn4jeDyw+CHhVoAnm9UxQyB0Yw1OT+mktA==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/preset-env" "^7.1.6"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.18.1"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
 jsdoc@3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
@@ -13298,6 +13636,13 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5-writer@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/json5-writer/-/json5-writer-0.1.8.tgz#98e1934ef6002f8ac12f36438e2b39c49af213fd"
+  integrity sha512-h5sqkk/vSKvESOUTBniGWs8p8nTzHsoDrxPS9enJfQVINqXv3lm+FAyizLwbrCwCn0q7NXqDBb+r8AdUdK3XZw==
+  dependencies:
+    jscodeshift "^0.6.3"
+
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -13310,7 +13655,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -14062,6 +14407,15 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
+log-update@^3.3.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-3.4.0.tgz#3b9a71e00ac5b1185cc193a36d654581c48f97b9"
+  integrity sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    cli-cursor "^2.1.0"
+    wrap-ansi "^5.0.0"
+
 loglevel@^1.4.1:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
@@ -14178,7 +14532,7 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   dependencies:
     pify "^3.0.0"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -15315,7 +15669,7 @@ node-dir@0.1.8:
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.8.tgz#55fb8deb699070707fb67f91a460f0448294c77d"
   integrity sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=
 
-node-dir@^0.1.10:
+node-dir@^0.1.10, node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
@@ -15393,6 +15747,11 @@ node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
+
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-releases@^1.1.29, node-releases@^1.1.60:
   version "1.1.60"
@@ -15844,7 +16203,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -16388,6 +16747,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pirates@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+  dependencies:
+    node-modules-regexp "^1.0.0"
 
 pixelworks@1.1.0:
   version "1.1.0"
@@ -18314,12 +18680,32 @@ recast@^0.15.0:
     private "~0.1.5"
     source-map "~0.6.1"
 
+recast@^0.16.1:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.16.2.tgz#3796ebad5fe49ed85473b479cd6df554ad725dc2"
+  integrity sha512-O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==
+  dependencies:
+    ast-types "0.11.7"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
+
 recast@^0.17.3:
   version "0.17.6"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.17.6.tgz#64ae98d0d2dfb10ff92ff5fb9ffb7371823b69fa"
   integrity sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==
   dependencies:
     ast-types "0.12.4"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
+
+recast@^0.18.1:
+  version "0.18.10"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.10.tgz#605ebbe621511eb89b6356a7e224bff66ed91478"
+  integrity sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==
+  dependencies:
+    ast-types "0.13.3"
     esprima "~4.0.0"
     private "^0.1.8"
     source-map "~0.6.1"
@@ -18498,6 +18884,11 @@ regexpp@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
   integrity sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==
+
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -18914,6 +19305,13 @@ rimraf@2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rimraf@2.6.3, rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -18925,13 +19323,6 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
-
-rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -19305,7 +19696,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -19701,6 +20092,15 @@ slice-ansi@1.0.0:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
   dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
 slide@^1.1.5:
@@ -20412,7 +20812,7 @@ strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@5.2.0, strip-ansi@^5.1.0:
+strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -20479,6 +20879,11 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+
+strip-json-comments@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -20839,6 +21244,16 @@ table@^4.0.1:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
 taffydb@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
@@ -21068,6 +21483,11 @@ textextensions@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
+
+throat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
 throttle-debounce@^2.0.1, throttle-debounce@^2.1.0:
   version "2.3.0"
@@ -21376,6 +21796,38 @@ ts-loader@6.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+ts-migrate-plugins@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ts-migrate-plugins/-/ts-migrate-plugins-0.1.0.tgz#482f092851474e78f7ecb5d3c31e378eaf03b3dc"
+  integrity sha512-mzsq0Mv5mkOmjIpIjZMqLYktvPaB1vaeUpQ7+Fo33/9TfxovJ8Wq7OKB7pG3GBECpQEuNLgWVbtBaz3WV2UDaQ==
+  dependencies:
+    eslint "^6.1.0"
+    jscodeshift "^0.7.0"
+    ts-migrate-server "^0.1.0"
+    typescript "3.9.7"
+
+ts-migrate-server@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ts-migrate-server/-/ts-migrate-server-0.1.0.tgz#1ee886a46d02a7cbc230d34b07cdb23e182418c0"
+  integrity sha512-UpRsjFl25bHOk68r7ix2aehA2NplBMinqNLD5gUqLNCYdlRshhpOqJ9IJDsArV4M1IdCw4ldjHm1mamRoOgwOw==
+  dependencies:
+    typescript "3.9.7"
+    updatable-log "^0.2.0"
+
+ts-migrate@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ts-migrate/-/ts-migrate-0.1.2.tgz#7e612647373c41d1635bc4b74768d31ace88a445"
+  integrity sha512-2J4V17ci+drIYv5Ms8HkMJS6nvxhpJu1HKsdmLo179r9jLlO/E4Xu2w5GiTU3dygt8MpRb94oihhvUeLN1PQ9g==
+  dependencies:
+    create-jest-runner "^0.5.3"
+    json5 "^2.1.1"
+    json5-writer "^0.1.8"
+    ts-migrate-plugins "^0.1.0"
+    ts-migrate-server "^0.1.0"
+    typescript "3.9.7"
+    updatable-log "^0.2.0"
+    yargs "^15.0.2"
+
 ts-pnp@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -21495,6 +21947,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -21825,6 +22282,15 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
+updatable-log@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/updatable-log/-/updatable-log-0.2.0.tgz#8adfe35dd744bd87e8bf217425e4e8bb81b6f3c6"
+  integrity sha512-gR48/mTR6YFB+B1sNoap3nx8HFbEvDl0ej9KhlQTFZdmP8yL5fzFiCUfeHCUf1QvNnXowY1pM9iiGkPKrd0XyQ==
+  dependencies:
+    chalk "^2.4.2"
+    figures "^3.0.0"
+    log-update "^3.3.0"
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
@@ -22011,6 +22477,11 @@ v8-compile-cache@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
   integrity sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA==
+
+v8-compile-cache@^2.0.3:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
+  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -22659,6 +23130,15 @@ wrap-ansi@^3.0.1:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
 
+wrap-ansi@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -22681,6 +23161,22 @@ write-file-atomic@^1.2.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write-file-atomic@^2.3.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 write@^0.2.1:
   version "0.2.1"
@@ -22850,7 +23346,7 @@ yargs@^11.1.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^15.3.1:
+yargs@^15.0.2, yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
Description

Either elimates or ignores existing ts errors, so we can stop ignoring them moving forward

Reviewers
@stevenmalmgren @andrewkfiedler @vinamartin @a-asaad 

What are the relevant tickets?
Fixes: #359 

Testing

- run `yarn build` in `ui-frontend/packages/catalog-ui-search`. You shouldn't get see any typescript errors.
-  Bonus: Verify that major routes still work. These changes should be pretty benign
