### PR TITLE
Fix NPE when sorting is not specified

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestBuilder.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/QueryRequestBuilder.java
@@ -27,6 +27,7 @@ import ddf.catalog.operation.impl.FacetedQueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.TermFacetPropertiesImpl;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -160,14 +161,16 @@ public class QueryRequestBuilder {
   public QueryRequest build() throws CqlParseException {
 
     List<SortBy> sortBys =
-        sorts
-            .stream()
-            .filter(
-                s ->
-                    StringUtils.isNotEmpty(s.getAttribute())
-                        && StringUtils.isNotEmpty(s.getDirection()))
-            .map(s -> parseSort(s.getAttribute(), s.getDirection()))
-            .collect(Collectors.toList());
+        sorts == null
+            ? new ArrayList<>()
+            : sorts
+                .stream()
+                .filter(
+                    s ->
+                        StringUtils.isNotEmpty(s.getAttribute())
+                            && StringUtils.isNotEmpty(s.getDirection()))
+                .map(s -> parseSort(s.getAttribute(), s.getDirection()))
+                .collect(Collectors.toList());
     if (sortBys.isEmpty()) {
       sortBys.add(new SortByImpl(Result.TEMPORAL, DEFAULT_SORT_ORDER));
     }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -350,6 +350,9 @@ public class CqlTransformHandler implements Route {
 
   private CollectionResultComparator getResultComparators(List<CqlRequest.Sort> sorts) {
     CollectionResultComparator resultComparator = new CollectionResultComparator();
+    if (sorts == null) {
+      return resultComparator;
+    }
     for (CqlRequest.Sort sort : sorts) {
       Comparator<Result> comparator;
 


### PR DESCRIPTION
If a query request does not have specify the sorting, then an NPE can occur. This PR addresses two locations where that NPE can happen.