### PR TITLE
[3.4.x] G-9453 Added CQL Sanitizing method for Search Save and Query Titles

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -143,6 +143,11 @@ module.exports = Marionette.LayoutView.extend({
     this.$el.removeClass('is-editing')
     this.onBeforeShow()
   },
+  setDefaultTitle() {
+    this.queryView
+      ? this.queryView.setDefaultTitle()
+      : this.queryContent.currentView.setDefaultTitle()
+  },
   save() {
     const queryContentView = this.queryView
       ? this.queryView
@@ -154,9 +159,13 @@ module.exports = Marionette.LayoutView.extend({
     }
     queryContentView.save()
     this.queryTitle.currentView.save()
+    if (this.model.get('title') === '') {
+      this.setDefaultTitle()
+    }
     if (store.getCurrentQueries().get(this.model) === undefined) {
       store.getCurrentQueries().add(this.model)
     }
+    this.model.cqlSanitizePlugin()
     this.cancel()
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     this.originalType = this.model.get('type')
@@ -172,6 +181,9 @@ module.exports = Marionette.LayoutView.extend({
     }
     queryContentView.save()
     this.queryTitle.currentView.save()
+    if (this.model.get('title') === '') {
+      this.setDefaultTitle()
+    }
     if (store.getCurrentQueries().get(this.model) === undefined) {
       store.getCurrentQueries().add(this.model)
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-title/query-title.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-title/query-title.view.js
@@ -84,10 +84,14 @@ module.exports = Marionette.LayoutView.extend({
   },
   handleTitleUpdate() {
     this.$el.find('input').val(this.model.get('title'))
+    this.updateButtonTitle()
   },
   updateQueryName(e) {
-    this.$el.find('.button-title').html(this.getSearchTitle() + zeroWidthSpace)
+    this.updateButtonTitle()
     this.save()
+  },
+  updateButtonTitle() {
+    this.$el.find('.button-title').html(this.getSearchTitle() + zeroWidthSpace)
   },
   save() {
     this.model.set('title', this.$el.find('input').val())

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-title/query-title.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-title/query-title.view.js
@@ -84,7 +84,6 @@ module.exports = Marionette.LayoutView.extend({
   },
   handleTitleUpdate() {
     this.$el.find('input').val(this.model.get('title'))
-    this.updateQueryName()
   },
   updateQueryName(e) {
     this.$el.find('.button-title').html(this.getSearchTitle() + zeroWidthSpace)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -316,6 +316,9 @@ Query.Model = PartialAssociatedModel.extend({
       })
     })
   },
+  cqlSanitizePlugin() {
+    return
+  },
   async preQueryPlugin(data) {
     return data
   },


### PR DESCRIPTION
What does this PR do?

Forward port of https://github.com/codice/ddf/pull/6445

Adds a method to sanitize CQL queries for use in downstream projects as well as ported changes from https://github.com/codice/ddf/pull/6433 which solves a related issue.

Who is reviewing it?
@leo-sakh
@jMoneee
@frnkshin
@cassandrabailey293

How should this be tested?
build / run, verify no regression when building searches without titles and default titles are getting set /saved correctly, verify when editing a query by removing it's title that saving / running the query produces the correct default title.

