### PR TITLE
Fixes UI crashing issues with query basic time

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
@@ -22,7 +22,7 @@ const validateShape = ({ value, onChange }: Props) => {
 }
 
 const isInvalid = ({ value }: Props) => {
-  return value.last === undefined || value.unit === undefined
+  return value === undefined || value.last === undefined || value.unit === undefined
 }
 
 export const DateRelativeField = ({ value, onChange }: Props) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/home.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/home.tsx
@@ -174,6 +174,7 @@ const LeftTop = ({ selectionInterface }: { selectionInterface: any }) => {
           color="primary"
           size="small"
           onClick={() => {
+            selectionInterface.getCurrentQuery().trigger('update')
             selectionInterface.getCurrentQuery().startSearchFromFirstPage()
           }}
         >

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
@@ -107,6 +107,9 @@ function isTypeLimiter(filter: any) {
 
 // strip extra quotes
 const stripQuotes = (property: any) => {
+  if(property === undefined){
+    return ''
+  }
   return property.replace(/^"(.+(?="$))"$/, '$1')
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -35,6 +35,9 @@ export const getFilteredAttributeList = () => {
 }
 
 export const getAttributeType = (attribute: string): string => {
+  if(attribute === undefined) {
+    return ''
+  }
   const type = metacardDefinitions.metacardTypes[attribute].type
   if (type === 'GEOMETRY') return 'LOCATION'
   if (isIntegerType(type)) return 'INTEGER'


### PR DESCRIPTION
To test:
1. Make sure UI doesn't crash when selecting relative time query in Basic Search
2. Create a new basic query and select time, delete all of the attributes (e.g. created, modified, etc.) verify the UI doesn't crash
3. Verify that modifying time filter actually performs the query. 