### PR TITLE
Bring ui-frontend and catalog-ui-search package json to same ace version

### DIFF
--- a/ui-frontend/package.json
+++ b/ui-frontend/package.json
@@ -16,7 +16,7 @@
     "mvn:install-file": "mvn org.apache.maven.plugins:maven-install-plugin:install-file -Dfile=target/packages-packages.zip -DpomFile=pom.xml -Dclassifier=packages -Dpackaging=zip"
   },
   "devDependencies": {
-    "@connexta/ace": "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0",
+    "@connexta/ace": "git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135",
     "@connexta/eslint-config-connexta": "git://github.com/connexta/eslint-config-connexta.git#105393617ec845b009b682882c95313ba50144b1",
     "@connexta/eslint-plugin-connexta": "git://github.com/connexta/eslint-plugin-connexta.git#9b366b8924c3dbe03aedcfe6d25c8eb3567cc061",
     "bootstrap-sass": "3.4.1",

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@blueprintjs/core": "3.29.0",
     "@blueprintjs/datetime": "3.18.3",
-    "@connexta/ace": "git://github.com/connexta/ace.git#7c2dee5cb3013a4c1b95c9b92acd44e38301b611",
+    "@connexta/ace": "git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135",
     "@connexta/atlas": "0.0.60",
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -1499,9 +1499,9 @@
   dependencies:
     commander "^2.15.1"
 
-"@connexta/ace@git://github.com/connexta/ace.git#7c2dee5cb3013a4c1b95c9b92acd44e38301b611":
+"@connexta/ace@git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135":
   version "1.0.0"
-  resolved "git://github.com/connexta/ace.git#7c2dee5cb3013a4c1b95c9b92acd44e38301b611"
+  resolved "git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135"
   dependencies:
     "@babel/core" "^7.0.0"
     "@storybook/addon-actions" "5.2.8"
@@ -1553,7 +1553,7 @@
     mocha-loader "1.1.3"
     ora "3.0.0"
     postcss-loader "3.0.0"
-    prettier "1.14.2"
+    prettier "2.1.2"
     puppeteer "1.5.0"
     raw-loader "0.5.1"
     react-dev-utils "5.0.2"
@@ -17445,10 +17445,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+prettier@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 prettier@^1.5.3:
   version "1.19.1"

--- a/ui-frontend/yarn.lock
+++ b/ui-frontend/yarn.lock
@@ -1248,9 +1248,9 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@connexta/ace@git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0":
+"@connexta/ace@git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135":
   version "1.0.0"
-  resolved "git://github.com/connexta/ace.git#76bada4b2f4d9f8163bc73cf0dd2a5bbea0b3ad0"
+  resolved "git://github.com/connexta/ace.git#149ba3b62076c6bb567ade2478e819587ea3b135"
   dependencies:
     "@babel/core" "^7.0.0"
     "@storybook/addon-actions" "5.2.8"


### PR DESCRIPTION
UI-frontend and catalog-ui-search were using different versions of ace on different sides of the prettier bump. This meant that formatting in one would give you different results than formatting in the other.

This brings them up to the same version.