### PR TITLE
Fixes a race condition where extension point was referenced too early

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -575,11 +575,6 @@ const CustomList = ({
   )
 }
 
-const getCustomEditableAttributes = (async () => {
-  const attrs = await extension.customEditableAttributes()
-  return attrs
-})()
-
 export const useCustomReadOnlyCheck = () => {
   const [
     customEditableAttributes,
@@ -588,7 +583,7 @@ export const useCustomReadOnlyCheck = () => {
   const [loading, setLoading] = React.useState(true)
 
   const initializeCustomEditableAttributes = async () => {
-    const attrs = await getCustomEditableAttributes
+    const attrs = await extension.customEditableAttributes()
     if (attrs !== undefined) {
       setCustomEditableAttributes(attrs)
     }


### PR DESCRIPTION
Changes the order ever so slightly of this call out to our extension point to avoid a race condition where the extension point would never get called.

To test: 
Using a downstream project, create a customEditableAttributes extension and verify that the customEditableAttributes extension point gets called.