### PR TITLE
Updates search date/date range pickers to go back as far as 1900

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -69,6 +69,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
       <Grid item className="w-full pb-2">
         <DateInput
           className={MuiOutlinedInputBorderClasses}
+          minDate={new Date('Jan 1, 1900')}
           closeOnSelection={false}
           fill
           formatDate={DateHelpers.Blueprint.commonProps.formatDate}
@@ -80,7 +81,8 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           {...(value.date
             ? {
                 value: DateHelpers.Blueprint.DateProps.generateValue(
-                  value.date
+                  value.date,
+                  new Date('Jan 1, 1900')
                 ),
               }
             : {})}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -17,7 +17,7 @@ import { DateInput } from '@blueprintjs/datetime'
 
 // @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
 import user from '../singletons/user-instance'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, DefaultMinDate } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
 import { ValueTypes } from '../filter-builder/filter.structure'
@@ -69,7 +69,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
       <Grid item className="w-full pb-2">
         <DateInput
           className={MuiOutlinedInputBorderClasses}
-          minDate={new Date('Jan 1, 1900')}
+          minDate={DefaultMinDate}
           closeOnSelection={false}
           fill
           formatDate={DateHelpers.Blueprint.commonProps.formatDate}
@@ -81,8 +81,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           {...(value.date
             ? {
                 value: DateHelpers.Blueprint.DateProps.generateValue(
-                  value.date,
-                  new Date('Jan 1, 1900')
+                  value.date
                 ),
               }
             : {})}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -10,7 +10,7 @@ import {
 } from '@blueprintjs/datetime/lib/esm/common/dateUtils'
 import { getDefaultMaxDate } from '@blueprintjs/datetime/lib/esm/datePickerCore'
 
-export const DefaultMinDate = new Date('Jan 1 1900')
+export const DefaultMinDate = new Date('Jan 1, 1900')
 
 export const DefaultMaxDate = getDefaultMaxDate()
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -55,14 +55,13 @@ export const DateHelpers = {
           return ''
         }
       },
-      isValid: (date: Date, minDate?: Date, maxDate?: Date) => {
+      isValid: (
+        date: Date,
+        minDate: Date = DefaultMinDate,
+        maxDate: Date = DefaultMaxDate
+      ) => {
         return (
-          date &&
-          isDateValid(date) &&
-          isDayInRange(date, [
-            minDate || DefaultMinDate,
-            maxDate || DefaultMaxDate,
-          ])
+          date && isDateValid(date) && isDayInRange(date, [minDate, maxDate])
         )
       },
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -77,8 +77,12 @@ export const DateHelpers = {
           }
         }) as IDateInputProps['onChange']
       },
-      generateValue: (value: string) =>
-        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(value),
+      generateValue: (value: string, minDate?: Date, maxDate?: Date) =>
+        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+          value,
+          minDate,
+          maxDate
+        ),
     },
     DateRangeProps: {
       generateOnChange: (onChange: (value: ValueTypes['during']) => void) => {
@@ -95,10 +99,22 @@ export const DateHelpers = {
           }
         }) as IDateRangeInputProps['onChange']
       },
