### PR TITLE
ISR-6010 edit attrs from inspector summary

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
@@ -50,6 +50,5 @@ export const displayHighlightedAttrInFull = (
     />
   )
   textArray.push(afterText)
-  return <Typography>{textArray}
-  <button>8888888888888</button></Typography>
+  return <Typography>{textArray}</Typography>
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
@@ -50,5 +50,6 @@ export const displayHighlightedAttrInFull = (
     />
   )
   textArray.push(afterText)
-  return <Typography>{textArray}</Typography>
+  return <Typography>{textArray}
+  <button>8888888888888</button></Typography>
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -26,9 +26,10 @@ import useTheme from '@material-ui/core/styles/useTheme'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
 import { useLazyResultsSelectedResultsFromSelectionInterface } from '../../selection-interface/hooks'
 import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
-import TransferList from './transfer-list'
+import TransferList, {useCustomReadOnlyCheck} from './transfer-list'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
 import AddIcon from '@material-ui/icons/Add'
+import EditIcon from '@material-ui/icons/Edit'
 import Box from '@material-ui/core/Box'
 import { Elevations } from '../../theme/theme'
 import { DarkDivider } from '../../dark-divider/dark-divider'
@@ -428,11 +429,34 @@ const AttributeComponent = ({
     value = [value]
   }
   let label = TypedMetacardDefs.getAlias({ attr })
+  const {isWritable} = useCustomReadOnlyCheck()
+  const dialogContext = useDialog()
+
   const isFiltered =
     filter !== '' ? !label.toLowerCase().includes(filter.toLowerCase()) : false
   const MemoItem = React.useMemo(() => {
     return (
-      <Grid container direction="row" wrap={'nowrap'}>
+      <Grid container direction="row" wrap={'nowrap'} className="group relative">
+        {isWritable({attribute: attr, lazyResult})  ?  <div className="p-1 hidden group-hover:block absolute right-0 top-0">
+         <Button onClick={() => {
+           dialogContext.setProps({
+            open: true,
+            children: (
+              <Editor
+                attr={attr}
+                lazyResult={lazyResult}
+                onCancel={() => {
+                  dialogContext.setProps({open: false, children: null})
+                }}
+                onSave={() => {
+                  dialogContext.setProps({open: false, children: null})
+                }}
+              />
+            ),
+           })
+         }}><EditIcon></EditIcon></Button>
+        </div>: null }
+       
         <Grid
           item
           xs={4}
@@ -542,7 +566,7 @@ const AttributeComponent = ({
         </Grid>
       </Grid>
     )
-  }, [summaryShown, forceRender])
+  }, [summaryShown, forceRender, isWritable])
   return (
     <div style={{ display: isFiltered ? 'none' : 'block' }}>{MemoItem}</div>
   )
@@ -647,6 +671,8 @@ const Summary = ({ selectionInterface }: Props) => {
           })
       : []
   }, [expanded, summaryShown])
