### PR TITLE
Adds more granularity to RELATIVE temporal search and adds AROUND temporal search type

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { DateInput } from '@blueprintjs/datetime'
+
+// @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
+import user from '../singletons/user-instance'
+import { DateHelpers } from './date-helpers'
+import { MuiOutlinedInputBorderClasses } from '../theme/theme'
+import useTimePrefs from './useTimePrefs'
+import { ValueTypes } from '../filter-builder/filter.structure'
+import Grid from '@material-ui/core/Grid/Grid'
+import { NumberField } from './number'
+import TextField from '@material-ui/core/TextField/TextField'
+import MenuItem from '@material-ui/core/MenuItem/MenuItem'
+
+type DateAroundProps = {
+  value: ValueTypes['around']
+  onChange: (val: ValueTypes['around']) => void
+}
+
+const defaultValue = {
+  date: new Date().toISOString(),
+  buffer: {
+    amount: '1',
+    unit: 'd'
+  }
+} as ValueTypes['around']
+
+const validateShape = ({ value, onChange }: DateAroundProps) => {
+  if (!value.date || !value.buffer || DateHelpers.Blueprint.commonProps.parseDate(value.date) === null) {
+    onChange(defaultValue)
+  }
+}
+
+export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
+  const [date, setDate] = React.useState(new Date().toISOString())
+
+  useTimePrefs()
+  React.useEffect(() => {
+    validateShape({ onChange, value })
+  }, [])
+  React.useEffect(() => {
+    onChange({
+      ...defaultValue,
+      ...value,
+      date: date
+    })
+  }, [date])
+
+  return (
+      <Grid
+      container
+      alignItems="stretch"
+      direction="column"
+      wrap="nowrap"
+    >
+      <Grid item className="w-full pb-2">
+      <DateInput
+        className={MuiOutlinedInputBorderClasses}
+        closeOnSelection={false}
+        fill
+        formatDate={DateHelpers.Blueprint.commonProps.formatDate}
+        onChange={DateHelpers.Blueprint.DateProps.generateOnChange(setDate)}
+        parseDate={DateHelpers.Blueprint.commonProps.parseDate}
+        placeholder={'M/D/YYYY'}
+        shortcuts
+        timePrecision="minute"
+        {...(value.date
+          ? {
+              value: DateHelpers.Blueprint.DateProps.generateValue(value.date),
+            }
+          : {})}
+      />
+      </Grid>
+      <Grid item className="w-full pb-2">
+        with buffer of
+      </Grid>
+      <Grid container direction="row" className="w-full">
+      <Grid item xs={4} className="pb-2">
+        <NumberField
+          type="float"
+          onChange={(val) => {
+            if (onChange)
+              onChange({
+                ...defaultValue,
+                ...value,
+                buffer: {
+                  ...defaultValue.buffer,
+                  ...value.buffer,
+                  amount: val
+                }
+              })
+          }}
+          {...(value.buffer
+            ? {
+                value: value.buffer.amount
+              }
+            : {})}
+        />
+      </Grid>
+      <Grid item xs={8} className="pl-2">
+        <TextField
+          fullWidth
+          variant="outlined"
+          select
+          onChange={(e) => {
+            if (onChange)
+              onChange({
+                ...defaultValue,
+                ...value,
+                buffer: {
+                  ...defaultValue.buffer,
+                  ...value.buffer,
+                  unit: e.target.value as ValueTypes['around']['buffer']['unit'],
+                }
+              })
+          }}
+          size="small"
+          {
+            ...(value.buffer ? {
+              value: value.buffer.unit
+            } : {value: 'd'})
+          }
+        >
+          <MenuItem value="s">Seconds</MenuItem>
+          <MenuItem value="m">Minutes</MenuItem>
+          <MenuItem value="h">Hours</MenuItem>
+          <MenuItem value="d">Days</MenuItem>
+          <MenuItem value="w">Weeks</MenuItem>
+          <MenuItem value="M">Months</MenuItem>
+          <MenuItem value="y">Years</MenuItem>
+        </TextField>
+      </Grid>
+    </Grid>
+    </Grid>
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -35,12 +35,16 @@ const defaultValue = {
   date: new Date().toISOString(),
   buffer: {
     amount: '1',
-    unit: 'd'
-  }
+    unit: 'd',
+  },
 } as ValueTypes['around']
 
 const validateShape = ({ value, onChange }: DateAroundProps) => {
-  if (!value.date || !value.buffer || DateHelpers.Blueprint.commonProps.parseDate(value.date) === null) {
+  if (
+    !value.date ||
+    !value.buffer ||
+    DateHelpers.Blueprint.commonProps.parseDate(value.date) === null
+  ) {
     onChange(defaultValue)
   }
 }
@@ -56,95 +60,93 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
     onChange({
       ...defaultValue,
       ...value,
-      date: date
+      date: date,
     })
   }, [date])
 
   return (
-      <Grid
-      container
-      alignItems="stretch"
-      direction="column"
-      wrap="nowrap"
-    >
+    <Grid container alignItems="stretch" direction="column" wrap="nowrap">
       <Grid item className="w-full pb-2">
-      <DateInput
-        className={MuiOutlinedInputBorderClasses}
-        closeOnSelection={false}
-        fill
-        formatDate={DateHelpers.Blueprint.commonProps.formatDate}
-        onChange={DateHelpers.Blueprint.DateProps.generateOnChange(setDate)}
-        parseDate={DateHelpers.Blueprint.commonProps.parseDate}
-        placeholder={'M/D/YYYY'}
-        shortcuts
-        timePrecision="minute"
-        {...(value.date
-          ? {
-              value: DateHelpers.Blueprint.DateProps.generateValue(value.date),
-            }
-          : {})}
-      />
+        <DateInput
+          className={MuiOutlinedInputBorderClasses}
+          closeOnSelection={false}
+          fill
+          formatDate={DateHelpers.Blueprint.commonProps.formatDate}
+          onChange={DateHelpers.Blueprint.DateProps.generateOnChange(setDate)}
+          parseDate={DateHelpers.Blueprint.commonProps.parseDate}
+          placeholder={'M/D/YYYY'}
+          shortcuts
+          timePrecision="minute"
+          {...(value.date
+            ? {
+                value: DateHelpers.Blueprint.DateProps.generateValue(
+                  value.date
+                ),
+              }
+            : {})}
+        />
       </Grid>
       <Grid item className="w-full pb-2">
         with buffer of
       </Grid>
       <Grid container direction="row" className="w-full">
-      <Grid item xs={4} className="pb-2">
-        <NumberField
-          type="float"
-          onChange={(val) => {
-            if (onChange)
-              onChange({
-                ...defaultValue,
-                ...value,
-                buffer: {
-                  ...defaultValue.buffer,
-                  ...value.buffer,
-                  amount: val
+        <Grid item xs={4} className="pb-2">
+          <NumberField
+            type="float"
+            onChange={(val) => {
+              if (onChange)
+                onChange({
+                  ...defaultValue,
+                  ...value,
+                  buffer: {
+                    ...defaultValue.buffer,
+                    ...value.buffer,
+                    amount: val,
+                  },
+                })
+            }}
+            {...(value.buffer
+              ? {
+                  value: value.buffer.amount,
                 }
-              })
-          }}
-          {...(value.buffer
-            ? {
-                value: value.buffer.amount
-              }
-            : {})}
-        />
-      </Grid>
-      <Grid item xs={8} className="pl-2">
-        <TextField
-          fullWidth
-          variant="outlined"
-          select
-          onChange={(e) => {
-            if (onChange)
-              onChange({
-                ...defaultValue,
-                ...value,
-                buffer: {
-                  ...defaultValue.buffer,
-                  ...value.buffer,
-                  unit: e.target.value as ValueTypes['around']['buffer']['unit'],
+              : {})}
+          />
+        </Grid>
+        <Grid item xs={8} className="pl-2">
+          <TextField
+            fullWidth
+            variant="outlined"
+            select
+            onChange={(e) => {
+              if (onChange)
+                onChange({
+                  ...defaultValue,
+                  ...value,
+                  buffer: {
+                    ...defaultValue.buffer,
+                    ...value.buffer,
+                    unit: e.target
+                      .value as ValueTypes['around']['buffer']['unit'],
+                  },
+                })
+            }}
+            size="small"
+            {...(value.buffer
+              ? {
+                  value: value.buffer.unit,
                 }
-              })
-          }}
-          size="small"
-          {
-            ...(value.buffer ? {
-              value: value.buffer.unit
-            } : {value: 'd'})
-          }
-        >
-          <MenuItem value="s">Seconds</MenuItem>
-          <MenuItem value="m">Minutes</MenuItem>
-          <MenuItem value="h">Hours</MenuItem>
-          <MenuItem value="d">Days</MenuItem>
-          <MenuItem value="w">Weeks</MenuItem>
-          <MenuItem value="M">Months</MenuItem>
-          <MenuItem value="y">Years</MenuItem>
-        </TextField>
+              : { value: 'd' })}
+          >
+            <MenuItem value="s">Seconds</MenuItem>
+            <MenuItem value="m">Minutes</MenuItem>
+            <MenuItem value="h">Hours</MenuItem>
+            <MenuItem value="d">Days</MenuItem>
+            <MenuItem value="w">Weeks</MenuItem>
+            <MenuItem value="M">Months</MenuItem>
+            <MenuItem value="y">Years</MenuItem>
+          </TextField>
+        </Grid>
       </Grid>
-    </Grid>
     </Grid>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
@@ -75,6 +75,7 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
           <MenuItem value="m">Minutes</MenuItem>
           <MenuItem value="h">Hours</MenuItem>
           <MenuItem value="d">Days</MenuItem>
+          <MenuItem value="w">Weeks</MenuItem>
           <MenuItem value="M">Months</MenuItem>
           <MenuItem value="y">Years</MenuItem>
         </TextField>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
@@ -34,11 +34,8 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
     return null
   }
   return (
-    <Grid container direction="column" className="w-full">
-      <Grid item className="w-full pb-2 pl-2">
-        within the last
-      </Grid>
-      <Grid item className="w-full pb-2">
+    <Grid container direction="row" className="w-full">
+      <Grid item xs={4} className="pb-2">
         <NumberField
           type="float"
           onChange={(val) => {
@@ -56,7 +53,7 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
             : {})}
         />
       </Grid>
-      <Grid item className="w-full">
+      <Grid item xs={8} className="pl-2">
         <TextField
           fullWidth
           variant="outlined"
@@ -72,6 +69,7 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
           size="small"
           value={value.unit}
         >
+          <MenuItem value="s">Seconds</MenuItem>
           <MenuItem value="m">Minutes</MenuItem>
           <MenuItem value="h">Hours</MenuItem>
           <MenuItem value="d">Days</MenuItem>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -48,7 +48,7 @@ export const serialize = {
       return ''
     }
     //Weeks is not a valid unit, so convert this to days
-    if(unit === 'w') {
+    if (unit === 'w') {
       let convertedUnit = 'd'
       let convertedLast = (parseInt(last) * 7).toString()
       return `RELATIVE(${'P' + convertedLast + convertedUnit.toUpperCase()})`
@@ -57,11 +57,15 @@ export const serialize = {
     return `RELATIVE(${prefix + last + unit.toUpperCase()})`
   },
   dateAround: (value: ValueTypes['around']) => {
-    if(value.buffer === undefined || value.date === undefined) {
+    if (value.buffer === undefined || value.date === undefined) {
       return ''
     }
-    let before = moment(value.date).subtract(value.buffer.amount, value.buffer.unit).toISOString()
-    let after = moment(value.date).add(value.buffer.amount, value.buffer.unit).toISOString()
+    let before = moment(value.date)
+      .subtract(value.buffer.amount, value.buffer.unit)
+      .toISOString()
+    let after = moment(value.date)
+      .add(value.buffer.amount, value.buffer.unit)
+      .toISOString()
     return `DURING ${before}/${after}`
   },
   dateBetween: (value: ValueTypes['between']) => {
@@ -131,13 +135,13 @@ export type ValueTypes = {
     last: string
     //NOTE: Weeks is not a valid unit, but we allow it in our system.
     //This is converted to days to become valid cql
-    unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w' 
+    unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w'
   }
   around: {
     date: string
     buffer: {
       amount: string
-      unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w' 
+      unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w'
     }
   }
   during: {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -52,7 +52,7 @@ export const serialize = {
       let convertedLast = (parseInt(last) * 7).toString()
       return `RELATIVE(${'P' + convertedLast + convertedUnit.toUpperCase()})`
     }
-    const prefix = unit === 'm' || unit === 'h' ? 'PT' : 'P'
+    const prefix = unit === 's' || unit === 'm' || unit === 'h' ? 'PT' : 'P'
     return `RELATIVE(${prefix + last + unit.toUpperCase()})`
   },
   dateBetween: (value: ValueTypes['between']) => {
@@ -122,7 +122,7 @@ export type ValueTypes = {
     last: string
     //NOTE: Weeks is not a valid unit, but we allow it in our system.
     //This is converted to days to become valid cql
-    unit: 'm' | 'h' | 'd' | 'M' | 'y' | 'w' 
+    unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w' 
   }
   during: {
     start: string

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -46,6 +46,12 @@ export const serialize = {
     if (unit === undefined || !parseFloat(last)) {
       return ''
     }
+    //Weeks is not a valid unit, so convert this to days
+    if(unit === 'w') {
+      let convertedUnit = 'd'
+      let convertedLast = (parseInt(last) * 7).toString()
+      return `RELATIVE(${'P' + convertedLast + convertedUnit.toUpperCase()})`
+    }
     const prefix = unit === 'm' || unit === 'h' ? 'PT' : 'P'
     return `RELATIVE(${prefix + last + unit.toUpperCase()})`
   },
@@ -114,7 +120,9 @@ export type ValueTypes = {
   integer: number
   relative: {
     last: string
-    unit: 'm' | 'h' | 'd' | 'M' | 'y'
+    //NOTE: Weeks is not a valid unit, but we allow it in our system.
+    //This is converted to days to become valid cql
+    unit: 'm' | 'h' | 'd' | 'M' | 'y' | 'w' 
   }
   during: {
     start: string

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter/comparators.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter/comparators.tsx
@@ -18,6 +18,7 @@ export const dateComparators = [
   'RELATIVE',
   'BETWEEN',
   'IS EMPTY',
+  'AROUND',
 ]
 export const geometryComparators = ['INTERSECTS', 'IS EMPTY']
 export const stringComparators = [

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
@@ -128,39 +128,14 @@ const QueryTime = ({ value, onChange }: QueryTimeProps) => {
           label="Time"
         />
         {value ? (
-          <TextField
-            fullWidth
-            variant="outlined"
-            size="small"
-            select
-            value={value.type}
-            onChange={(e) => {
-              onChange({
-                ...value,
-                type: e.target.value,
-              })
-            }}
-          >
-            <MenuItem value="AFTER">After</MenuItem>
-            <MenuItem value="BEFORE">Before</MenuItem>
-            <MenuItem value="DURING">Between</MenuItem>
-            <MenuItem value="RELATIVE">Relative</MenuItem>
-          </TextField>
-        ) : null}
-      </div>
-      {value ? (
-        <div>
           <Grid
             container
             alignItems="stretch"
-            direction="row"
+            direction="column"
             wrap="nowrap"
             className="pt-2"
           >
-            <Grid item>
-              <Swath className="w-1 h-full" />
-            </Grid>
-            <Grid item className="w-full pl-2">
+            <Grid item className="w-full pb-2">
               <Autocomplete
                 // @ts-ignore Property 'fullWidth' does not exist on type (error is wrong)
                 fullWidth
@@ -195,31 +170,53 @@ const QueryTime = ({ value, onChange }: QueryTimeProps) => {
                 )}
               />
             </Grid>
-          </Grid>
-          <Grid
-            container
-            alignItems="stretch"
-            direction="row"
-            wrap="nowrap"
-            className="pt-2"
-          >
-            <Grid item>
-              <Swath className="w-1 h-full" />
+            <Grid
+              container
+              alignItems="stretch"
+              direction="row"
+              wrap="nowrap"
+              className="pt-2"
+            >
+              <Grid item>
+                <Swath className="w-1 h-full" />
+              </Grid>
+              <Grid container direction="column">
+                <Grid item className="w-full pl-2 pb-2">
+                  <TextField
+                    fullWidth
+                    variant="outlined"
+                    size="small"
+                    select
+                    value={value.type}
+                    onChange={(e) => {
+                      onChange({
+                        ...value,
+                        type: e.target.value,
+                      })
+                    }}
+                  >
+                    <MenuItem value="AFTER">After</MenuItem>
+                    <MenuItem value="BEFORE">Before</MenuItem>
+                    <MenuItem value="DURING">Between</MenuItem>
+                    <MenuItem value="RELATIVE">Relative</MenuItem>
+                  </TextField>
+                </Grid>
+                <Grid item className="w-full pl-2">
+                  <FilterInput
+                    filter={{ ...value, property: value.property[0] }}
+                    setFilter={(val: any) => {
+                      onChange({
+                        ...value,
+                        value: val.value,
+                      })
+                    }}
+                  />
+                </Grid>
+              </Grid>
             </Grid>
-            <Grid item className="w-full pl-2">
-              <FilterInput
-                filter={{ ...value, property: value.property[0] }}
-                setFilter={(val: any) => {
-                  onChange({
-                    ...value,
-                    value: val.value,
-                  })
-                }}
-              />
-            </Grid>
           </Grid>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
@@ -198,7 +198,8 @@ const QueryTime = ({ value, onChange }: QueryTimeProps) => {
                     <MenuItem value="AFTER">After</MenuItem>
                     <MenuItem value="BEFORE">Before</MenuItem>
                     <MenuItem value="DURING">Between</MenuItem>
-                    <MenuItem value="RELATIVE">Relative</MenuItem>
+                    <MenuItem value="RELATIVE">Within the last</MenuItem>
+                    <MenuItem value="AROUND">Around</MenuItem>
                   </TextField>
                 </Grid>
                 <Grid item className="w-full pl-2">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -576,10 +576,8 @@ function write(filter) {
       return `${wrap(filter.property)} = '${serialize.dateRelative(
         filter.value
       )}'`
-    case 'AROUND': 
-        return `${wrap(filter.property)} ${serialize.dateAround(
-          filter.value
-        )}`
+    case 'AROUND':
+      return `${wrap(filter.property)} ${serialize.dateAround(filter.value)}`
     case 'BEFORE':
     case 'AFTER':
       return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -576,6 +576,10 @@ function write(filter) {
       return `${wrap(filter.property)} = '${serialize.dateRelative(
         filter.value
       )}'`
+    case 'AROUND': 
+        return `${wrap(filter.property)} ${serialize.dateAround(
+          filter.value
+        )}`
     case 'BEFORE':
     case 'AFTER':
       return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/comparatorUtils.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/comparatorUtils.tsx
@@ -26,7 +26,7 @@ export const dateComparators = [
   },
   {
     value: 'RELATIVE',
-    label: 'RELATIVE',
+    label: 'WITHIN THE LAST',
   },
   {
     value: 'DURING',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/comparatorUtils.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/comparatorUtils.tsx
@@ -36,6 +36,10 @@ export const dateComparators = [
     value: 'IS NULL',
     label: 'IS EMPTY',
   },
+  {
+    value: 'AROUND',
+    label: 'AROUND',
+  },
 ] as ComparatorType[]
 // verified
 export const geometryComparators = [

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -33,6 +33,7 @@ import { BooleanField } from '../../../component/fields/boolean'
 import MetacardDefinitions from '../../../component/tabs/metacard/metacardDefinitions'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 import MuiTextField from '@material-ui/core/TextField'
+import { DateAroundField } from '../../../component/fields/date-around'
 export type Props = {
   filter: FilterClass
   setFilter: (filter: FilterClass) => void
@@ -78,6 +79,13 @@ const FilterInput = ({ filter, setFilter }: Props) => {
       return (
         <DateRelativeField
           value={value as ValueTypes['relative']}
+          onChange={onChange}
+        />
+      )
+    case 'AROUND': 
+      return (
+        <DateAroundField
+          value={value as ValueTypes['around']}
           onChange={onChange}
         />
       )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -82,7 +82,7 @@ const FilterInput = ({ filter, setFilter }: Props) => {
           onChange={onChange}
         />
       )
-    case 'AROUND': 
+    case 'AROUND':
       return (
         <DateAroundField
           value={value as ValueTypes['around']}


### PR DESCRIPTION
## **What this PR does:**

### 1. [**Reorders the time input on Query basic to be more human readable**](https://github.com/codice/ddf-ui/pull/448/commits/db6c0a50000e7fdf37614514c6cdb3c10e6f7b3f)
Changes the fields to be in "attribute" "property" "value" order to read like a sentence, e.g. "Created before 02 Nov 2020"
![Screen Shot 2020-11-04 at 10 52 24](https://user-images.githubusercontent.com/9013407/98150420-dc492280-1e8b-11eb-98b1-3d0754a2d8c5.png)


### 2. [**Adds weeks to relative query**](https://github.com/codice/ddf-ui/pull/448/commits/dfbe951c89fa2db6ec705293781adeb1b9a6564b)
Weeks wasn't previously supported as an option for relative queries because it's not supported when converting to cql. This adds weeks to the dropdown and then converts it to days when it gets converted to cql. 
![Screen Shot 2020-11-04 at 07 01 01](https://user-images.githubusercontent.com/9013407/98150339-b9b70980-1e8b-11eb-9998-2f7dc1441836.png)

### 3. [**Adds seconds to relative query**](https://github.com/codice/ddf-ui/pull/448/commits/6c3780894e10dd3ceaf302059bed04619d83cc15)
Seconds was already supported so this just adds it in as a dropdown option and also brings the amount and unit on to the same line visually so it takes up less space.
![Screen Shot 2020-11-04 at 10 54 08](https://user-images.githubusercontent.com/9013407/98150575-187c8300-1e8c-11eb-84ca-3971458512ab.png)

### 4. [**Adds "Around" temporal filter type**](https://github.com/codice/ddf-ui/pull/448/commits/061e8e1a5910dd085c02fd276cfca6aeb9ae7225)
Adds in a new filter type, "AROUND" which gets converted to cql as a "BETWEEN" (duration).
The idea is that "AROUND" is similar to "relative" queries, except it takes a specific date + buffer. A great comparison would be doing a point radius spatial query- this is a similar idea except temporal.
![Screen Shot 2020-11-04 at 07 01 27](https://user-images.githubusercontent.com/9013407/98150690-49f54e80-1e8c-11eb-931c-c35915a3de06.png)

### 5. **Renames "Relative" to "Within the Last"**
Hopefully this name update conveys to users that relative queries imply "now". Whenever this query is run, it will always be within the last "2 weeks".
![Screen Shot 2020-11-04 at 07 01 54](https://user-images.githubusercontent.com/9013407/98150928-a193ba00-1e8c-11eb-807a-9ac9a61b3148.png)




