### PR TITLE
[3.6.x] Fixes displaying Archive/Overwrite tabs

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
@@ -130,5 +130,9 @@ module.exports = TabsView.extend({
       'is-preview-disabled',
       !properties.isMetacardPreviewEnabled()
     )
+    this.$el.toggleClass(
+      'is-editing-disabled',
+      !user.canWrite(this.selectionInterface.getSelectedResults().first())
+    )
   },
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -499,7 +499,7 @@ User.Response = Backbone.AssociatedModel.extend({
         return this.canWrite(thing.get('metacard').get('properties'))
       case 'query-result.collection':
       default:
-        if (this.some !== undefined) {
+        if (thing.some !== undefined) {
           !thing.some(subthing => {
             return !this.canWrite(subthing)
           })


### PR DESCRIPTION
Fixes issue with displaying archive/overwrite tabs on results users didn't have write access to.
**Note**: ~I noticed this causes a pretty severe performance degradation on loading multiple results, looking into adding a loading state to lessen the blow here but I'm open to thoughts on how to make this check faster.~ This performance issue exists without this change. 