### PR TITLE
[3.4.x] G-7920 Improve Result Form UX

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -58,7 +58,7 @@ module.exports = Marionette.LayoutView.extend({
         model: new Property({
           readOnly: this.model.get('readOnly'),
           enumFiltering: true,
-          showValidationIssues: true,
+          showValidationIssues: false,
           enumMulti: true,
           enum: _.filter(
             metacardDefinitions.sortedMetacardTypes,
@@ -134,7 +134,7 @@ module.exports = Marionette.LayoutView.extend({
         }
         this.showWarningSymbol(
           $titleValidationElement,
-          'Name field cannot be blank'
+          'Title field cannot be blank'
         )
       }
       if (attributesEmpty) {


### PR DESCRIPTION
### Forward port of DDF 2.19.x PR: https://github.com/codice/ddf/pull/6364

#### What does this PR do?
Improves result form UX by only showing input validation errors when the user tries to click Save

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@kentmorrissey @brhumphe @brianfelix @Lambeaux 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the `Result Form` page in Intrigue
2. Click `+ New Result Form`
3. Verify no validation errors are shown
4. Click `Save` without entering any values
5. Verify validation errors for Title and Attributes are now shown
6. Play around with modifying existing result forms to test for regressions