### PR TITLE
Bump snapshot version from 4.0.0-SNAPSHOT to 4.1.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Welcome to ddf-ui, the home of Intrigue. 
 
 ## Installing in DDF
-Note: Change `3.7.0-SNAPSHOT` to the desired or most recent version of ddf-ui. 
+Note: Change `4.1.0-SNAPSHOT` to the desired or most recent version of ddf-ui. 
 
 1. Inside of a DDF karaf console run the following commands:
     ```
-    feature:repo-add mvn:org.codice.ddf.search/intrigue-ui-app/3.7.0-SNAPSHOT/xml/features
+    feature:repo-add mvn:org.codice.ddf.search/intrigue-ui-app/4.1.0-SNAPSHOT/xml/features
     ```
     ```
     feature:install catalog-ui-app
@@ -15,7 +15,7 @@ Note: Change `3.7.0-SNAPSHOT` to the desired or most recent version of ddf-ui.
     This will add the backend repo and then install the app.
 
     ```
-    feature:repo-add mvn:org.codice.ddf.search/ui-frontend/3.7.0-SNAPSHOT/xml/features
+    feature:repo-add mvn:org.codice.ddf.search/ui-frontend/4.1.0-SNAPSHOT/xml/features
     ```
     ```
     feature:install ui-frontend
@@ -23,7 +23,7 @@ Note: Change `3.7.0-SNAPSHOT` to the desired or most recent version of ddf-ui.
     This will add the frontend repo and then install the app.
 2. (Optional) Add the following bundle to `bundleLocations` in `etc/application-definitions/search-ui.json`:
     ```
-    "mvn:org.codice.ddf.search/catalog-ui-search/3.7.0-SNAPSHOT"
+    "mvn:org.codice.ddf.search/catalog-ui-search/4.1.0-SNAPSHOT"
     ```
     This configures the Intrigue configurations to appear under the `Search UI` app in the DDF Admin Console.
 3. (Optional) Add a configuration file at `etc/org.codice.ddf.ui.searchui.filter.RedirectServlet.config` with the following contents:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <name>DDF :: UI</name>
   <artifactId>catalog-ui</artifactId>
   <groupId>org.codice.ddf.search</groupId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <organization>
     <name>Codice Foundation</name>

--- a/ui-backend/audit/audit-api/pom.xml
+++ b/ui-backend/audit/audit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-application/pom.xml
+++ b/ui-backend/audit/audit-application/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-logging/pom.xml
+++ b/ui-backend/audit/audit-logging/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/pom.xml
+++ b/ui-backend/audit/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>
     <artifactId>audit</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <name>DDF :: Catalog :: UI :: Audit</name>
 
     <modules>

--- a/ui-backend/catalog-ui-enumeration/pom.xml
+++ b/ui-backend/catalog-ui-enumeration/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
 

--- a/ui-backend/catalog-ui-oauth/pom.xml
+++ b/ui-backend/catalog-ui-oauth/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ui-backend/catalog-ui-search-api/pom.xml
+++ b/ui-backend/catalog-ui-search-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-search-api</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search API</name>

--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-search</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search</name>

--- a/ui-backend/catalog-ui-splitter/pom.xml
+++ b/ui-backend/catalog-ui-splitter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-splitter</artifactId>
     <name>DDF :: Catalog :: UI :: Splitter</name>

--- a/ui-backend/intrigue-ui-app/pom.xml
+++ b/ui-backend/intrigue-ui-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: UI :: Search UI :: App</name>

--- a/ui-backend/javalin-utils/pom.xml
+++ b/ui-backend/javalin-utils/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>javalin-utils</artifactId>

--- a/ui-backend/pom.xml
+++ b/ui-backend/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>catalog-ui</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>
     <artifactId>backend</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-ui</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>


### PR DESCRIPTION
4.0.0 was released, and the 4.0.x branch is using 4.0.1-SNAPSHOT.