### PR TITLE
Update to latest ace to pull in ability to purge tailwind

### DIFF
--- a/ui-frontend/package.json
+++ b/ui-frontend/package.json
@@ -16,7 +16,7 @@
     "mvn:install-file": "mvn org.apache.maven.plugins:maven-install-plugin:install-file -Dfile=target/packages-packages.zip -DpomFile=pom.xml -Dclassifier=packages -Dpackaging=zip"
   },
   "devDependencies": {
-    "@connexta/ace": "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e",
+    "@connexta/ace": "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0",
     "@connexta/eslint-config-connexta": "git://github.com/connexta/eslint-config-connexta.git#105393617ec845b009b682882c95313ba50144b1",
     "@connexta/eslint-plugin-connexta": "git://github.com/connexta/eslint-plugin-connexta.git#9b366b8924c3dbe03aedcfe6d25c8eb3567cc061",
     "bootstrap-sass": "3.4.1",

--- a/ui-frontend/packages/admin/package.json
+++ b/ui-frontend/packages/admin/package.json
@@ -16,7 +16,7 @@
     "@types/react": "16.9.34",
     "@types/react-dom": "16.9.7",
     "@types/styled-components": "5.1.0",
-    "@connexta/ace": "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e"
+    "@connexta/ace": "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
   },
   "dependencies": {
     "@connexta/kanri": "0.0.11",

--- a/ui-frontend/packages/admin/yarn.lock
+++ b/ui-frontend/packages/admin/yarn.lock
@@ -1248,9 +1248,9 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@connexta/ace@git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e":
+"@connexta/ace@git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0":
   version "1.0.0"
-  resolved "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e"
+  resolved "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
   dependencies:
     "@babel/core" "^7.0.0"
     "@storybook/addon-actions" "5.2.8"

--- a/ui-frontend/packages/catalog-ui-search/tailwind.config.js
+++ b/ui-frontend/packages/catalog-ui-search/tailwind.config.js
@@ -1,4 +1,11 @@
 module.exports = {
+  purge: [
+    './src/**/*.tsx',
+    './src/**/*.jsx',
+    './src/**/*.hbs',
+    './src/**/*.js',
+    './src/**/*.ts',
+  ],
   theme: {
     namedGroups: ['1', '2'],
     extend: {

--- a/ui-frontend/packages/cesium-assets/package.json
+++ b/ui-frontend/packages/cesium-assets/package.json
@@ -18,6 +18,6 @@
   ],
   "context-path": "/search/catalog/cesium/assets",
   "devDependencies": {
-    "@connexta/ace": "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e"
+    "@connexta/ace": "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
   }
 }

--- a/ui-frontend/packages/cesium-assets/yarn.lock
+++ b/ui-frontend/packages/cesium-assets/yarn.lock
@@ -1248,9 +1248,9 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@connexta/ace@git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e":
+"@connexta/ace@git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0":
   version "1.0.0"
-  resolved "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e"
+  resolved "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
   dependencies:
     "@babel/core" "^7.0.0"
     "@storybook/addon-actions" "5.2.8"

--- a/ui-frontend/yarn.lock
+++ b/ui-frontend/yarn.lock
@@ -1248,9 +1248,9 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@connexta/ace@git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e":
+"@connexta/ace@git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0":
   version "1.0.0"
-  resolved "git://github.com/connexta/ace.git#99f79c6d7f76862572f522bfcde26b662749761e"
+  resolved "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
   dependencies:
     "@babel/core" "^7.0.0"
     "@storybook/addon-actions" "5.2.8"


### PR DESCRIPTION
 - Update to latest ace, where node env is properly set to production.  This let's us purge unused tailwind css.