### PR TITLE
Update location editing via Managed Attributes to use the specialized location input

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
@@ -102,8 +102,14 @@ function dmsCoordinateToDD(coordinate) {
 function dmsPointToWkt(point) {
   const latitude = parseDmsCoordinate(point.latitude.coordinate)
   const longitude = parseDmsCoordinate(point.longitude.coordinate)
-  const _latitude = dmsCoordinateToDD({...latitude, direction: point.latitude.direction})
-  const _longitude = dmsCoordinateToDD({...longitude, direction: point.longitude.direction})
+  const _latitude = dmsCoordinateToDD({
+    ...latitude,
+    direction: point.latitude.direction,
+  })
+  const _longitude = dmsCoordinateToDD({
+    ...longitude,
+    direction: point.longitude.direction,
+  })
   return new wkx.Point(_longitude, _latitude)
 }
 
@@ -213,10 +219,22 @@ function validateDmsBoundingBox(boundingbox) {
     return false
   }
 
-  const ddNorth = dmsCoordinateToDD({...north, direction: boundingbox.north.direction})
-  const ddSouth = dmsCoordinateToDD({...south, direction: boundingbox.south.direction})
-  const ddEast = dmsCoordinateToDD({...east, direction: boundingbox.east.direction})
-  const ddWest = dmsCoordinateToDD({...west, direction: boundingbox.west.direction})
+  const ddNorth = dmsCoordinateToDD({
+    ...north,
+    direction: boundingbox.north.direction,
+  })
+  const ddSouth = dmsCoordinateToDD({
+    ...south,
+    direction: boundingbox.south.direction,
+  })
+  const ddEast = dmsCoordinateToDD({
+    ...east,
+    direction: boundingbox.east.direction,
+  })
+  const ddWest = dmsCoordinateToDD({
+    ...west,
+    direction: boundingbox.west.direction,
+  })
   if (ddNorth < ddSouth || ddEast < ddWest) {
     return false
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
@@ -100,10 +100,10 @@ function dmsCoordinateToDD(coordinate) {
  *  DMS -> WKT conversion utils
  */
 function dmsPointToWkt(point) {
-  const latitude = parseDmsCoordinate(point.latitude)
-  const longitude = parseDmsCoordinate(point.longitude)
-  const _latitude = dmsCoordinateToDD(latitude)
-  const _longitude = dmsCoordinateToDD(longitude)
+  const latitude = parseDmsCoordinate(point.latitude.coordinate)
+  const longitude = parseDmsCoordinate(point.longitude.coordinate)
+  const _latitude = dmsCoordinateToDD({...latitude, direction: point.latitude.direction})
+  const _longitude = dmsCoordinateToDD({...longitude, direction: point.longitude.direction})
   return new wkx.Point(_longitude, _latitude)
 }
 
@@ -186,8 +186,8 @@ function inValidRange(coordinate, maximum) {
 }
 
 function validateDmsPoint(point) {
-  const latitude = parseDmsCoordinate(point.latitude)
-  const longitude = parseDmsCoordinate(point.longitude)
+  const latitude = parseDmsCoordinate(point.latitude.coordinate)
+  const longitude = parseDmsCoordinate(point.longitude.coordinate)
   if (latitude && longitude) {
     return inValidRange(latitude, 90) && inValidRange(longitude, 180)
   }
@@ -195,10 +195,10 @@ function validateDmsPoint(point) {
 }
 
 function validateDmsBoundingBox(boundingbox) {
-  const north = parseDmsCoordinate(boundingbox.north)
-  const south = parseDmsCoordinate(boundingbox.south)
-  const east = parseDmsCoordinate(boundingbox.east)
-  const west = parseDmsCoordinate(boundingbox.west)
+  const north = parseDmsCoordinate(boundingbox.north.coordinate)
+  const south = parseDmsCoordinate(boundingbox.south.coordinate)
+  const east = parseDmsCoordinate(boundingbox.east.coordinate)
+  const west = parseDmsCoordinate(boundingbox.west.coordinate)
 
   if (!north || !south || !east || !west) {
     return false
@@ -213,10 +213,10 @@ function validateDmsBoundingBox(boundingbox) {
     return false
   }
 
-  const ddNorth = dmsCoordinateToDD(north)
-  const ddSouth = dmsCoordinateToDD(south)
-  const ddEast = dmsCoordinateToDD(east)
-  const ddWest = dmsCoordinateToDD(west)
+  const ddNorth = dmsCoordinateToDD({...north, direction: boundingbox.north.direction})
+  const ddSouth = dmsCoordinateToDD({...south, direction: boundingbox.south.direction})
+  const ddEast = dmsCoordinateToDD({...east, direction: boundingbox.east.direction})
+  const ddWest = dmsCoordinateToDD({...west, direction: boundingbox.west.direction})
   if (ddNorth < ddSouth || ddEast < ddWest) {
     return false
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector-lazy.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector-lazy.tsx
@@ -57,13 +57,13 @@ const LazyInspector = ({ selectionInterface }: Props) => {
   }, [selectedResults])
 
   return (
-      <MRC
-        key="inspector"
-        view={InspectorView}
-        viewOptions={{
-          selectionInterface,
-        }}
-      />
+    <MRC
+      key="inspector"
+      view={InspectorView}
+      viewOptions={{
+        selectionInterface,
+      }}
+    />
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -24,36 +24,28 @@ export type ExtensionPointsType = {
   providers: SFC<ProviderProps>
   metacardInteractions: any[]
   customFilterInput: (props: Props) => React.ReactNode | undefined
-  customCanWritePermission: (
-    props: {
-      attribute: string
-      lazyResult: LazyQueryResult
-      user: any
-      editableAttributes: string[]
-    }
-  ) => boolean | undefined
+  customCanWritePermission: (props: {
+    attribute: string
+    lazyResult: LazyQueryResult
+    user: any
+    editableAttributes: string[]
+  }) => boolean | undefined
   customEditableAttributes: () => string[]
-  resultItemTitleAddOn: (
-    {
-      lazyResult,
-    }: {
-      lazyResult: LazyQueryResult
-    }
-  ) => JSX.Element | null
-  resultItemRowAddOn: (
-    {
-      lazyResult,
-    }: {
-      lazyResult: LazyQueryResult
-    }
-  ) => JSX.Element | null
-  layoutDropdown: (
-    props: {
-      goldenLayout: any
-      layoutResult?: ResultType
-      editLayoutRef?: any
-    }
-  ) => JSX.Element | null
+  resultItemTitleAddOn: ({
+    lazyResult,
+  }: {
+    lazyResult: LazyQueryResult
+  }) => JSX.Element | null
+  resultItemRowAddOn: ({
+    lazyResult,
+  }: {
+    lazyResult: LazyQueryResult
+  }) => JSX.Element | null
+  layoutDropdown: (props: {
+    goldenLayout: any
+    layoutResult?: ResultType
+    editLayoutRef?: any
+  }) => JSX.Element | null
   customSourcesPage: (() => JSX.Element | null) | null
   navigationRight: any[]
 }


### PR DESCRIPTION
A location entry is now used when editing a metacard's location through the "manage attributes" modal (accessed from the Inspector's summary tab), as opposed to a plain text input. This PR also fixes an issue where all Lat/Lon (DMS) entries were considered invalid.

<img width="250" alt="Screen Shot 2020-10-05 at 10 12 27 AM" src="https://user-images.githubusercontent.com/31322332/95121775-60c94980-0704-11eb-8ca8-28e00e0ef743.png">

<img width="250" alt="Screen Shot 2020-10-05 at 10 12 59 AM" src="https://user-images.githubusercontent.com/31322332/95121786-658dfd80-0704-11eb-9780-c7868771e5c7.png">


Testing Instructions:
1. Build `DDF-2.26.0`, once the distribution is unzipped and started, run `profile:install standard` from the Karaf console.
2. Build this PR and follow the instructions in https://github.com/codice/ddf-ui/blob/master/README.md to install the catalog-ui.
3. Upload a geo-enabled resource.
4. Search for the resource, open it in the inspector, then choose "Manage Attributes" from the summary tab.
5. When you click the edit icon on the `location` field, you should get a location input, experiment with setting the location to different values.
  * Things to look out for:
    - The Lat/Lon (DMS) input should be working properly
    - The save button should be disabled when the input is invalid.
