### PR TITLE
DDF 2.26.0 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.25.1</ddf.version>
+    <ddf.version>2.26.0-SNAPSHOT</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <camel.version>2.22.1</camel.version>
     <commons-math3.version>3.6.1</commons-math3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.26.0-SNAPSHOT</ddf.version>
+    <ddf.version>2.26.0</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <camel.version>2.22.1</camel.version>
     <commons-math3.version>3.6.1</commons-math3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
     <!--Backend properties-->
     <ddf.version>2.26.0</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
-    <camel.version>2.22.1</camel.version>
+    <camel.version>2.24.2</camel.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <gson.version>2.8.5</gson.version>
     <jackson.version>2.11.0</jackson.version>
-    <karaf.version>4.2.6</karaf.version>
+    <karaf.version>4.2.9</karaf.version>
     <nimbus.version>8.14.1</nimbus.version>
     <nimbus.oidc.version>8.3</nimbus.oidc.version>
     <pac4j.version>4.0.1</pac4j.version>

--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -291,7 +291,7 @@
         </dependency>
         <dependency>
             <groupId>ddf.platform.security</groupId>
-            <artifactId>session-management-service</artifactId>
+            <artifactId>session-management-api</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
@@ -316,7 +316,7 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.servlet</groupId>
-            <artifactId>security-servlet-logout-service</artifactId>
+            <artifactId>security-servlet-logout-api</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
@@ -394,7 +394,7 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.servlet</groupId>
-            <artifactId>security-servlet-web-socket</artifactId>
+            <artifactId>security-servlet-web-socket-api</artifactId>
             <version>${ddf.version}</version>
         </dependency>
     </dependencies>
@@ -444,7 +444,6 @@
                             handlebars,
                             httpclient,
                             httpcore,
-                            platform-util,
                             tlmatcher,
                             gson-support,
                             guava,

--- a/ui-backend/intrigue-ui-app/src/main/resources/features.xml
+++ b/ui-backend/intrigue-ui-app/src/main/resources/features.xml
@@ -29,11 +29,12 @@
         <feature>resource-bundle-locator</feature>
         <feature>platform-usng4j</feature>
         <feature>platform-configuration</feature>
-        <feature>platform-email</feature>
         <feature>persistence-core</feature>
 
-        <feature>catalog-ui-search-api</feature>
+        <!-- Email feature resides in here-->
+        <feature>security-core-services</feature>
 
+        <feature>catalog-ui-search-api</feature>
 
         <configfile finalname="${ddf.etc}/org.codice.ddf.catalog.ui.config" override="false">
             mvn:org.codice.ddf.search/intrigue-ui-app/${project.version}/properties/catalog-ui-config


### PR DESCRIPTION
Updates to master for DDF 2.26.0.  
Includes cherry pick of https://github.com/codice/ddf-ui/pull/317 needed for a successful build using DDF 2.26.0-SNAP