### PR TITLE
[3.4.x] G-9774 Drop down window(s) closes and lose data when error banner is closed

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.js
@@ -217,7 +217,10 @@ Behaviors.addBehavior(
       $('body')
         .off(`mousedown.${this.view.cid}`)
         .on(`mousedown.${this.view.cid}`, event => {
-          if (!DropdownBehaviorUtility.drawing(event)) {
+          if (
+            !DropdownBehaviorUtility.drawing(event) &&
+            !DropdownBehaviorUtility.announcments(event)
+          ) {
             this.options.dropdowns
               .filter(dropdown => this.isOpen(dropdown))
               .forEach(dropdown =>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
@@ -22,6 +22,13 @@ const CustomElements = require('../js/CustomElements.js')
 const store = require('../js/store.js')
 
 module.exports = {
+  announcments(event) {
+    return (
+      $('#announcments')
+        .find(event.target)
+        .addBack(event.target).length > 0
+    )
+  },
   drawing(event) {
     return store.get('content').get('drawing')
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/dropdown.companion.view.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dropdown/dropdown.companion.view.js
@@ -277,7 +277,10 @@ module.exports = Marionette.LayoutView.extend(
     },
     listenForOutsideClick() {
       $('body').on('mousedown.' + this.cid, event => {
-        if (!DropdownBehaviorUtility.drawing(event)) {
+        if (
+          !DropdownBehaviorUtility.drawing(event) &&
+          !DropdownBehaviorUtility.announcments(event)
+        ) {
           if (!DropdownBehaviorUtility.withinAnyDropdown(event.target)) {
             this.close()
           }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
@@ -314,7 +314,10 @@ class Dropdown extends React.Component<Props, State> {
     })
   }
   handleOutsideInteraction = (event: any) => {
-    if (!DropdownBehaviorUtility.drawing(event)) {
+    if (
+      !DropdownBehaviorUtility.drawing(event) &&
+      !DropdownBehaviorUtility.announcments(event)
+    ) {
       this.checkOutsideClick(event.target)
     }
   }


### PR DESCRIPTION
ddf PRs:
2.19.x codice/ddf#6509

---------------------
#### What does this PR do?
When user is working within a dropdown window (e.g. Search form, List, Result Filter etc.), when they receive an error banner and click to close it, the dropdown closes and lose whatever was being worked on.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@zta6 
@Lambeaux 
@mojogitoverhere 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
• build / run / profile install / upload sample data
1. Go to a workspace
2. Create advanced search (Advanced Search)
3. Cause an error dialogue message to pop-up (e.g. select anyGeo and don't select any shape types and click "Search")
4. Try clicking on error dialogue and then try to close error dialogue
5. Ensure the Advanced search form you were working on before the error, is still displayed and did not close
6. Do steps 3 to 5 for other dropdown(s) such as Result filter, List, three-dot menu on the search pane etc.
7. Ensure when interacting with the error message dialogue, you do not lose any of the dropdown window's you've originally opened.
8. Ensure no regression to dropdown windows functionality (e.g. for Search Form, still able to change field and perform search after closing the error dialogue box)
9. Ensure no regression to Search Forms and Result Forms.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
##### Before
https://user-images.githubusercontent.com/65194214/106810491-4196e600-662a-11eb-97d5-affe6b5c2544.mp4

##### After
https://user-images.githubusercontent.com/65194214/106810479-3c399b80-662a-11eb-92d0-9106beecd260.mp4


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