-      generateValue: (value: ValueTypes['during']) =>
+      generateValue: (
+        value: ValueTypes['during'],
+        minDate?: Date,
+        maxDate?: Date
+      ) =>
         [
-          DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(value.start),
-          DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(value.end),
+          DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+            value.start,
+            minDate,
+            maxDate
+          ),
+          DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+            value.end,
+            minDate,
+            maxDate
+          ),
         ] as IDateRangeInputProps['value'],
     },
     converters: {
@@ -109,7 +125,11 @@ export const DateHelpers = {
        *
        * TLDR: Use this on an ISO date going INTO the blueprint datepicker (the value prop).  Use the sibling function TimeshiftedDateToISO to reverse this.
        */
-      ISOToTimeshiftedDate: (value: string): Date => {
+      ISOToTimeshiftedDate: (
+        value: string,
+        minDate?: Date,
+        maxDate?: Date
+      ): Date => {
         try {
           let momentShiftedDate = moment.utc(new Date(value).toUTCString())
           const utcOffsetMinutesLocal = new Date().getTimezoneOffset()
@@ -122,7 +142,11 @@ export const DateHelpers = {
 
           if (
             momentWithOffset.isValid() &&
-            DateHelpers.Blueprint.commonProps.isValid(momentWithOffset.toDate())
+            DateHelpers.Blueprint.commonProps.isValid(
+              momentWithOffset.toDate(),
+              minDate,
+              maxDate
+            )
           ) {
             return momentWithOffset.toDate()
           } else {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -8,10 +8,11 @@ import {
   isDateValid,
   isDayInRange,
 } from '@blueprintjs/datetime/lib/esm/common/dateUtils'
-import {
-  getDefaultMinDate,
-  getDefaultMaxDate,
-} from '@blueprintjs/datetime/lib/esm/datePickerCore'
+import { getDefaultMaxDate } from '@blueprintjs/datetime/lib/esm/datePickerCore'
+
+export const DefaultMinDate = new Date('Jan 1 1900')
+
+export const DefaultMaxDate = getDefaultMaxDate()
 
 export const DateHelpers = {
   General: {
@@ -59,8 +60,8 @@ export const DateHelpers = {
           date &&
           isDateValid(date) &&
           isDayInRange(date, [
-            minDate || getDefaultMinDate(),
-            maxDate || getDefaultMaxDate(),
+            minDate || DefaultMinDate,
+            maxDate || DefaultMaxDate,
           ])
         )
       },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -14,7 +14,7 @@
  **/
 import * as React from 'react'
 import { DateRangeInput, IDateRangeInputProps } from '@blueprintjs/datetime'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, DefaultMinDate } from './date-helpers'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
@@ -53,7 +53,7 @@ export const DateRangeField = ({
   return (
     <DateRangeInput
       allowSingleDayRange
-      minDate={new Date('Jan 1, 1900')}
+      minDate={DefaultMinDate}
       endInputProps={{
         fill: true,
         className: MuiOutlinedInputBorderClasses,
@@ -71,10 +71,7 @@ export const DateRangeField = ({
       timePrecision="minute"
       {...(value
         ? {
-            value: DateHelpers.Blueprint.DateRangeProps.generateValue(
-              value,
-              new Date('Jan 1, 1900')
-            ),
+            value: DateHelpers.Blueprint.DateRangeProps.generateValue(value),
           }
         : {})}
       {...BPDateRangeProps}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -53,6 +53,7 @@ export const DateRangeField = ({
   return (
     <DateRangeInput
       allowSingleDayRange
+      minDate={new Date('Jan 1, 1900')}
       endInputProps={{
         fill: true,
         className: MuiOutlinedInputBorderClasses,
@@ -70,7 +71,10 @@ export const DateRangeField = ({
       timePrecision="minute"
       {...(value
         ? {
-            value: DateHelpers.Blueprint.DateRangeProps.generateValue(value),
+            value: DateHelpers.Blueprint.DateRangeProps.generateValue(
+              value,
+              new Date('Jan 1, 1900')
+            ),
           }
         : {})}
       {...BPDateRangeProps}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -46,6 +46,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
     <>
       <DateInput
         className={MuiOutlinedInputBorderClasses}
+        minDate={new Date('Jan 1, 1900')}
         closeOnSelection={false}
         fill
         formatDate={DateHelpers.Blueprint.commonProps.formatDate}
@@ -56,7 +57,10 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         timePrecision="minute"
         {...(value
           ? {
-              value: DateHelpers.Blueprint.DateProps.generateValue(value),
+              value: DateHelpers.Blueprint.DateProps.generateValue(
+                value,
+                new Date('Jan 1, 1900')
+              ),
             }
           : {})}
         {...BPDateProps}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -17,7 +17,7 @@ import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
 
 // @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
 import user from '../singletons/user-instance'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, DefaultMinDate } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
 
@@ -46,7 +46,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
     <>
       <DateInput
         className={MuiOutlinedInputBorderClasses}
-        minDate={new Date('Jan 1, 1900')}
+        minDate={DefaultMinDate}
         closeOnSelection={false}
         fill
         formatDate={DateHelpers.Blueprint.commonProps.formatDate}
@@ -57,10 +57,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         timePrecision="minute"
         {...(value
           ? {
-              value: DateHelpers.Blueprint.DateProps.generateValue(
-                value,
-                new Date('Jan 1, 1900')
-              ),
+              value: DateHelpers.Blueprint.DateProps.generateValue(value),
             }
           : {})}
         {...BPDateProps}


### PR DESCRIPTION
Updates the date/date range pickers on the search page to go back as far as 1900.
To test: For each temporal type (Before, After, During, Around), try to set the query to a date before the year 2000. Make sure it gets updated properly on the UI and that the right query gets sent across to the backend (if you disable websockets, you can use the network tab to watch the cql requests).

![Screen Shot 2020-11-05 at 16 48 10](https://user-images.githubusercontent.com/9013407/98309169-0d5a4d80-1f87-11eb-9e5e-b9f75f794b4c.png)
![Screen Shot 2020-11-05 at 16 47 33](https://user-images.githubusercontent.com/9013407/98309172-0f241100-1f87-11eb-9fec-44a641136698.png)
