### PR TITLE
Update command to better exclude certain file types

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -20,7 +20,7 @@
     "m2": "yarn install:m2",
     "install:m2": "ace clean && ace bundle --tsTranspileOnly true && ace package && ace install",
     "publish:cpx-package": "cpx package.json dist && json -I -f dist/package.json -e 'this.private=false'",
-    "publish:cpx-src": "cpx \"src/**/*.!(tsx|ts)\" dist/src",
+    "publish:cpx-src": "cpx \"src/**/*.!(*tsx|*ts)\" dist/src",
     "publish:cpx-current": "cpx \"*\" dist",
     "publish:build": "rimraf dist && yarn publish:cpx-src && yarn publish:cpx-current && tsc && yarn publish:cpx-package",
     "publish:npm": "yarn publish:build && npm publish dist -timeout=99999"


### PR DESCRIPTION
 - If a file had multiple of the '.' character in it, the previous version of the matcher wouldn't handle it correctly.  First noticed this downstream when trying to import from the filter.structure.tsx file, since it has multiple '.' characters.  This new matcher appears to work as intended.

To test this, pull down and run the `publish:cpx-src` command and verify in the dist/src/main/webapp/component/filter-builder directory there is no filter.structure.tsx file.