### PR TITLE
Add timezone-compatible date pickers

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -25,7 +25,7 @@ type Props = {
   /**
    * Override if you absolutely must
    */
-  BPDateRangeProps?: IDateRangeInputProps
+  BPDateRangeProps?: Partial<IDateRangeInputProps>
 }
 
 const validateShape = ({ value, onChange }: Props) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -17,9 +17,7 @@ import { DateRangeInput, IDateRangeInputProps } from '@blueprintjs/datetime'
 import { DateHelpers } from './date-helpers'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
-// @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
-import user from '../singletons/user-instance'
-import { useBackbone } from '../selection-checkbox/useBackbone.hook'
+import useTimePrefs from './useTimePrefs'
 
 type Props = {
   value: ValueTypes['during']
@@ -48,19 +46,9 @@ export const DateRangeField = ({
   onChange,
   BPDateRangeProps,
 }: Props) => {
-  const { listenTo } = useBackbone()
-  const [, setForceRender] = React.useState(Math.random())
+  useTimePrefs()
   React.useEffect(() => {
     validateShape({ value, onChange, BPDateRangeProps })
-  }, [])
-  React.useEffect(() => {
-    listenTo(
-      user.getPreferences(),
-      'change:dateTimeFormat change:timeZone',
-      () => {
-        setForceRender(Math.random())
-      }
-    )
   }, [])
   return (
     <DateRangeInput

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
@@ -1,0 +1,176 @@
+import * as React from 'react'
+import { useState, useRef } from 'react'
+import {
+  DatePicker,
+  IDateInputProps,
+  IDatePickerProps,
+} from '@blueprintjs/datetime'
+import { DateHelpers } from './date-helpers'
+import { MuiOutlinedInputBorderClasses } from '../theme/theme'
+import TextField, { TextFieldProps } from '@material-ui/core/TextField'
+import InputAdornment from '@material-ui/core/InputAdornment'
+import IconButton from '@material-ui/core/IconButton'
+import CalendarIcon from '@material-ui/icons/Event'
+import Popover from '@material-ui/core/Popover'
+import useTimePrefs from './useTimePrefs'
+
+type DateFieldProps = {
+  value: string
+  onChange: (value: string) => void
+  disabled?: TextFieldProps['disabled']
+  variant?: TextFieldProps['variant']
+  error?: TextFieldProps['error']
+  helperText?: TextFieldProps['helperText']
+  label?: TextFieldProps['label']
+  disableShortcuts?: boolean
+  margin?: TextFieldProps['margin']
+  style?: React.CSSProperties
+  /**
+   * Override if you absolutely must
+   */
+  BPDateProps?: IDatePickerProps
+}
+
+const validateShape = ({ value, onChange }: DateFieldProps) => {
+  if (DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
+    onChange(new Date().toISOString())
+  }
+}
+
+const formatInputValue = (value: string) => {
+  if (value) {
+    const date = DateHelpers.Blueprint.commonProps.parseDate(value)
+    return DateHelpers.Blueprint.commonProps.formatDate(date!)
+  } else {
+    return '' // This allows us to display an empty state without label overlap
+  }
+}
+
+/**
+ * DateTimePicker that combines Mui TextField with BlueprintJs DatePicker
+ * @displayValue - the display text that is shown by the TextField. Anytime a valid date is input into the TextField, the value is updated
+ * @value - the value that holds the date. Often converted into a "TimeShiftedIso" to deal with the fact that Dates don't hold timezone data
+ * @isInternalChange - determines whether the updated value came from inside or outside the component
+ */
+const DateTimePicker = ({
+  value,
+  onChange,
+  disabled,
+  variant,
+  error,
+  helperText,
+  label,
+  disableShortcuts,
+  margin,
+  style,
+  BPDateProps,
+}: DateFieldProps) => {
+  useTimePrefs()
+  const [displayValue, setDisplayValue] = useState(formatInputValue(value))
+  const [isInternalChange, setIsInternalChange] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const dateIconRef = useRef<HTMLButtonElement | null>(null)
+
+  React.useEffect(() => {
+    validateShape({ onChange, value })
+  }, [])
+
+  React.useEffect(() => {
+    if (isInternalChange) {
+      setIsInternalChange(false)
+    } else {
+      // If the value is updated externally (i.e. a new value is passed into the component),
+      // then we need to update the display value.
+      // This allows us to keep the displayValue and value separate
+      // and type in the TextField without being hijacked
+      setDisplayValue(formatInputValue(value))
+    }
+  }, [value])
+
+  const generateOnChange = (onChange: (value: string) => void) => {
+    return ((selectedDate, isUserChange) => {
+      if (onChange && selectedDate && isUserChange) {
+        setIsInternalChange(true)
+        setDisplayValue(
+          DateHelpers.Blueprint.commonProps.formatDate(selectedDate)
+        )
+        onChange(
+          DateHelpers.Blueprint.converters.TimeshiftedDateToISO(selectedDate)
+        )
+      }
+    }) as IDateInputProps['onChange']
+  }
+
+  const dateIsValid = (value: string) => {
+    const generatedDate = DateHelpers.Blueprint.DateProps.generateValue(value)
+    return DateHelpers.Blueprint.commonProps.isValid(generatedDate)
+  }
+
+  return (
+    <>
+      <TextField
+        onChange={(e) => {
+          setDisplayValue(e.target.value)
+          if (dateIsValid(e.target.value)) {
+            onChange(e.target.value)
+            setIsInternalChange(true)
+          }
+        }}
+        onClick={() => setAnchorEl(dateIconRef.current)}
+        disabled={disabled}
+        label={label || 'Date'}
+        margin={margin}
+        value={displayValue}
+        variant={variant}
+        style={style}
+        error={error}
+        helperText={helperText}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                ref={dateIconRef}
+                disabled={disabled}
+                onClick={() => setAnchorEl(dateIconRef.current)}
+              >
+                <CalendarIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        disableAutoFocus={true}
+        disableEnforceFocus={true}
+      >
+        <DatePicker
+          key="picker"
+          className={MuiOutlinedInputBorderClasses}
+          onChange={generateOnChange(onChange)}
+          shortcuts={!disableShortcuts}
+          timePrecision="minute"
+          // @ts-ignore this allows an empty picker
+          value={
+            value === undefined
+              ? value
+              : DateHelpers.Blueprint.DateProps.generateValue(value)
+          }
+          {...BPDateProps}
+        />
+      </Popover>
+    </>
+  )
+}
+
+export default DateTimePicker

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
@@ -82,9 +82,9 @@ const DateTimePicker = ({
             className="cursor-pointer"
             position="end"
             onClick={() => {
-                if (inputRef.current) {
-                  inputRef.current.focus()
-                }
+              if (inputRef.current) {
+                inputRef.current.focus()
+              }
             }}
           >
             <CalendarIcon

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
@@ -35,6 +35,7 @@ const DateTimePicker = ({
   TextFieldProps,
   BPDateProps,
 }: DateFieldProps) => {
+  const inputRef = React.useRef<HTMLInputElement>()
   /**
    * We want to avoid causing the TextField below to percieve a change to inputComponent when possible, because that mucks with focus.
    *
@@ -73,10 +74,19 @@ const DateTimePicker = ({
       InputLabelProps={{ shrink: true }}
       value={value}
       onChange={onChange as any}
+      inputRef={inputRef}
       InputProps={{
         inputComponent: inputComponent,
         endAdornment: (
-          <InputAdornment position="end">
+          <InputAdornment
+            className="cursor-pointer"
+            position="end"
+            onClick={() => {
+                if (inputRef.current) {
+                  inputRef.current.focus()
+                }
+            }}
+          >
             <CalendarIcon
               className={
                 TextFieldProps?.variant === 'outlined' ? 'mr-1' : 'mr-4'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-time-picker.tsx
@@ -56,6 +56,9 @@ const DateTimePicker = ({
           BPDateProps={{
             ...BPDateProps,
             className: classes,
+            inputProps: {
+              inputRef: props.inputRef,
+            },
           }}
         />
       )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -27,11 +27,11 @@ type DateFieldProps = {
   /**
    * Override if you absolutely must
    */
-  BPDateProps?: IDateInputProps
+  BPDateProps?: Partial<IDateInputProps>
 }
 
 const validateShape = ({ value, onChange }: DateFieldProps) => {
-  if (!value || DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
+  if (DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
     onChange(new Date().toISOString())
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -19,7 +19,7 @@ import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
 import user from '../singletons/user-instance'
 import { DateHelpers } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
-import { useBackbone } from '../selection-checkbox/useBackbone.hook'
+import useTimePrefs from './useTimePrefs'
 
 type DateFieldProps = {
   value: string
@@ -31,25 +31,15 @@ type DateFieldProps = {
 }
 
 const validateShape = ({ value, onChange }: DateFieldProps) => {
-  if (DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
+  if (!value || DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
     onChange(new Date().toISOString())
   }
 }
 
 export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
-  const { listenTo } = useBackbone()
-  const [, setForceRender] = React.useState(Math.random())
+  useTimePrefs()
   React.useEffect(() => {
     validateShape({ onChange, value })
-  }, [])
-  React.useEffect(() => {
-    listenTo(
-      user.getPreferences(),
-      'change:dateTimeFormat change:timeZone',
-      () => {
-        setForceRender(Math.random())
-      }
-    )
   }, [])
 
   return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+import { useBackbone } from '../selection-checkbox/useBackbone.hook'
+// @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
+import user from '../singletons/user-instance'
+
+const useTimePrefs = () => {
+  const { listenTo } = useBackbone()
+  const [, setForceRender] = useState(Math.random())
+
+  useEffect(() => {
+    listenTo(
+      user.getPreferences(),
+      'change:dateTimeFormat change:timeZone',
+      () => {
+        setForceRender(Math.random())
+      }
+    )
+  }, [])
+}
+
+export default useTimePrefs

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -15,15 +15,11 @@ import { useDialog } from '@connexta/atlas/atoms/dialog'
 import DialogActions from '@material-ui/core/DialogActions'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogContent from '@material-ui/core/DialogContent'
-import { KeyboardDateTimePicker } from '@connexta/atlas/atoms/pickers'
-import { getDateTimeFormat } from '../../user/utils'
 import useSnack from '../../hooks/useSnack'
 import LinearProgress from '@material-ui/core/LinearProgress'
 const $ = require('jquery')
 const ResultUtils = require('../../../js/ResultUtils.js')
 import PublishIcon from '@material-ui/icons/Publish'
-// @ts-ignore ts-migrate(6133) FIXME: 'AutoSizer' is declared but its value is never rea... Remove this comment to see the full error message
-import AutoSizer from 'react-virtualized-auto-sizer'
 import Paper from '@material-ui/core/Paper'
 import useTheme from '@material-ui/core/styles/useTheme'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
@@ -33,74 +29,11 @@ import TransferList from './transfer-list'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
 import AddIcon from '@material-ui/icons/Add'
 import Box from '@material-ui/core/Box'
-// @ts-ignore ts-migrate(6133) FIXME: 'dark' is declared but its value is never read.
-import { Elevations, dark, light } from '../../theme/theme'
+import { Elevations } from '../../theme/theme'
 import { DarkDivider } from '../../dark-divider/dark-divider'
 import { displayHighlightedAttrInFull } from './highlightUtil'
+import DateTimePicker from '../../fields/date-time-picker'
 import Geometry from '../../../react-component/input-wrappers/geometry'
-//metacardDefinitions.metacardTypes[attribute].type
-//metacardDefinitions.metacardTypes[attribute].multivalued
-//properties.isReadOnly(attribute)
-//properties.attributeAliases[attribute]
-//metacardDefinitions.validation[attribute]
-//metacardDefinitions.enums[attribute]
-//properties.requiredAttributes.includes(property)
-//metacardDefinitions.isHiddenTypeExceptThumbnail(property)
-/**
- *  _setCalculatedType() {
-    let calculatedType
-
-    switch (this.get('type')) {
-      case 'DATE':
-        calculatedType = 'date'
-        break
-      case 'TIME':
-        calculatedType = 'time'
-        break
-      case 'BINARY':
-        calculatedType = 'thumbnail'
-        break
-      case 'LOCATION':
-        calculatedType = 'location'
-        break
-      case 'TEXTAREA':
-        calculatedType = 'textarea'
-        break
-      case 'BOOLEAN':
-        calculatedType = 'boolean'
-        break
-      case 'LONG':
-      case 'DOUBLE':
-      case 'FLOAT':
-      case 'INTEGER':
-      case 'SHORT':
-        calculatedType = 'number'
-        break
-      case 'RANGE':
-        calculatedType = 'range'
-        break
-      case 'GEOMETRY':
-        calculatedType = 'geometry'
-        break
-      case 'AUTOCOMPLETE':
-        calculatedType = 'autocomplete'
-        break
-      case 'COLOR':
-        calculatedType = 'color'
-        break
-      case 'NEAR':
-        calculatedType = 'near'
-        break
-      case 'PASSWORD':
-        calculatedType = 'password'
-        break
-      case 'STRING':
-      case 'XML':
-      default:
-        calculatedType = 'text'
-        break
-    }
- */
 
 function getSummaryShown(): string[] {
   const userchoices = user
@@ -251,21 +184,17 @@ export const Editor = ({
                   switch (attrType) {
                     case 'DATE':
                       return (
-                        <KeyboardDateTimePicker
-                          disabled={mode !== Mode.Normal}
+                        <DateTimePicker
+                          disabled={mode === Mode.Normal}
                           value={val}
-                          onChange={(e: any) => {
-                            values[index] = e.toISOString()
+                          onChange={(value) => {
+                            values[index] = value
                             setValues([...values])
                           }}
-                          DialogProps={{
-                            disablePortal: true,
-                            style: {
-                              minWidth: '500px',
-                            },
+                          style={{
+                            minWidth: '500px',
                           }}
-                          format={getDateTimeFormat()}
-                          fullWidth
+                          label={label}
                         />
                       )
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -185,16 +185,19 @@ export const Editor = ({
                     case 'DATE':
                       return (
                         <DateTimePicker
-                          disabled={mode === Mode.Normal}
                           value={val}
                           onChange={(value) => {
                             values[index] = value
                             setValues([...values])
                           }}
-                          style={{
-                            minWidth: '500px',
+                          TextFieldProps={{
+                            disabled: mode !== Mode.Normal,
+                            label: label,
+                            variant: 'outlined',
                           }}
-                          label={label}
+                          BPDateProps={{
+                            disabled: mode !== Mode.Normal,
+                          }}
                         />
                       )
 
@@ -657,6 +660,7 @@ const Summary = ({ selectionInterface }: Props) => {
                     elevation: Elevations.panels,
                   },
                   open: true,
+                  disableEnforceFocus: true, // otherwise we can't click inside 3rd party libraries using portals (like date picker from blueprint)
                   children: (
                     <div
                       style={{


### PR DESCRIPTION
Add the timezone-compatible pickers and utilities that Andrew made as well as one with a MUI TextField. Replaces KeyBoardDatePickers.

The first commit has already been reviewed in #413 

Instructions for testing are downstream