### PR TITLE
Fixes ids for map layers

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layer-item/layer-item.collection.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layer-item/layer-item.collection.view.js
@@ -23,7 +23,8 @@ import LayerItem from '../../react-component/layer-item'
 const LayerItemView = Marionette.ItemView.extend({
   attributes() {
     return {
-      'data-id': this.model.id,
+      'data-id': 'layer-item-collection-container',
+      'layer-id': this.model.id,
     }
   },
   template() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layer-item/layer-item.collection.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layer-item/layer-item.collection.view.js
@@ -23,7 +23,7 @@ import LayerItem from '../../react-component/layer-item'
 const LayerItemView = Marionette.ItemView.extend({
   attributes() {
     return {
-      'data-id': 'layer-item-collection-container',
+      'data-id': this.model.id,
     }
   },
   template() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layers/layers.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layers/layers.view.js
@@ -133,7 +133,7 @@ module.exports = Marionette.LayoutView.extend({
       (element, index) => {
         this.model
           .get('mapLayers')
-          .get(element.getAttribute('data-id'))
+          .get(element.getAttribute('layer-id'))
           .set('order', index)
       }
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/layer-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/layer-item.tsx
@@ -134,7 +134,7 @@ class LayerItem extends React.Component<ContainerProps, State> {
     }
 
     return (
-      <Component data-id={id}>
+      <Component data-id="layer-item-container" layer-id={id}>
         <LayerItemPresentation {...props} />
       </Component>
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/layer-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/layer-item.tsx
@@ -134,7 +134,7 @@ class LayerItem extends React.Component<ContainerProps, State> {
     }
 
     return (
-      <Component data-id="layer-item-container">
+      <Component data-id={id}>
         <LayerItemPresentation {...props} />
       </Component>
     )


### PR DESCRIPTION
[This function](https://github.com/codice/ddf-ui/blob/master/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layers/layers.view.js#L130-L141) was looking for the data-id in order to properly update the order but it was failing since the data-id would never match any of the ids.

To test, make sure you can reorder map layers, reset default, and do all those fun map layer things.