### PR TITLE
Adds multivalued highlighting on the UI, makes highlight structure easier to use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <spatial4j.version>0.7</spatial4j.version>
     <tika.version>1.24.1</tika.version>
     <usng4j.version>0.4</usng4j.version>
+    <org.slf4j.version>1.7.29</org.slf4j.version>
 
     <!-- Command line argument properties for the maven-surefire-plugin -->
     <codice-test.version>0.3</codice-test.version>

--- a/ui-backend/catalog-plugin-highlight/pom.xml
+++ b/ui-backend/catalog-plugin-highlight/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>backend</artifactId>
+        <groupId>org.codice.ddf.search</groupId>
+        <version>4.1.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>catalog-plugin-highlight</artifactId>
+    <name>DDF :: Catalog :: Plugin :: Highlight Transform Plugin</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency />
+                        <Export-Package />
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.78</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ui-backend/catalog-plugin-highlight/src/main/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPlugin.java
+++ b/ui-backend/catalog-plugin-highlight/src/main/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPlugin.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.plugin.highlight;
+
+import com.google.common.annotations.VisibleForTesting;
+import ddf.catalog.Constants;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.Highlight;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResultAttributeHighlight;
+import ddf.catalog.operation.ResultHighlight;
+import ddf.catalog.plugin.PostQueryPlugin;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Transforms solr highlights into an easily displayable format on the frontend */
+public class HighlightTransformPlugin implements PostQueryPlugin {
+  private int bufferSize;
+
+  public HighlightTransformPlugin() {
+    // Create a 80 char buffer around the string
+    bufferSize = 80;
+  }
+
+  @VisibleForTesting
+  protected HighlightTransformPlugin(int bufferSize) {
+    this.bufferSize = bufferSize;
+  }
+
+  @VisibleForTesting
+  protected static class ProcessedHighlight {
+    private String id;
+    private List<Map<String, String>> highlights;
+
+    public ProcessedHighlight(String id) {
+      this.id = id;
+      highlights = new ArrayList<>();
+    }
+
+    public void addHighlight(
+        String attribute, String highlight, String startIndex, String endIndex, String valueIndex) {
+      HashMap<String, String> highlightMap = new HashMap<>();
+      highlightMap.put("attribute", attribute);
+      highlightMap.put("highlight", highlight);
+      highlightMap.put("valueIndex", valueIndex);
+      highlightMap.put("startIndex", startIndex);
+      highlightMap.put("endIndex", endIndex);
+      highlights.add(highlightMap);
+    }
+
+    public List<Map<String, String>> getHighlights() {
+      return highlights;
+    }
+
+    public String getId() {
+      return id;
+    }
+  }
+
+  @Override
+  public QueryResponse process(QueryResponse input) {
+    ArrayList<ProcessedHighlight> processedHighlights = new ArrayList<>();
+    if (input.getProperties().containsKey(Constants.QUERY_HIGHLIGHT_KEY)) {
+      List<Result> results = input.getResults();
+      List<ResultHighlight> resultHighlights =
+          (List<ResultHighlight>) input.getProperties().get(Constants.QUERY_HIGHLIGHT_KEY);
+      for (ResultHighlight resultHighlight : resultHighlights) {
+        String id = resultHighlight.getResultId();
+        ProcessedHighlight processedHighlight = new ProcessedHighlight(id);
+
+        Result matchingResult =
+            results
+                .stream()
+                .filter(result -> result.getMetacard().getId().equals(id))
+                .findAny()
+                .orElse(null);
+        if (matchingResult != null) {
+          List<ResultAttributeHighlight> resultAttributeHighlights =
+              resultHighlight.getAttributeHighlights();
+
+          for (ResultAttributeHighlight resultAttributeHighlight : resultAttributeHighlights) {
+            String attributeName = resultAttributeHighlight.getAttributeName();
+            List<Highlight> highlights = resultAttributeHighlight.getHighlights();
+
+            for (Highlight highlight : highlights) {
+              processHighlight(processedHighlight, matchingResult, attributeName, highlight);
+            }
+          }
+        }
+        addToProcessedHighlights(processedHighlights, processedHighlight);
+      }
+    }
+
+    input.getProperties().put(Constants.QUERY_HIGHLIGHT_KEY, processedHighlights);
+    return input;
+  }
+
+  private void processHighlight(
+      ProcessedHighlight processedHighlight,
+      Result matchingResult,
+      String attributeName,
+      Highlight highlight) {
+    Attribute attribute = matchingResult.getMetacard().getAttribute(attributeName);
+    String value = (String) attribute.getValues().get(highlight.getValueIndex());
+
+    if (!value.equals("REDACTED")) {
+      String highlightedString = createHighlightString(highlight, value, attributeName);
+      processedHighlight.addHighlight(
+          attributeName,
+          highlightedString,
+          String.valueOf(highlight.getBeginIndex()),
+          String.valueOf(highlight.getEndIndex()),
+          String.valueOf(highlight.getValueIndex()));
+    }
+  }
+
+  private void addToProcessedHighlights(
+      ArrayList<ProcessedHighlight> processedHighlights, ProcessedHighlight processedHighlight) {
+    if (!processedHighlight.getHighlights().isEmpty()) {
+      processedHighlights.add(processedHighlight);
+    }
+  }
+
+  @VisibleForTesting
+  protected String createHighlightString(Highlight highlight, String value, String attribute) {
+    String startBuffer = getStartBuffer(highlight, value, attribute);
+    String endBuffer = getEndBuffer(highlight, value, attribute);
+
+    String substring =
+        "<span class=\"highlight\">"
+            + value.substring(highlight.getBeginIndex(), highlight.getEndIndex())
+            + "</span>";
+
+    return startBuffer + substring + endBuffer;
+  }
+
+  @VisibleForTesting
+  protected String getStartBuffer(Highlight highlight, String value, String attribute) {
+    String startBuffer = "";
+
+    // A special case for title is that we want the whole string
+    if (attribute.equals(Metacard.TITLE)) {
+      return value.substring(0, highlight.getBeginIndex());
+    }
+    // if the highlighted section is at the beginning, don't add a start buffer
+    if (highlight.getBeginIndex() > 0) {
+      int startIndex = highlight.getBeginIndex() - bufferSize;
+      if (startIndex <= 0) {
+        startBuffer = value.substring(0, highlight.getBeginIndex());
+      } else startBuffer = "...".concat(value.substring(startIndex, highlight.getBeginIndex()));
+    }
+    return startBuffer;
+  }
+
+  @VisibleForTesting
+  protected String getEndBuffer(Highlight highlight, String value, String attribute) {
+    String endBuffer = "";
+
+    // A special case for title is that we want the whole string
+    if (attribute.equals(Metacard.TITLE)) {
+      return value.substring(highlight.getEndIndex());
+    }
+    // if the highlighted section is at the end, don't add an end buffer
+    if (highlight.getEndIndex() != value.length()) {
+      int endIndex = highlight.getEndIndex() + bufferSize;
+      if (endIndex >= value.length()) {
+        endBuffer = value.substring(highlight.getEndIndex());
+      } else {
+        endBuffer = value.substring(highlight.getEndIndex(), endIndex).concat("...");
+      }
+    }
+    return endBuffer;
+  }
+}

