### PR TITLE
Encode 'service' query parameter in Intrigue logout link

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/container.tsx
@@ -32,7 +32,8 @@ class UserContainer extends React.Component<{}, State> {
     }
   }
   signOut() {
-    window.location.href = '../../logout?service=' + window.location.href
+    window.location.href =
+      '../../logout?service=' + encodeURIComponent(window.location.href)
   }
   render() {
     const { username, isGuest, email } = this.state


### PR DESCRIPTION
### Description
This was inspired by this PR: https://github.com/codice/ddf/pull/6310
I'm not aware of any current bugs caused by the unencoded query parameter, but URIs may contain characters that could cause issues (e.g. `&`). This change is to be safe.

### Reviewers
@blen-desta @bakejeyner @emmberk @garrettfreibott @stustison 