### PR TITLE
Add a default for the optional sorts parameter when exporting multiple results

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -145,6 +145,7 @@ class ResultsExport extends React.Component<Props, State> {
       response = await exportResultSet('zipCompression', {
         searches,
         count,
+        sorts: [],
         args: {
           transformerId: uriEncodedTransformerId,
         },
@@ -153,6 +154,7 @@ class ResultsExport extends React.Component<Props, State> {
       response = await exportResultSet(uriEncodedTransformerId, {
         searches,
         count,
+        sorts: []
       })
     } else {
       const result = this.props.results[0]

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -154,7 +154,7 @@ class ResultsExport extends React.Component<Props, State> {
       response = await exportResultSet(uriEncodedTransformerId, {
         searches,
         count,
-        sorts: []
+        sorts: [],
       })
     } else {
       const result = this.props.results[0]

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -30,7 +30,7 @@ export type ResultSet = {
 export type ExportBody = {
   searches: ResultSet[]
   count: number
-  sorts?: Object[]
+  sorts: Object[]
   args?: Object
 }
 
@@ -96,7 +96,7 @@ export const exportResultSet = async (
 ) => {
   return await fetch(`./internal/cql/transform/${transformer}`, {
     method: 'POST',
-    body: JSON.stringify({ ...body, sorts: body.sorts || [] }),
+    body: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json',
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -96,7 +96,7 @@ export const exportResultSet = async (
 ) => {
   return await fetch(`./internal/cql/transform/${transformer}`, {
     method: 'POST',
-    body: JSON.stringify(body),
+    body: JSON.stringify({ ...body, sorts: body.sorts || [] }),
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
This PR fixes a regression where exporting results fails with a 500 error and this exception in the logs
```
10:38:57,933 | ERROR | tp100990966-1029 | spark.http.matching.GeneralError           55 | catalog-ui-search    |
java.lang.NullPointerException: null
	at org.codice.ddf.catalog.ui.query.cql.QueryRequestBuilder.build(QueryRequestBuilder.java:164) ~[bundleFile:?]
	at org.codice.ddf.catalog.ui.query.cql.CqlRequestImpl.createQueryRequest(CqlRequestImpl.java:207) ~[bundleFile:?]
	at org.codice.ddf.catalog.ui.util.CqlQueriesImpl.executeCqlQuery(CqlQueriesImpl.java:95) ~[bundleFile:?]
	at org.codice.ddf.catalog.ui.query.handlers.CqlTransformHandler.lambda$handle$3(CqlTransformHandler.java:240) ~[bundleFile:?]
	...
	at org.codice.ddf.catalog.ui.query.handlers.CqlTransformHandler.handle(CqlTransformHandler.java:252) ~[bundleFile:?]
	...
```

I'm not sure if the best solution is to handle a `null` value for `sorts` in the backend java code or to make sure that a null is not sent to the backend. I chose to make sure that `sorts` is populated in the request to the backend so that this NPE doesn't occur.

#### REST request body before
```json
{
  "searches": [
    {
      "srcs": [
        "ISRI"
      ],
      "cql": "(((\"id\" ILIKE 'f6d28b05-be2c-4765-b49c-2d6bbd742f2b')) OR ((\"id\" ILIKE '0c234d7a-0071-4c6f-8033-965aca44327b')))",
      "count": 2
    }
  ],
  "count": 2
}
```

#### REST request body after this PR
```json
{
  "searches": [
    {
      "srcs": [
        "ISRI"
      ],
      "cql": "(((\"id\" ILIKE '0c234d7a-0071-4c6f-8033-965aca44327b')) OR ((\"id\" ILIKE 'f6d28b05-be2c-4765-b49c-2d6bbd742f2b')))",
      "count": 2
    }
  ],
  "count": 2,
  "sorts": []
}
```

### Steps to reproduce:
1. Ctrl+click to select multiple results
2. Use the `Export as` option

![image](https://user-images.githubusercontent.com/8041246/97610975-cee6f080-19d2-11eb-8216-69a015d4f47e.png)