### PR TITLE
[3.4.x] G-9627 Line Location Buffer Error & Map issues

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
@@ -23,10 +23,7 @@ const store = require('../js/store.js')
 
 module.exports = {
   drawing(event) {
-    return (
-      event.target.constructor === HTMLCanvasElement &&
-      store.get('content').get('drawing')
-    )
+    return store.get('content').get('drawing')
   },
   hasRightRoom(left, element) {
     return left + element.clientWidth < window.innerWidth

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -123,6 +123,7 @@ module.exports = Marionette.LayoutView.extend({
     )
   },
   showQueryForm(collection, id) {
+    wreqr.vent.trigger('resetSearch')
     this.editor.show(
       new QueryAdvanced({
         model: this.model,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -598,8 +598,8 @@ module.exports = Marionette.LayoutView.extend({
             pointText = pointText.substring(0, pointText.length - 1)
             const latLon = pointText.split(' ')
             locationModel = new LocationModel({
-              lat: latLon[1],
-              lon: latLon[0],
+              lat: Number(latLon[1]),
+              lon: Number(latLon[0]),
               radius: filter.distance,
               color,
             })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -49,7 +49,7 @@ function translateFromOpenlayersCoordinates(coords) {
 function translateToOpenlayersCoordinates(coords) {
   const coordinates = []
   _.each(coords, item => {
-    if (item[0].constructor === Array) {
+    if (Array.isArray(item[0])) {
       coordinates.push(translateToOpenlayersCoordinates(item))
     } else {
       coordinates.push(
@@ -134,11 +134,15 @@ Draw.LineView = Marionette.View.extend({
       // Handles case where model changes to empty vars and we don't want to draw anymore
       return
     }
-    const lineWidth =
+    let lineWidth =
       DistanceUtils.getDistanceInMeters(
         this.model.get('lineWidth'),
         this.model.get('lineUnits')
       ) || 1
+
+    if (lineWidth < 0) {
+      lineWidth = 1
+    }
 
     rectangle.A = this.adjustPoints(rectangle.A)
     const turfLine = Turf.lineString(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -79,15 +79,11 @@ class LocationInput extends React.Component {
     this.props.listenTo(this.locationModel, 'change:mode', () => {
       this.clearLocation()
     })
-    this.props.listenTo(this.locationModel, 'change:polygon', () => {
-      if (this.locationModel.get('mode') !== 'poly') {
-        wreqr.vent.trigger('search:polydisplay', this.locationModel)
-      }
-    })
   }
   componentWillUnmount() {
     this.locationModel.off('change', this.setModelState)
-    wreqr.vent.trigger('search:drawend', this.locationModel)
+    this.clearLocation()
+    this.updateMap()
   }
   updateMap = () => {
     const mode =


### PR DESCRIPTION
ddf PRs:
2.19.x codice/ddf#6493

---------------------
#### What does this PR do?
Solve following issues:

- Issue 1 - Line Location Buffer Error. Unpredictable behavior when negative value is inputted for line Buffer.
- Issue 2 - When a shape is drawn in workspace and then go to create a Search Form and select to draw a shape, the previously drawn shape from workspace is displayed on the map.
- Issue 3 - When user click on draw and drawing on 3D map tab for Lists and/or Result Filter, if user click outside of map area, user lose the "cancel draw", but user is still able to draw, and won't be able to get rid of that shape and it won't appear on the filter form (anyGeo etc.) to delete. 
- Issue 4 - Keyword location geometry does not get cleared on 3D map, when switching between keyword values (e.g. United State, China), or location modes (e.g. Polygon, Line etc.)
- Issue 5 - Point Radius location disappears from map, after save of filter (e.g. Result filter, Lists) or performing a search (Workspace search)

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@zta6 
@Lambeaux 
@mojogitoverhere 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->


• build / run / profile install / upload sample data
• Ingest gazetteer data keywords
	https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/data/countries.geo.json
>gazetteer:update /..<path of file>../countries.geo.json

Issue 1:
1. Navigate to "Search Forms"
2. Click on '+ Search Forms' to create 
3. Add Line location for 'anyGeo' or 'location' or 'media.frame-center'
4. Open console log for debug
5. Draw Line geometry, then input negative values for Line buffer 
6. Ensure the Line geometry that was drawn does not disappear, and the negative values does not disappear from buffer input field 
7. Do same steps from 3 to 6 for Workspace Search, Workspace Result filter and Workspace Lists filter.  

Issue 2:
1. Go to Workspaces, open or click create a New Workspace
2. Click on Search and draw a shape via 'anyGeo' or 'location' or 'media.frame-center'
3. Navigate to "Search Forms"
4. Click on '+ Search Forms' to create
5. Select 'anyGeo' or 'location' or 'media.frame-center' and select a shape to draw
6. Ensure the previous drawn shape in workspace, does not appear, and able to draw new shape. When you go to workspace to draw another shape, map should be clear as well.

Issue 3:
1. Go to Workspaces, open or click create a New Workspace
2. Add 2D and 3D map. Go to 3D map
3. Click on 'Lists' tab' and "new list"
4.  select 'Yes' for "Limit based on filter"
5. Select  'anyGeo' or 'location' or 'media.frame-center' and select a shape to draw
6. If you hover over 3D Map should have a message "Click to add first point"
7. Click outside of the map, anywhere beside the "Cancel Drawing" or "Search Tab"
8. Ensure you do not loose the "Cancel Drawing"
9. Start drawing a geometry, but do not complete it
10. Ensure if you click on the "Search Tab" you lose the "Cancel Drawing" and if you hover over the 3D map, you won't see message  "Click to add first point" and will not be able to draw.
11. Ensure same thing is reflected on 2D map as well.
12. Do same test (from 5 to 11) for Result Filter. Where instead of "Search Tab" would be "Lists tab"

Issue 4:
1. Go to Workspaces, open or click create a New Workspace
2. Add 2D and 3D map. Go to 3D map
3.  Open Search and select  'anyGeo' or 'location' or 'media.frame-center' search and select keyword mode
4. Search for and select a keyword region 
5. See that the geo for that region pops up on 3D map
6. Search another region in the same anyGeo Keyword search
7. See the new region pop up and the old one go away
8. Also ensure if a keyword region is select and drawn on map, if select different drawing mode (Polygon, Line etc.), the keyword region is cleared from 3D map.
9. Do same test for Result filter and Lists filters (from 3 to 8).
 Ensure no regression for followings:
https://github.com/codice/ddf/pull/6029
https://github.com/codice/ddf/pull/6345

Issue 5:
1. Go to Workspaces, open or click create a New Workspace
2. Add 2D and 3D map. Go to 3D map
3.  Open Search and select  'anyGeo' or 'location' or 'media.frame-center' search and select keyword mode
4. Select and draw Point Radius and Click on Search
5. Ensure the Point Radius geometry is displayed on 3D and 2D map and do not disapear.
6. Do same test for Result filter (Click on Save filter) and Lists filter (click on save filter and click on create List. Note after click on create List, the shape should disappear on 3D and 2D map, and reappear if click to edit the list.)

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
#### Issue 1 - Before
https://user-images.githubusercontent.com/65194214/104630114-9f519700-5657-11eb-8fd7-cea284ea52e1.mp4

#### Issue 1 - After 
https://user-images.githubusercontent.com/65194214/104630173-b0020d00-5657-11eb-9541-628caa9172b5.mp4

#### Issue 2 - Before
https://user-images.githubusercontent.com/65194214/104630211-ba240b80-5657-11eb-9781-e6067a2ae1ae.mp4

#### Issue 2 - After 
https://user-images.githubusercontent.com/65194214/104630405-f22b4e80-5657-11eb-9011-fa044019f454.mp4

#### Issue 3 - Before
https://user-images.githubusercontent.com/65194214/104630709-551ce580-5658-11eb-9c47-1e20c20313c4.mp4

#### Issue 3 - After 
https://user-images.githubusercontent.com/65194214/104630499-0c652c80-5658-11eb-88ec-bda4b831b680.mp4

#### Issue 4 - Before
https://user-images.githubusercontent.com/65194214/104630531-1850ee80-5658-11eb-8ca4-6d757be4a541.mp4

#### Issue 4 - After 
https://user-images.githubusercontent.com/65194214/104630550-1e46cf80-5658-11eb-9943-90560aef44c1.mp4

#### Issue 5 - Before
https://user-images.githubusercontent.com/65194214/104630574-256ddd80-5658-11eb-9288-662f0e3f7c8e.mp4

#### Issue 5 - After 
https://user-images.githubusercontent.com/65194214/104630591-2bfc5500-5658-11eb-848b-6e62fffc955e.mp4



#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
