### PR TITLE
Add dropdown for editing enumerated types on metacards

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -6,6 +6,7 @@ import Button from '@material-ui/core/Button'
 const user = require('../../singletons/user-instance')
 const properties = require('../../../js/properties.js')
 import TypedMetacardDefs from './metacardDefinitions'
+import Autocomplete from '@material-ui/lab/Autocomplete'
 import Checkbox from '@material-ui/core/Checkbox'
 import Divider from '@material-ui/core/Divider'
 const Common = require('../../../js/Common.js')
@@ -217,12 +218,13 @@ export const Editor = ({
   const [mode, setMode] = React.useState(Mode.Normal)
   const [values, setValues] = React.useState(
     Array.isArray(lazyResult.plain.metacard.properties[attr])
-      ? lazyResult.plain.metacard.properties[attr]
+      ? lazyResult.plain.metacard.properties[attr].slice(0)
       : [lazyResult.plain.metacard.properties[attr]]
   )
   const label = TypedMetacardDefs.getAlias({ attr })
   const isMultiValued = TypedMetacardDefs.isMulti({ attr })
   const attrType = TypedMetacardDefs.getType({ attr })
+  const enumForAttr = TypedMetacardDefs.getEnum({ attr: attr })
   const addSnack = useSnack()
 
   return (
@@ -244,10 +246,30 @@ export const Editor = ({
       <DialogContent style={{ minHeight: '30em', minWidth: '60vh' }}>
         {values.map((val: any, index: number) => {
           return (
-            <Grid container direction="row">
+            <Grid container direction="row" className="my-2">
               {index !== 0 ? <Divider style={{ margin: '5px 0px' }} /> : null}
               <Grid item md={11}>
                 {(() => {
+                  if (enumForAttr) {
+                    return (
+                      <Autocomplete
+                        disabled={mode === 'saving'}
+                        value={val}
+                        onChange={(_e: any, newValue: string) => {
+                          values[index] = newValue
+                          setValues([...values])
+                        }}
+                        // @ts-ignore fullWidth does exist on Autocomplete
+                        fullWidth
+                        disableClearable
+                        size="small"
+                        options={enumForAttr}
+                        renderInput={(params) => (
+                          <TextField {...params} variant="outlined" />
+                        )}
+                      />
+                    )
+                  }
                   switch (attrType) {
                     case 'DATE':
                       return (
@@ -268,7 +290,6 @@ export const Editor = ({
                           fullWidth
                         />
                       )
-
                     case 'BINARY':
                       return (
                         <ThumbnailInput


### PR DESCRIPTION
Adds a dropdown for editing enumerated types on metacards.

![image](https://user-images.githubusercontent.com/6109231/96631294-21921f80-12e4-11eb-8d83-264fdbe1e6c5.png)

How to Test:
1. Build and run DDF.
1. Build this PR and follow the instructions in https://github.com/codice/ddf-ui/blob/master/README.md to install the catalog-ui.
1. Select a metacard and try to edit an attribute that is an enumerated type. (ex: datatype, country code, etc.)
1. Verify that a dropdown appears instead of a text field.