--- a/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="highlightTransformPlugin"
+          class="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransformPlugin"/>
+    <service ref="highlightTransformPlugin" interface="ddf.catalog.plugin.PostQueryPlugin"/>
+</blueprint>

--- a/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
+++ b/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
@@ -1,0 +1,156 @@
+/* Copyright (c) Connexta, LLC */
+package org.codice.ddf.catalog.ui.plugin.highlight;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.operation.Highlight;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResultAttributeHighlight;
+import ddf.catalog.operation.ResultHighlight;
+import ddf.catalog.operation.impl.HighlightImpl;
+import ddf.catalog.operation.impl.QueryResponseImpl;
+import ddf.catalog.operation.impl.ResultAttributeHighlightImpl;
+import ddf.catalog.operation.impl.ResultHighlightImpl;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HighlightTransformPluginTest {
+  QueryRequest request;
+
+  private QueryResponse input;
+
+  // Use a smaller buffer size for ease of testing
+  private HighlightTransformPlugin plugin = new HighlightTransformPlugin(10);
+
+  private String value = "Lorem ipsum dolor sit amet";
+
+  @Before
+  public void setup() {
+    request = mock(QueryRequest.class);
+    input = new QueryResponseImpl(request);
+  }
+
+  @Test
+  public void testNoHighlights() {
+    QueryResponse output = plugin.process(input);
+    assertThat(output.getProperties(), hasKey(Constants.QUERY_HIGHLIGHT_KEY));
+    assertThat(
+        output.getProperties().get(Constants.QUERY_HIGHLIGHT_KEY), is(Collections.EMPTY_LIST));
+  }
+
+  @Test
+  public void testProcessHighlights() {
+    String id = "123456789";
+    // Highlight the word "Lorem"
+    Highlight highlight = new HighlightImpl(0, 5);
+
+    Metacard metacard = new MetacardImpl();
+    metacard.setAttribute(new AttributeImpl("description", value));
+    metacard.setAttribute(new AttributeImpl("id", "123456789"));
+    Result result = new ResultImpl(metacard);
+
+    QueryResponse response = new QueryResponseImpl(request, Arrays.asList(result), 1);
+    ResultAttributeHighlight resultAttributeHighlight =
+        new ResultAttributeHighlightImpl("description", Arrays.asList(highlight));
+    ResultHighlight resultHighlight =
+        new ResultHighlightImpl(id, Arrays.asList(resultAttributeHighlight));
+
+    response
+        .getProperties()
+        .put(Constants.QUERY_HIGHLIGHT_KEY, (Serializable) Arrays.asList(resultHighlight));
+
+    QueryResponse processedResponse = plugin.process(response);
+    assertThat(
+        processedResponse.getProperties().containsKey(Constants.QUERY_HIGHLIGHT_KEY), is(true));
+    ArrayList<HighlightTransformPlugin.ProcessedHighlight> highlights =
+        (ArrayList<HighlightTransformPlugin.ProcessedHighlight>)
+            processedResponse.getProperties().get(Constants.QUERY_HIGHLIGHT_KEY);
+    assertThat(highlights.get(0).getId(), is("123456789"));
+    assertThat(highlights.get(0).getHighlights().get(0).get("attribute"), is("description"));
+    assertThat(
+        highlights.get(0).getHighlights().get(0).get("highlight"),
+        is("<span class=\"highlight\">Lorem</span> ipsum dol..."));
+  }
+
+  @Test
+  public void testGetStartBufferWithHighlightAtStart() {
+    // Highlight the word "Lorem"
+    Highlight highlight = new HighlightImpl(0, 5);
+    String startBuffer = plugin.getStartBuffer(highlight, value, "description");
+    // Assert that the buffer is blank because its the first word in the string
+    assertThat(startBuffer, equalTo(""));
+  }
+
+  @Test
+  public void testGetStartBufferWithHighlightInMiddle() {
+    // Highlight the word "dolor"
+    Highlight highlight = new HighlightImpl(12, 17);
+    String startBuffer = plugin.getStartBuffer(highlight, value, "description");
+    // Assert that the buffer contains front trail because its mid string
+    assertThat(startBuffer, equalTo("...rem ipsum "));
+  }
+
+  @Test
+  public void testGetStartBufferAtStartOfValue() {
+    // Highlight the word "ipsum"
+    Highlight highlight = new HighlightImpl(6, 11);
+    String startBuffer = plugin.getStartBuffer(highlight, value, "description");
+    // Assert that the buffer doesn't have front trail and starts at first word
+    assertThat(startBuffer, equalTo("Lorem "));
+  }
+
+  @Test
+  public void testGetEndBufferWithHighlightAtEnd() {
+    // Highlight the word "amet"
+    Highlight highlight = new HighlightImpl(22, 26);
+    String startBuffer = plugin.getEndBuffer(highlight, value, "description");
+    // Assert that the buffer is blank because its the last word in the string
+    assertThat(startBuffer, equalTo(""));
+  }
+
+  @Test
+  public void testGetEndBufferWithHighlightInMiddle() {
+    // Highlight the word "ipsum"
+    Highlight highlight = new HighlightImpl(6, 11);
+    String endBuffer = plugin.getEndBuffer(highlight, value, "description");
+    // Assert that the buffer has end trail as it is mid string
+    assertThat(endBuffer, equalTo(" dolor sit..."));
+  }
+
+  @Test
+  public void testGetEndBufferAtEndOfValue() {
+    // Highlight the word "dolor"
+    Highlight highlight = new HighlightImpl(12, 17);
+    String startBuffer = plugin.getEndBuffer(highlight, value, "description");
+    // Assert that the buffer stops on last word
+    assertThat(startBuffer, equalTo(" sit amet"));
+  }
+
+  @Test
+  public void testDontTruncateTitles() {
+    // Highlight the word "dolor"
+    Highlight highlight = new HighlightImpl(12, 17);
+    String resultString = plugin.createHighlightString(highlight, value, "title");
+    // Assert that the buffer stops on last word
+    assertThat(
+        resultString, equalTo("Lorem ipsum <span class=\"highlight\">dolor</span> sit amet"));
+  }
+}

