### PR TITLE
Update how gazetteer clears out

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -433,6 +433,9 @@ module.exports = function CesiumMap(
       map.scene.camera.moveEnd.removeEventListener(callback)
     },
     doPanZoom(coords) {
+      if (coords.length === 0) {
+        return
+      }
       const cartArray = coords.map((coord) =>
         Cesium.Cartographic.fromDegrees(
           coord[0],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/gazetteer-autocomplete.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/gazetteer-autocomplete.tsx
@@ -132,6 +132,7 @@ const GazetteerAutoComplete = ({
       onChange={onValueSelect}
       onBlur={() => setInput('')}
       noOptionsText={getNoOptionsText()}
+      autoHighlight
       renderInput={(params) => (
         <TextField
           {...params}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.tsx
@@ -101,7 +101,7 @@ const Keyword = (props: Props) => {
 
   const onChange = async (suggestion: Suggestion) => {
     if (!suggestion) {
-      props.setState({ hasKeyword: false, value: '', polygon: undefined })
+      props.setState({ hasKeyword: false, value: '', polygon: [] })
       setValue('')
       return
     }


### PR DESCRIPTION
 - We need to set it to [] rather than undefined, otherwise the map components don't work as expected.  Also fixes an issue where clearing gazetteer on 3d map would pan back to home.  Now both 2d map and 3d map stay in place when clearing gazetteer
 - Also adds autohighlight so first option is selected automatically and user can just press enter.