### PR TITLE
Search Result Highlighting Update Highlight Style (#6243)

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -86,7 +86,7 @@ const GlobalStyles = createGlobalStyle<ThemeInterface>`
         outline: none !important; 
       }
       span.highlight {
-        font-weight: bolder;
+        background-color: rgba(66, 110, 203, 0.40);
       }
       .MuiToolbar-root a,
       .MuiToolbar-root .MuiBreadcrumbs-separator {


### PR DESCRIPTION
Update highlighted results to have light blue backgrounds while removing the bold effect. 

I added a transparency to these to blend better with light and dark themes: ✅ 

I thought the 100% blue highlight was overpowering the dark text: ❌ 

Light mode:
![Screen Shot 2020-12-15 at 10 05 34 AM](https://user-images.githubusercontent.com/1139009/102248202-288d7680-3ebe-11eb-9615-3ada049fb055.png)

Dark Mode:
![Screen Shot 2020-12-15 at 10 08 24 AM](https://user-images.githubusercontent.com/1139009/102248253-3642fc00-3ebe-11eb-9c44-90759ef33be8.png)

