### PR TITLE
Swaps the keyword in the location component out for the gazetteer

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/gazetteer-autocomplete.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/gazetteer-autocomplete.tsx
@@ -4,10 +4,14 @@ import { Suggestion } from '../location/gazetteer'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import TextField, { TextFieldProps } from '@material-ui/core/TextField'
+import Button from '@material-ui/core/Button'
+import Chip from '@material-ui/core/Chip'
+import RoomIcon from '@material-ui/icons/Room'
+import DeleteIcon from '@material-ui/icons/Clear'
 
 type Props = {
   suggester: (input: string) => Promise<Suggestion[]>
-  onChange: (suggestion: Suggestion) => Promise<void>
+  onChange: (suggestion?: Suggestion) => Promise<void>
   debounce?: number
   minimumInputLength?: number
   onError?: any
@@ -24,7 +28,8 @@ const GazetteerAutoComplete = ({
   value,
   ...props
 }: Props) => {
-  const [input, setInput] = useState('')
+  const [selected, setSelected] = React.useState(value)
+  const [input, setInput] = useState(value)
   const [loading, setLoading] = useState(false)
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -87,6 +92,34 @@ const GazetteerAutoComplete = ({
     } else {
       return error || 'No results found'
     }
+  }
+  React.useEffect(() => {
+    setSelected(Boolean(value))
+  }, [value])
+
+  if (selected) {
+    return (
+      <Chip
+        className="w-full px-2 py-1 mt-2 justify-start rounded"
+        style={{ height: '42px' }}
+        avatar={<RoomIcon />}
+        label={
+          <div className="flex flex-row flex-no-wrap items-center">
+            <div className="flex-shrink w-full truncate">{value}</div>
+            <Button
+              color="primary"
+              className="flex-shrink-0"
+              onClick={() => {
+                props.onChange(undefined)
+              }}
+            >
+              <DeleteIcon />
+            </Button>
+          </div>
+        }
+        variant="outlined"
+      />
+    )
   }
 
   return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.tsx
@@ -108,6 +108,7 @@ export const getLargestBbox = (
 }
 
 type Props = {
+  value: string
   setState: any
   fetch?: any
   placeholder?: string
@@ -308,6 +309,7 @@ const Gazetteer = (props: Props) => {
     <div>
       {onlineGazetteer ? (
         <Keyword
+          value={props.value}
           setState={props.setState}
           suggester={suggester}
           geofeature={geofeature}
@@ -317,6 +319,7 @@ const Gazetteer = (props: Props) => {
         />
       ) : (
         <Keyword
+          value={props.value}
           setState={props.setState}
           suggester={suggesterWithLiteralSupport}
           geofeature={geofeatureWithLiteralSupport}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.tsx
@@ -101,6 +101,7 @@ const Keyword = (props: Props) => {
 
   const onChange = async (suggestion: Suggestion) => {
     if (!suggestion) {
+      props.setState({ hasKeyword: false, value: '', polygon: undefined })
       setValue('')
       return
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
@@ -13,7 +13,6 @@
  *
  **/
 import * as React from 'react'
-import Keyword from './keyword'
 const LocationOldModel = require('../../component/location-old/location-old')
 const CustomElements = require('../../js/CustomElements.js')
 const wreqr = require('../../js/wreqr.js')
@@ -29,6 +28,7 @@ const Line = require('./line')
 const Polygon = require('./polygon')
 const PointRadius = require('./point-radius')
 const BoundingBox = require('./bounding-box')
+import Gazetteer from './gazetteer'
 const plugin = require('plugins/location')
 
 type InputType = {
@@ -61,7 +61,7 @@ const inputs = plugin({
       return (
         // Offsets className="form-group clearfix" below
         <div style={{ marginTop: -15 }}>
-          <Keyword
+          <Gazetteer
             {...props}
             value={keywordValue}
             setState={({ value, ...data }: any) => {


### PR DESCRIPTION

https://user-images.githubusercontent.com/11984853/103969724-c83bce80-5123-11eb-8d5c-b42de38dd1ce.mov

 - Rather than have two seperate components (one in filter tree, on on the map), these are now the same.

Slight styling change from video here, to make chip less chippy.
![Screen Shot 2021-01-07 at 8 15 07 PM](https://user-images.githubusercontent.com/11984853/103970277-17ceca00-5125-11eb-8b1a-134372f3d444.png)
