### PR TITLE
fix default column order for exporting the table

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -20,14 +20,12 @@ import {
   Transformer,
 } from '../../react-component/utils/export'
 const user = require('../../component/singletons/user-instance.js')
-import Sources from '../../component/singletons/sources-instance'
 import {
   exportResultSet,
   ExportCountInfo,
   DownloadInfo,
 } from '../../react-component/utils/export'
 import saveFile from '../../react-component/utils/save-file'
-const _ = require('underscore')
 const announcement = require('../../component/announcement/index.jsx')
 const properties = require('../../js/properties.js')
 const contentDisposition = require('content-disposition')
@@ -65,8 +63,7 @@ export function getStartIndex(
   //   : 1
 }
 function getSrcs(selectionInterface: any) {
-  const srcs = selectionInterface.getCurrentQuery().get('src')
-  return srcs === undefined ? _.pluck(Sources.toJSON(), 'id') : srcs
+  return selectionInterface.getCurrentQuery().getSelectedSources()
 }
 export function getSrcCount(
   src: any,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -197,7 +197,7 @@ export const getDownloadBody = (downloadInfo: DownloadInfo) => {
   const sorts = getSorts(selectionInterface)
   const args = {
     hiddenFields: hiddenFields.length > 0 ? hiddenFields : [],
-    columnOrder: columnOrder.length > 0 ? columnOrder : {},
+    columnOrder: columnOrder.length > 0 ? columnOrder : [],
     columnAliasMap: properties.attributeAliases,
   }
 


### PR DESCRIPTION
For exporting a table, the default column order was "{}", but needs to be "[]".

This is for the "Export" link that appears at the top of the search results, not the export option from the three-dot context menus.

To test, you will need two sources, one local and one remote. I used the geoserver docker and created a WFS 1.1.0 source. See the geoserver readme if you need help setting it up.

Try exporting results with two source, one local source, and one remote source. 
