### PR TITLE
[3.4.x] G-8889 Allow multi-select without holding down Ctrl button

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/selection.behavior.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/selection.behavior.js
@@ -42,6 +42,7 @@ Behaviors.addBehavior(
   Marionette.Behavior.extend({
     events() {
       return {
+        [`click ${this.options.noClick}`]: 'handleCheckboxClick',
         [`click ${this.options.selectionSelector}`]: 'handleClick',
         [`mousedown ${this.options.selectionSelector}`]: 'handleMouseDown',
       }
@@ -49,6 +50,7 @@ Behaviors.addBehavior(
     lastTarget: undefined,
     lastMouseDown: Date.now(),
     lastClick: Date.now(),
+    isCheckboxClick: undefined,
     onRender() {
       this.view.$el.addClass('has-selection-behavior')
     },
@@ -60,8 +62,17 @@ Behaviors.addBehavior(
       this.interpretClick(event)
       this.updateStateOnClick(event)
     },
+    handleCheckboxClick(event) {
+      this.isCheckboxClick = true
+    },
     interpretClick(event) {
-      if (event.altKey || this.isTextSelection() || this.isDoubleClick(event)) {
+      if (
+        event.altKey ||
+        this.isTextSelection() ||
+        this.isDoubleClick(event) ||
+        this.isCheckboxClick
+      ) {
+        this.isCheckboxClick = false
         return
       }
       const resultid = event.currentTarget.getAttribute('data-resultid')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -138,6 +138,7 @@ const ResultSelector = Marionette.LayoutView.extend({
       selection: {
         selectionInterface: this.options.selectionInterface,
         selectionSelector: `${CustomElements.getNamespace()}result-item`,
+        noClick: '.checkbox-container',
       },
     }
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-checkbox/item-checkbox.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-checkbox/item-checkbox.tsx
@@ -51,7 +51,17 @@ export const ItemCheckbox = ({ selectionInterface, model }: any) => {
   }, [])
 
   return (
-    <Root className={'checkbox-container'}>
+    <Root
+      className={'checkbox-container'}
+      onClick={e => {
+        e.stopPropagation()
+        if (isSelected({ selectionInterface, model })) {
+          selectionInterface.removeSelectedResult(model)
+        } else {
+          selectionInterface.addSelectedResult(model)
+        }
+      }}
+    >
       <span className={className} />
     </Root>
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/table/tbody.view.js
@@ -26,6 +26,7 @@ module.exports = Marionette.CollectionView.extend({
       selection: {
         selectionInterface: this.options.selectionInterface,
         selectionSelector: `> *`,
+        noClick: '.checkbox-container',
       },
     }
   },


### PR DESCRIPTION
#### 2.19.x PR https://github.com/codice/ddf/pull/6327
______________
#### What does this PR do?
Allows the user to select multiple results using the checkbox without holding down the Ctrl button in both the results list and the table view. 
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@mojogitoverhere 
#### How should this be tested?
Upload multiple results (3 or more)
Verify that you're able to select multiple results via checkboxes without holding down the Ctrl button in the results list
Do the same as above in the table view
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: G-8889
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
