### PR TITLE
[WIP] Adjusts spellcheck to be done presearch (inline on any text field)

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/text.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/text.tsx
@@ -14,8 +14,14 @@
  **/
 import * as React from 'react'
 
-import MuiTextField from '@material-ui/core/TextField'
+import MuiTextField, {
+  TextFieldProps as MuiTextFieldProps,
+} from '@material-ui/core/TextField'
 import { ValueTypes } from '../filter-builder/filter.structure'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import CloseIcon from '@material-ui/icons/Close'
+import Button from '@material-ui/core/Button'
+import OverflowTooltip from '../overflow-tooltip/overflow-tooltip'
 
 /**
  * Use this to easily latch onto events for this input in ancestor components (pressing enter to search, etc.)
@@ -30,6 +36,8 @@ const inputProps = {
 type TextFieldProps = {
   value: ValueTypes['text']
   onChange: (val: ValueTypes['text']) => void
+  TextFieldProps?: Partial<MuiTextFieldProps>
+  SpellingSuggestionClassName?: string
 }
 
 const defaultValue = ''
@@ -40,22 +48,101 @@ const validateShape = ({ value, onChange }: TextFieldProps) => {
   }
 }
 
-export const TextField = ({ value, onChange }: TextFieldProps) => {
+export const TextField = ({
+  value,
+  onChange,
+  TextFieldProps,
+  SpellingSuggestionClassName,
+}: TextFieldProps) => {
   React.useEffect(() => {
     validateShape({ value, onChange })
   }, [])
+  const [spellingSuggestion, setSpellingSuggestion] = React.useState(
+    '' as string
+  )
+  const [checkingSpelling, setCheckingSpelling] = React.useState(false)
+  React.useEffect(() => {
+    let timeoutid = (undefined as unknown) as NodeJS.Timeout
+    setSpellingSuggestion('')
+    // should we filter out * and other types of weird values?
+    // we could add a user preference check to this as well, so folks can disable it permanently
+    if (value && value !== spellingSuggestion && value !== '*') {
+      setCheckingSpelling(true)
+      timeoutid = setTimeout(() => {
+        // hit suggestion endpoint, precanned for now
+        fetch('').then(() => {
+          setCheckingSpelling(false)
+          setSpellingSuggestion(value + 's') // fake suggestion until we get endpoint
+        })
+      }, 500)
+    }
+    return () => {
+      setCheckingSpelling(false)
+      clearTimeout(timeoutid)
+    }
+  }, [value])
   return (
-    <MuiTextField
-      fullWidth
-      variant="outlined"
-      placeholder="Use * for wildcard."
-      value={value || ''}
-      onChange={(e) => {
-        onChange(e.target.value)
-      }}
-      inputProps={inputProps}
-      className="whitespace-normal"
-      size="small"
-    />
+    <>
+      <MuiTextField
+        fullWidth
+        variant="outlined"
+        placeholder="Use * for wildcard."
+        value={value || ''}
+        onChange={(e) => {
+          onChange(e.target.value)
+        }}
+        inputProps={inputProps}
+        className="whitespace-normal"
+        size="small"
+        InputProps={{
+          endAdornment: checkingSpelling ? (
+            <CircularProgress style={{ width: '1rem', height: '1rem' }} />
+          ) : null,
+        }}
+        {...TextFieldProps}
+      />
+      {spellingSuggestion ? (
+        <>
+          <div className={`ml-2 p-2 -mb-2 ${SpellingSuggestionClassName}`}>
+            <div className="flex flex-row items-center flex-no-wrap">
+              <div className="flex-shrink-0" style={{ width: '100px' }}>
+                Did you mean{' '}
+              </div>
+              <OverflowTooltip>
+                {({ refOfThingToMeasure }) => {
+                  return (
+                    <Button
+                      onClick={() => {
+                        onChange(spellingSuggestion)
+                      }}
+                      className="flex-shrink"
+                      variant="text"
+                      color="primary"
+                      size="small"
+                      title={spellingSuggestion}
+                    >
+                      <span ref={refOfThingToMeasure} className="truncate">
+                        {spellingSuggestion}
+                      </span>
+                    </Button>
+                  )
+                }}
+              </OverflowTooltip>
+              <div>?</div>
+              <Button
+                onClick={() => {
+                  setSpellingSuggestion('')
+                }}
+                variant="text"
+                color="inherit"
+                size="small"
+              >
+                <CloseIcon />
+              </Button>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overflow-tooltip/overflow-tooltip.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overflow-tooltip/overflow-tooltip.tsx
@@ -1,0 +1,70 @@
+import React, { useRef, useEffect, useState, MutableRefObject } from 'react'
+import Tooltip, { TooltipProps } from '@material-ui/core/Tooltip'
+import Paper from '@material-ui/core/Paper'
+import { hot } from 'react-hot-loader'
+import { Elevations } from '../theme/theme'
+
+type OverflowTipType = {
+  children: ({
+    refOfThingToMeasure,
+  }: {
+    refOfThingToMeasure?: MutableRefObject<HTMLDivElement>
+  }) => JSX.Element
+  tooltipProps?: Partial<TooltipProps>
+}
+const OverflowTip = ({ children, tooltipProps }: OverflowTipType) => {
+  // Create Ref
+  const textElementRef = useRef<any>()
+
+  const compareSize = () => {
+    if (textElementRef.current) {
+      const compare =
+        textElementRef.current.scrollWidth > textElementRef.current.clientWidth
+      console.log('compare: ', compare)
+      setIsOverflowed(compare)
+    } else {
+      console.log(
+        'WARNING: No element found to compare.  You must take in and set a ref (refOfThingToMeasure) on one of your elements so this knows when to display a tooltip.'
+      )
+    }
+  }
+
+  // compare once and add resize listener on "componentDidMount"
+  useEffect(() => {
+    compareSize()
+    window.addEventListener('resize', compareSize)
+  }, [])
+
+  // remove resize listener again on "componentWillUnmount"
+  useEffect(
+    () => () => {
+      window.removeEventListener('resize', compareSize)
+    },
+    []
+  )
+
+  // Define state and function to update the value
+  const [isOverflowed, setIsOverflowed] = useState(false)
+  return (
+    <Tooltip
+      title={
+        <Paper
+          className="p-1 overflow-auto max-w-screen-sm"
+          elevation={Elevations.overlays}
+        >
+          {children({})}
+        </Paper>
+      }
+      PopperProps={{
+        className: '',
+      }}
+      disableHoverListener={!isOverflowed}
+      disableFocusListener={!isOverflowed}
+      {...tooltipProps}
+    >
+      {children({ refOfThingToMeasure: textElementRef })}
+    </Tooltip>
+  )
+}
+
+export default hot(module)(OverflowTip)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
@@ -41,6 +41,7 @@ import Grid from '@material-ui/core/Grid'
 import Chip from '@material-ui/core/Chip'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 import TypedMetacardDefs from '../tabs/metacard/metacardDefinitions'
+import { TextField as CustomTextField } from '../fields/text'
 
 function isNested(filter: any) {
   let nested = false
@@ -387,31 +388,29 @@ const QueryBasic = ({ model }: QueryBasicProps) => {
       <div className="editor-properties px-2 py-3">
         <div className="">
           <Typography className="pb-2">Keyword</Typography>
-          <TextField
-            fullWidth
+          <CustomTextField
             value={basicFilter.anyText ? basicFilter.anyText[0].value : ''}
-            placeholder={`Text to search for. Use "*" for wildcard.`}
-            id="Text"
-            onChange={(e) => {
+            onChange={(value) => {
               basicFilter.anyText[0] = new FilterClass({
                 ...basicFilter.anyText[0],
-                value: e.target.value,
+                value: value,
               })
               model.set(
                 'filterTree',
                 constructFilterFromBasicFilter({ basicFilter })
               )
             }}
-            onKeyUp={(e) => {
-              if (e.which === 13) {
-                model.startSearchFromFirstPage()
-              }
+            SpellingSuggestionClassName="-mb-4"
+            TextFieldProps={{
+              id: 'Text',
+              inputProps: { ref: inputRef },
+              onKeyUp: (e) => {
+                if (e.which === 13) {
+                  model.startSearchFromFirstPage()
+                }
+              },
+              placeholder: `Text to search for. Use "*" for wildcard.`,
             }}
-            inputProps={{
-              ref: inputRef as any,
-            }}
-            size="small"
-            variant="outlined"
           />
         </div>
         <div className="pt-2">


### PR DESCRIPTION
 - blank and * do not send a spellcheck suggestion, we can adjust this as much as we like.
 - does not remove the old setting, this is to see if folks like this style.  If they do, we'll add on to this and use the old setting to turn on and off spellcheck
 - Right now it's a canned suggestion that simply adds 's' to everything.
 - Users can dismiss them, or accept them.

![Screen Shot 2020-12-02 at 2 12 33 PM](https://user-images.githubusercontent.com/11984853/100932056-8d050a80-34a8-11eb-8017-9ad49b0267ae.png)
![Screen Shot 2020-12-02 at 2 13 14 PM](https://user-images.githubusercontent.com/11984853/100932058-8d9da100-34a8-11eb-9bd4-57370eb6b988.png)
![Screen Shot 2020-12-02 at 2 13 08 PM](https://user-images.githubusercontent.com/11984853/100932060-8e363780-34a8-11eb-8155-0be721229903.png)
![Screen Shot 2020-12-02 at 2 12 45 PM](https://user-images.githubusercontent.com/11984853/100932062-8ecece00-34a8-11eb-8fee-05e56bfe6d1c.png)

Do not merge this, it's merely for others to decide if we want to move forward on this.  We'd need to remove some old spellcheck stuff, and adjust it to use the old setting for if spellcheck is on or not (for users to turn off / on).