### PR TITLE
[4.1.x] Add ability to limit buffer to just before or after for around

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -37,12 +37,14 @@ const defaultValue = {
     amount: '1',
     unit: 'd',
   },
+  direction: 'both',
 } as ValueTypes['around']
 
 const validateShape = ({ value, onChange }: DateAroundProps) => {
   if (
     !value.date ||
     !value.buffer ||
+    !value.direction ||
     DateHelpers.Blueprint.commonProps.parseDate(value.date) === null
   ) {
     onChange(defaultValue)
@@ -149,6 +151,24 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           </TextField>
         </Grid>
       </Grid>
+      <TextField
+        variant="outlined"
+        select
+        value={value.direction || 'both'}
+        onChange={(e) => {
+          if (onChange)
+            onChange({
+              ...defaultValue,
+              ...value,
+              direction: e.target.value as ValueTypes['around']['direction'],
+            })
+        }}
+        size="small"
+      >
+        <MenuItem value="both">Before and After</MenuItem>
+        <MenuItem value="before">Before</MenuItem>
+        <MenuItem value="after">After</MenuItem>
+      </TextField>
     </Grid>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -93,15 +93,23 @@ export const serialize = {
     return `RELATIVE(${prefix + last + unit.toUpperCase()})`
   },
   dateAround: (value: ValueTypes['around']) => {
-    if (value.buffer === undefined || value.date === undefined) {
+    if (
+      value.buffer === undefined ||
+      value.date === undefined ||
+      value.direction === undefined
+    ) {
       return ''
     }
-    let before = moment(value.date)
-      .subtract(value.buffer.amount, value.buffer.unit)
-      .toISOString()
-    let after = moment(value.date)
-      .add(value.buffer.amount, value.buffer.unit)
-      .toISOString()
+    let before = ['both', 'before'].includes(value.direction)
+      ? moment(value.date)
+          .subtract(value.buffer.amount, value.buffer.unit)
+          .toISOString()
+      : value.date
+    let after = ['both', 'after'].includes(value.direction)
+      ? moment(value.date)
+          .add(value.buffer.amount, value.buffer.unit)
+          .toISOString()
+      : value.date
     return `DURING ${before}/${after}`
   },
   dateBetween: (value: ValueTypes['between']) => {
@@ -221,6 +229,7 @@ export type ValueTypes = {
       amount: string
       unit: 'm' | 'h' | 'd' | 'M' | 'y' | 's' | 'w'
     }
+    direction: 'both' | 'before' | 'after'
   }
   during: {
     start: string


### PR DESCRIPTION
 - Adds onto the around component to allow before / after exclusive operations.

To verify:  
Ensure the outgoing cql bounds the during appropriately by inspecting the network, or ingest data that allows you to verify.