+
+
   React.useEffect(() => {
     globalExpanded = expanded
   }, [expanded])

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -429,7 +429,7 @@ const AttributeComponent = ({
     value = [value]
   }
   let label = TypedMetacardDefs.getAlias({ attr })
-  const { isWritable } = useCustomReadOnlyCheck()
+  const { isNotWritable } = useCustomReadOnlyCheck()
   const dialogContext = useDialog()
 
   const isFiltered =
@@ -442,7 +442,7 @@ const AttributeComponent = ({
         wrap={'nowrap'}
         className="group relative"
       >
-        {isWritable({ attribute: attr, lazyResult }) ? (
+        {isNotWritable({ attribute: attr, lazyResult }) ? null : (
           <div className="p-1 hidden group-hover:block absolute right-0 top-0">
             <Button
               onClick={() => {
@@ -466,7 +466,7 @@ const AttributeComponent = ({
               <EditIcon></EditIcon>
             </Button>
           </div>
-        ) : null}
+        )}
 
         <Grid
           item
@@ -577,7 +577,7 @@ const AttributeComponent = ({
         </Grid>
       </Grid>
     )
-  }, [summaryShown, forceRender, isWritable])
+  }, [summaryShown, forceRender, isNotWritable])
   return (
     <div style={{ display: isFiltered ? 'none' : 'block' }}>{MemoItem}</div>
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -672,7 +672,6 @@ const Summary = ({ selectionInterface }: Props) => {
       : []
   }, [expanded, summaryShown])
 
-
   React.useEffect(() => {
     globalExpanded = expanded
   }, [expanded])

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -26,7 +26,7 @@ import useTheme from '@material-ui/core/styles/useTheme'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
 import { useLazyResultsSelectedResultsFromSelectionInterface } from '../../selection-interface/hooks'
 import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
-import TransferList, {useCustomReadOnlyCheck} from './transfer-list'
+import TransferList, { useCustomReadOnlyCheck } from './transfer-list'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
 import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
@@ -429,34 +429,45 @@ const AttributeComponent = ({
     value = [value]
   }
   let label = TypedMetacardDefs.getAlias({ attr })
-  const {isWritable} = useCustomReadOnlyCheck()
+  const { isWritable } = useCustomReadOnlyCheck()
   const dialogContext = useDialog()
 
   const isFiltered =
     filter !== '' ? !label.toLowerCase().includes(filter.toLowerCase()) : false
   const MemoItem = React.useMemo(() => {
     return (
-      <Grid container direction="row" wrap={'nowrap'} className="group relative">
-        {isWritable({attribute: attr, lazyResult})  ?  <div className="p-1 hidden group-hover:block absolute right-0 top-0">
-         <Button onClick={() => {
-           dialogContext.setProps({
-            open: true,
-            children: (
-              <Editor
-                attr={attr}
-                lazyResult={lazyResult}
-                onCancel={() => {
-                  dialogContext.setProps({open: false, children: null})
-                }}
-                onSave={() => {
-                  dialogContext.setProps({open: false, children: null})
-                }}
-              />
-            ),
-           })
-         }}><EditIcon></EditIcon></Button>
-        </div>: null }
-       
+      <Grid
+        container
+        direction="row"
+        wrap={'nowrap'}
+        className="group relative"
+      >
+        {isWritable({ attribute: attr, lazyResult }) ? (
+          <div className="p-1 hidden group-hover:block absolute right-0 top-0">
+            <Button
+              onClick={() => {
+                dialogContext.setProps({
+                  open: true,
+                  children: (
+                    <Editor
+                      attr={attr}
+                      lazyResult={lazyResult}
+                      onCancel={() => {
+                        dialogContext.setProps({ open: false, children: null })
+                      }}
+                      onSave={() => {
+                        dialogContext.setProps({ open: false, children: null })
+                      }}
+                    />
+                  ),
+                })
+              }}
+            >
+              <EditIcon></EditIcon>
+            </Button>
+          </div>
+        ) : null}
+
         <Grid
           item
           xs={4}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -116,7 +116,7 @@ const CustomList = ({
   const isIndeterminate = numberChecked !== items.length && numberChecked !== 0
   const isCompletelySelected =
     numberChecked === items.length && items.length !== 0
-  const { isWritable } = useCustomReadOnlyCheck()
+  const { isNotWritable } = useCustomReadOnlyCheck()
   return (
     <Paper
       // @ts-ignore ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
@@ -228,7 +228,7 @@ const CustomList = ({
                       const alias = TypedMetacardDefs.getAlias({
                         attr: value,
                       })
-                      const isReadonly = isWritable({
+                      const isReadonly = isNotWritable({
                         attribute: value,
                         lazyResult,
                       })
@@ -404,7 +404,7 @@ export const useCustomReadOnlyCheck = () => {
 
   return {
     loading,
-    isWritable: ({
+    isNotWritable: ({
       attribute,
       lazyResult,
     }: {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -82,7 +82,6 @@ const CustomList = ({
   handleToggleAll,
   mode,
   classes,
-  checkIsReadOnly,
   handleToggle,
   checked,
   dialogContext,
@@ -101,7 +100,6 @@ const CustomList = ({
   handleToggleAll: (props: any) => () => void
   mode: 'loading' | string
   classes: any
-  checkIsReadOnly: (props: any) => boolean
   handleToggle: (props: any) => () => void
   checked: string[]
   dialogContext: {
@@ -118,6 +116,7 @@ const CustomList = ({
   const isIndeterminate = numberChecked !== items.length && numberChecked !== 0
   const isCompletelySelected =
     numberChecked === items.length && items.length !== 0
+  const { isWritable } = useCustomReadOnlyCheck()
   return (
     <Paper
       // @ts-ignore ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
@@ -229,7 +228,7 @@ const CustomList = ({
                       const alias = TypedMetacardDefs.getAlias({
                         attr: value,
                       })
-                      const isReadonly = checkIsReadOnly(value)
+                      const isReadonly = isWritable({attribute: value, lazyResult})
                       const isFiltered =
                         filter !== ''
                           ? !alias.toLowerCase().includes(filter.toLowerCase())
@@ -376,6 +375,51 @@ const CustomList = ({
   )
 }
 
+const getCustomEditableAttributes = (async () => {
+  const attrs = await extension.customEditableAttributes()
+  return attrs
+})()
+
+export const useCustomReadOnlyCheck = () => {
+  const [
+    customEditableAttributes,
+    setCustomEditableAttributes,
+  ] = React.useState([] as string[])
+  const [loading, setLoading] = React.useState(true)
+
+  const initializeCustomEditableAttributes = async () => {
+    const attrs = await getCustomEditableAttributes
+    if (attrs !== undefined) {
+      setCustomEditableAttributes(attrs)
+    }
+    setLoading(false)
+  }
+
+  React.useEffect(() => {
+    initializeCustomEditableAttributes()
+  }, [])
+
+  return {
+    loading,
+    isWritable: ({attribute,lazyResult}: {attribute: string, lazyResult: LazyQueryResult}) => {
+      const perm = extension.customCanWritePermission({
+        attribute,
+        lazyResult,
+        user,
+        editableAttributes: customEditableAttributes,
+      })
+      if (perm !== undefined) {
+        return !perm
+      }
+      return (
+        (lazyResult.isRemote() &&
+          !(user.canWrite(lazyResult.getBackbone()) as boolean)) ||
+        TypedMetacardDefs.isReadonly({ attr: attribute })
+      )
+    }
+  }
+}
+
 const TransferList = ({
   startingLeft,
   startingRight,
@@ -397,40 +441,12 @@ const TransferList = ({
   const [checked, setChecked] = React.useState<string[]>([])
   const [left, setLeft] = React.useState(startingLeft)
   const [right, setRight] = React.useState(startingRight)
-  const [
-    customEditableAttributes,
-    setCustomEditableAttributes,
-  ] = React.useState([] as string[])
-
+  const { loading } = useCustomReadOnlyCheck()
   React.useEffect(() => {
-    setMode('loading')
-    getCustomAttrs()
-  }, [])
-
-  const getCustomAttrs = async () => {
-    const attrs = await extension.customEditableAttributes()
-    if (attrs !== undefined) {
-      setCustomEditableAttributes(attrs)
+    if (!loading) {
+      setMode('normal')
     }
-    setMode('normal')
-  }
-
-  const checkIsReadOnly = (attribute: string) => {
-    const perm = extension.customCanWritePermission({
-      attribute,
-      lazyResult,
-      user,
-      editableAttributes: customEditableAttributes,
-    })
-    if (perm !== undefined) {
-      return !perm
-    }
-    return (
-      (lazyResult.isRemote() &&
-        !(user.canWrite(lazyResult.getBackbone()) as boolean)) ||
-      TypedMetacardDefs.isReadonly({ attr: attribute })
-    )
-  }
+  }, [loading])
 
   const leftChecked = intersection(checked, left)
   const rightChecked = intersection(checked, right)
@@ -512,7 +528,6 @@ const TransferList = ({
               right={right}
               onSave={onSave}
               updateActive={updateActive}
-              checkIsReadOnly={checkIsReadOnly}
               numberOfChecked={numberOfChecked}
               handleToggle={handleToggle}
               handleToggleAll={handleToggleAll}
@@ -558,7 +573,6 @@ const TransferList = ({
               right={right}
               onSave={onSave}
               updateActive={updateActive}
-              checkIsReadOnly={checkIsReadOnly}
               numberOfChecked={numberOfChecked}
               handleToggle={handleToggle}
               handleToggleAll={handleToggleAll}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -228,7 +228,10 @@ const CustomList = ({
                       const alias = TypedMetacardDefs.getAlias({
                         attr: value,
                       })
-                      const isReadonly = isWritable({attribute: value, lazyResult})
+                      const isReadonly = isWritable({
+                        attribute: value,
+                        lazyResult,
+                      })
                       const isFiltered =
                         filter !== ''
                           ? !alias.toLowerCase().includes(filter.toLowerCase())
@@ -401,7 +404,13 @@ export const useCustomReadOnlyCheck = () => {
 
   return {
     loading,
-    isWritable: ({attribute,lazyResult}: {attribute: string, lazyResult: LazyQueryResult}) => {
+    isWritable: ({
+      attribute,
+      lazyResult,
+    }: {
+      attribute: string
+      lazyResult: LazyQueryResult
+    }) => {
       const perm = extension.customCanWritePermission({
         attribute,
         lazyResult,
@@ -416,7 +425,7 @@ export const useCustomReadOnlyCheck = () => {
           !(user.canWrite(lazyResult.getBackbone()) as boolean)) ||
         TypedMetacardDefs.isReadonly({ attr: attribute })
       )
-    }
+    },
   }
 }
 


### PR DESCRIPTION
we want to allow editing from the inspector summary.

search and pull up the inspector summary for an ingested product. hover over values on the table and the values that are not read only will have an edit icon on hover where the editor modal will pop up to edit attributes from
@jlcsmith @andrewkfiedler @vinamartin 

<img width="782" alt="Screen Shot 2020-11-17 at 11 37 01 AM" src="https://user-images.githubusercontent.com/72404488/99432481-6bf9c280-28c9-11eb-973f-7191f030400b.png">
<img width="1245" alt="Screen Shot 2020-11-17 at 11 37 35 AM" src="https://user-images.githubusercontent.com/72404488/99432495-71efa380-28c9-11eb-8fc2-d4b676d6665e.png">
