### PR TITLE
Add optional param for getting a metacard w/ storeId

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -259,7 +259,7 @@ public class MetacardApplication implements SparkApplication {
         "/metacard/:id",
         (req, res) -> {
           String id = req.params(":id");
-          String storeId = Optional.ofNullable(req.queryParams("storeId")).orElse(null);
+          String storeId = req.queryParams("storeId");
           return util.metacardToJson(id, storeId);
         });
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -259,7 +259,8 @@ public class MetacardApplication implements SparkApplication {
         "/metacard/:id",
         (req, res) -> {
           String id = req.params(":id");
-          return util.metacardToJson(id);
+          String storeId = Optional.ofNullable(req.queryParams("storeId")).orElse(null);
+          return util.metacardToJson(id, storeId);
         });
 
     get(

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -50,6 +50,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -178,12 +179,23 @@ public class EndpointUtil implements EndpointUtility {
 
   public Metacard getMetacardById(String id)
       throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    return getMetacardById(id, null);
+  }
+
+  public Metacard getMetacardById(String id, String storeId)
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    Collection<String> storeIds;
+    if (storeId == null) {
+      storeIds = null;
+    } else {
+      storeIds = Arrays.asList(storeId);
+    }
     Filter idFilter = filterBuilder.attribute(Core.ID).is().equalTo().text(id);
     Filter tagsFilter = filterBuilder.attribute(Core.METACARD_TAGS).is().like().text("*");
     Filter filter = filterBuilder.allOf(idFilter, tagsFilter);
 
     QueryResponse queryResponse =
-        catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter), false));
+        catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter), storeIds));
 
     if (queryResponse.getResults().isEmpty()) {
       throw new NotFoundException("Could not find metacard for id: " + id);
@@ -509,9 +521,9 @@ public class EndpointUtil implements EndpointUtility {
     return outerMap;
   }
 
-  public String metacardToJson(String id)
+  public String metacardToJson(String id, String storeId)
       throws SourceUnavailableException, UnsupportedQueryException, FederationException {
-    return metacardToJson(getMetacardById(id));
+    return metacardToJson(getMetacardById(id, storeId));
   }
 
   public String metacardToJson(Metacard metacard) {


### PR DESCRIPTION
To test: 
Using postman, make sure /internal/metacard/${id} is still working without an optional param.
Make sure /internal/metacard/${id}?storeId=${storeId} works.