### PR TITLE
Update default checking for date, and default for date-range

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -34,8 +34,10 @@ const validateShape = ({ value, onChange }: Props) => {
     value.start === undefined ||
     value.end === undefined
   ) {
+    const start = new Date()
+    start.setDate(start.getDate() - 1) // start and end can't be equal or the backend will throw a fit
     onChange({
-      start: new Date().toISOString(),
+      start: start.toISOString(),
       end: new Date().toISOString(),
     })
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -31,7 +31,8 @@ type DateFieldProps = {
 }
 
 const validateShape = ({ value, onChange }: DateFieldProps) => {
-  if (DateHelpers.Blueprint.commonProps.parseDate(value) === null) {
+  const dateValue = new Date(value)
+  if (dateValue.toString() === 'Invalid Date') {
     onChange(new Date().toISOString())
   }
 }


### PR DESCRIPTION
 - The date validity check would never get triggered before, now it does a simple attempt at constructing a date and sees if it's invalid.
 - The date range default used before is seen as invalid on the backend since start === end.  This just subtracts a day from start to fix the issue.