### PR TITLE
Removes default filter tree from model

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -142,12 +142,6 @@ Query.Model = Backbone.AssociatedModel.extend({
     return _merge(
       {
         cql: "anyText ILIKE '*'",
-        filterTree: new FilterBuilderClass({
-          filters: [
-            new FilterClass({ value: '*', property: 'anyText', type: 'ILIKE' }),
-          ],
-          type: 'AND',
-        }),
         associatedFormModel: undefined,
         excludeUnnecessaryAttributes: true,
         count: properties.resultCount,


### PR DESCRIPTION
 - If we don't, we don't have a way to force reconstitution from cql.  This is because the defaults function runs before the initialize where we do the reconstution from cql.  Furthermore, there isn't a way that I can see in the defaults call to access what the attributes are, so no dice on doing some logic there.
 - The side effect of this, is if a query is made now without a filterTree specified (or cql), the default filter tree is actually reconstituted from the cql default.