--- a/ui-backend/intrigue-ui-app/pom.xml
+++ b/ui-backend/intrigue-ui-app/pom.xml
@@ -117,6 +117,11 @@
     <dependencies>
         <dependency>
             <groupId>org.codice.ddf.search</groupId>
+            <artifactId>catalog-plugin-highlight</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.search</groupId>
             <artifactId>catalog-ui-search</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/ui-backend/intrigue-ui-app/src/main/resources/features.xml
+++ b/ui-backend/intrigue-ui-app/src/main/resources/features.xml
@@ -61,6 +61,7 @@
         <bundle>mvn:org.codice.ddf.search/audit-api/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.search/audit-application/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.search/audit-logging/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.search/catalog-plugin-highlight/${project.version}</bundle>
     </feature>
 
     <feature name="javalin" version="${project.version}" description="Javalin Web Framework">

--- a/ui-backend/pom.xml
+++ b/ui-backend/pom.xml
@@ -20,6 +20,7 @@
         <module>catalog-ui-search</module>
         <module>catalog-ui-oauth</module>
         <module>catalog-ui-splitter</module>
+        <module>catalog-plugin-highlight</module>
         <module>intrigue-ui-app</module>
         <module>audit</module>
         <module>javalin-utils</module>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
@@ -17,13 +17,18 @@ const comparator = (a: AttributeHighlight, b: AttributeHighlight) => {
 
 export const displayHighlightedAttrInFull = (
   highlights: Array<AttributeHighlight>,
-  text: String
+  text: String,
+  index: number,
 ) => {
   //sort these in the order in which they appear
   highlights.sort(comparator)
+  // only use the highlights from this value if multivalued
+  const filteredHighlights = highlights.filter(highlight => 
+    parseInt(highlight.valueIndex) === index
+  )
   let textArray = []
   let currentIndex = 0
-  highlights.forEach((highlight, index) => {
+  filteredHighlights.forEach((highlight, index) => {
     const highlightStart = parseInt(highlight.startIndex)
     const highlightEnd = parseInt(highlight.endIndex)
     const beforeText = (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/highlightUtil.tsx
@@ -18,13 +18,13 @@ const comparator = (a: AttributeHighlight, b: AttributeHighlight) => {
 export const displayHighlightedAttrInFull = (
   highlights: Array<AttributeHighlight>,
   text: String,
-  index: number,
+  index: number
 ) => {
   //sort these in the order in which they appear
   highlights.sort(comparator)
   // only use the highlights from this value if multivalued
-  const filteredHighlights = highlights.filter(highlight => 
-    parseInt(highlight.valueIndex) === index
+  const filteredHighlights = highlights.filter(
+    (highlight) => parseInt(highlight.valueIndex) === index
   )
   let textArray = []
   let currentIndex = 0

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -463,7 +463,7 @@ const AttributeComponent = ({
                 })
               }}
             >
-              <EditIcon/>
+              <EditIcon />
             </Button>
           </div>
         )}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -463,7 +463,7 @@ const AttributeComponent = ({
                 })
               }}
             >
-              <EditIcon></EditIcon>
+              <EditIcon/>
             </Button>
           </div>
         )}
@@ -561,7 +561,8 @@ const AttributeComponent = ({
                               }
                               return displayHighlightedAttrInFull(
                                 lazyResult.highlights[attr],
-                                val
+                                val,
+                                index
                               )
                             } else {
                               return <Typography>{val}</Typography>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -33,6 +33,7 @@ export type AttributeHighlight = {
   attribute: string
   endIndex: string
   startIndex: string
+  valueIndex: string
 }
 
 export type AttributeHighlights = {


### PR DESCRIPTION
## What this PR does:

1. Contributes back a plugin that makes the highlighting structure easier to work with. This is has been used and tested in a downstream project. This makes it easier to work with highlights on the frontend and makes it so everyone can use this functionality now.
![Screen Shot 2020-11-24 at 11 15 38](https://user-images.githubusercontent.com/9013407/100135276-a70a7180-2e46-11eb-99c7-19952ea1a1a1.png)
2. In our original implementation of this plugin, we had a 10 character buffer for previews. As part of contributing this plugin back, I've increased the buffer to make it larger and less aggressive, but kept a 10 char buffer for ease of testing 
![Screen Shot 2020-11-24 at 11 15 43](https://user-images.githubusercontent.com/9013407/100135285-aa9df880-2e46-11eb-869f-652166a22e8a.png)

### New Features:
1. Multivalued highlights now properly highlight the correct term instead of all terms.
![Screen Shot 2020-11-24 at 11 16 51](https://user-images.githubusercontent.com/9013407/100135289-ad005280-2e46-11eb-97c7-b58b0551dceb.png)
2. Doing a star search on an attribute (e.g. "return results that have the **language** attribute") will highlight all values.
![Screen Shot 2020-11-24 at 11 17 05](https://user-images.githubusercontent.com/9013407/100135298-aeca1600-2e46-11eb-9cef-2e72642bbf9c.png)
