### PR TITLE
Initialize filterTree with valid default

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -136,7 +136,12 @@ Query.Model = Backbone.AssociatedModel.extend({
     return _merge(
       {
         cql: "anyText ILIKE ''",
-        filterTree: { property: 'anyText', value: '', type: 'ILIKE' },
+        filterTree: new FilterBuilderClass({
+          filters: [
+            new FilterClass({ value: '*', property: 'anyText', type: 'ILIKE' }),
+          ],
+          type: 'AND',
+        }),
         associatedFormModel: undefined,
         excludeUnnecessaryAttributes: true,
         count: properties.resultCount,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -280,7 +280,7 @@ Query.Model = Backbone.AssociatedModel.extend({
    */
   updateCqlBasedOnFilterTree() {
     const filterTree = this.get('filterTree')
-    if (filterTree.filters.length === 0) {
+    if (!filterTree || filterTree.filters.length === 0) {
       this.set(
         'filterTree',
         new FilterBuilderClass({


### PR DESCRIPTION
We expect the filterTree to have a `filters` property (see https://github.com/codice/ddf-ui/blob/master/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js#L278), but don't initialize it with one. This fixes that.

@jlcsmith @andrewkfiedler 