### PR TITLE
[3.4.x] G-9209 fix search form fails to save linestring

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -92,10 +92,12 @@ function generateAnyGeoFilter(property, model) {
         value:
           'LINESTRING' +
           sanitizeForCql(JSON.stringify(lineToCQLLine(model.line))),
-        distance: DistanceUtils.getDistanceInMeters(
-          model.lineWidth,
-          model.lineUnits
-        ),
+        ...(model.lineWidth && {
+          distance: DistanceUtils.getDistanceInMeters(
+            model.lineWidth,
+            model.lineUnits
+          ),
+        }),
       }
     case 'POLYGON':
       if (!Array.isArray(model.polygon)) {


### PR DESCRIPTION
#### What does this PR do?
fixes search form editor failing to save a linestring geo without a buffer.
removes `distance` attribute when no buffer applied

#### Who is reviewing it? 
@cassandrabailey293 @hayleynorton @zta6 @abel-connexta 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@mojogitoverhere

#### How should this be tested?
- build / run / install
- create new search form in editor with linestring geo without buffer
- verify form saves correctly
- verify linestring geos with buffers as well and any other geo combination

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
