### PR TITLE
Add OWASP scan step to CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,14 @@ jobs: # a collection of steps
 
       - store_test_results:
           path: ~/test-results
+
+      - run:
+          name: Dependency Check
+          command: mvn dependency-check:aggregate
+
+      - store_artifacts:
+          path: target/dependency-check-report.html
+
 #      - store_artifacts: # store the uberjar as an artifact
 #          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
 #          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <compiler.fork>false</compiler.fork>
+    <dependency-check-maven.version>6.0.2</dependency-check-maven.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+    <mariadb.version>2.4.1</mariadb.version>
     <javalin.version>2.5.0</javalin.version>
     <javalin.thirdparty.bundle.version>2.5.0_1</javalin.thirdparty.bundle.version>
     <kotlin-osgi.version>1.2.61</kotlin-osgi.version>
@@ -280,6 +282,50 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>${dependency-check-maven.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>ddf.support</groupId>
+              <artifactId>support-owasp</artifactId>
+              <version>${ddf.support.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.mariadb.jdbc</groupId>
+              <artifactId>mariadb-java-client</artifactId>
+              <version>${mariadb.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <!-- The following properties enable using a centralized nvd server -->
+            <autoUpdate>${owasp.autoUpdate}</autoUpdate>
+            <databaseDriverName>${owasp.database.driverName}</databaseDriverName>
+            <connectionString>${owasp.database.url}</connectionString>
+            <serverId>${owasp.serverId}</serverId>
+            <!-- End Centralized NVD Server Configuration -->
+            <failOnError>false</failOnError>
+            <skipTestScope>true</skipTestScope>
+            <!--Disable by plugin maintainer recommendation on https://github.com/jeremylong/DependencyCheck/issues/978#issuecomment-349620687-->
+            <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
+            <!--Disable .NET analyzers-->
+            <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+            <!--Analyzes Ruby Gemfile.lock files, not OSGi bundles-->
+            <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+            <!--We don't use CMake, CocoaPods, AutoConf, or Ruby-->
+            <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled>
+            <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
+            <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
+            <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+            <suppressionFiles>
+              <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
+            </suppressionFiles>
+            <!-- This prevents a build failure on jdk tools jar -->
+            <skipSystemScope>true</skipSystemScope>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -300,12 +300,6 @@
             </dependency>
           </dependencies>
           <configuration>
-            <!-- The following properties enable using a centralized nvd server -->
-            <autoUpdate>${owasp.autoUpdate}</autoUpdate>
-            <databaseDriverName>${owasp.database.driverName}</databaseDriverName>
-            <connectionString>${owasp.database.url}</connectionString>
-            <serverId>${owasp.serverId}</serverId>
-            <!-- End Centralized NVD Server Configuration -->
             <failOnError>false</failOnError>
             <skipTestScope>true</skipTestScope>
             <!--Disable by plugin maintainer recommendation on https://github.com/jeremylong/DependencyCheck/issues/978#issuecomment-349620687-->


### PR DESCRIPTION
### Description
Adds an OWASP scan step to the CircleCI build. It stores the report so it is available as a build artifact in the CircleCI build page. The step adds about 3 minutes to CI builds.

### Reviewers
@codice/build
@codice/continuous-integration
@codice/security
