### PR TITLE
[3.4.x] G-8544 Removed 180 degree width constraint on bounding boxes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -177,7 +177,8 @@ module.exports = Backbone.AssociatedModel.extend({
       this.setBboxDmsFromMap()
     } else if (this.get('locationType') === 'dd') {
       this.setBboxLatLonFromMap()
-    } else if (this.get('prevLocationType') === 'utmUps') {
+    }
+    if (this.get('prevLocationType') === 'utmUps') {
       this.set('prevLocationType', '')
       this.set('locationType', 'utmUps')
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -21,6 +21,7 @@ const store = require('../../js/store.js')
 const Common = require('../../js/Common.js')
 const dmsUtils = require('../location-new/utils/dms-utils.js')
 const DistanceUtils = require('../../js/DistanceUtils.js')
+import { validateGeo } from '../../react-component/utils/validation'
 
 const converter = new usngs.Converter()
 const utmUpsLocationType = 'utmUps'
@@ -174,9 +175,9 @@ module.exports = Backbone.AssociatedModel.extend({
   drawingOff() {
     if (this.get('locationType') === 'dms') {
       this.setBboxDmsFromMap()
-    }
-    const prevLocationType = this.get('prevLocationType')
-    if (prevLocationType === 'utmUps') {
+    } else if (this.get('locationType') === 'dd') {
+      this.setBboxLatLonFromMap()
+    } else if (this.get('prevLocationType') === 'utmUps') {
       this.set('prevLocationType', '')
       this.set('locationType', 'utmUps')
     }
@@ -744,6 +745,47 @@ module.exports = Backbone.AssociatedModel.extend({
       },
       { silent: true }
     )
+  },
+
+  setBboxLatLonFromMap() {
+    let east = this.get('east') % 360
+    let west = this.get('west') % 360
+    if (east < -180) {
+      east += 360
+    } else if (east > 180) {
+      east -= 360
+    }
+    if (west > 180) {
+      west -= 360
+    } else if (west < -180) {
+      west += 360
+    }
+    if (
+      validateGeo(
+        'polygon',
+        JSON.stringify([
+          [west, this.get('north')],
+          [east, this.get('north')],
+          [west, this.get('south')],
+          [east, this.get('south')],
+          [west, this.get('north')],
+        ])
+      ).error
+    ) {
+      this.set({
+        mapNorth: undefined,
+        mapSouth: undefined,
+        mapEast: undefined,
+        mapWest: undefined,
+        north: undefined,
+        south: undefined,
+        east: undefined,
+        west: undefined,
+      })
+    } else {
+      this.set('east', east)
+      this.set('west', west)
+    }
   },
 
   setRadiusDmsFromMap() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.bbox.js
@@ -21,9 +21,7 @@ const properties = require('../properties.js')
 const wreqr = require('../wreqr.js')
 const NotificationView = require('./notification.view')
 const DrawingController = require('./drawing.controller')
-const olUtils = require('../OpenLayersGeometryUtils')
 const DistanceUtils = require('../DistanceUtils.js')
-import { validateGeo } from '../../react-component/utils/validation'
 
 const Draw = {}
 
@@ -86,29 +84,11 @@ Draw.BboxView = Marionette.View.extend({
       return
     }
 
-    if (
-      validateGeo(
-        'polygon',
-        JSON.stringify([
-          [west, north],
-          [east, north],
-          [west, south],
-          [east, south],
-          [west, north],
-        ])
-      ).error
-    ) {
-      return
-    }
-
-    // If we are crossing the date line, we must go outside [-180, 180]
-    // for openlayers to draw correctly. This means we can't draw boxes
-    // that encompass more than half the world. This actually matches
-    // how the backend searches anyway.
-    if (east - west < -180) {
+    // If done drawing and east < west, adjust east value by 360
+    // because this indicates that the box crosses the antimeridian
+    // (180 degrees longitude)
+    if (!model.get('drawing') && east < west) {
       east += 360
-    } else if (east - west > 180) {
-      west += 360
     }
 
     const northWest = ol.proj.transform(
@@ -207,9 +187,7 @@ Draw.BboxView = Marionette.View.extend({
   },
 
   handleRegionStop() {
-    const geometry = olUtils.wrapCoordinatesFromGeometry(
-      this.primitive.getGeometry()
-    )
+    const geometry = this.primitive.getGeometry()
     this.setModelFromGeometry(geometry)
     this.updateGeometry(this.model)
     this.listenTo(


### PR DESCRIPTION
#### ddf 2.19.x pr https://github.com/codice/ddf/pull/6452
_______________________________________
#### What does this PR do?
This PR removes the 180 degree width restraint on bounding boxes by checking whether or not it crosses the antimeridian using the conditional of not drawing and `east < west` instead of `east - west > 180 || east - west < -180` 
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
#### How should this be tested?
Verify that you can draw bounding boxes that cross the prime meridian and the antimeridian
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: G-8544
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.