### PR TITLE
[3.4.x] G-9577 Display error banner for export KML with no location

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlResultImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlResultImpl.java
@@ -156,10 +156,10 @@ public class CqlResultImpl implements CqlResult {
   }
 
   private String getDisplayName(TransformerDescriptors descriptors, String id, String title) {
-    Map<String, String> transformerDescriptor = descriptors.getMetacardTransformer(id);
+    Map<String, Object> transformerDescriptor = descriptors.getMetacardTransformer(id);
 
     if (transformerDescriptor != null) {
-      return transformerDescriptor.get("displayName");
+      return (String) transformerDescriptor.get("displayName");
     }
 
     return title.replaceFirst("^Export( as)?\\s+\\b", "");

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -341,8 +341,13 @@ public class CqlTransformHandler implements Route {
   private String getWarningMessage(
       String warningMsg, String idName, List<String> resultsNotToExport) {
     int count = 0;
+    int maxID = Math.min(resultsNotToExport.size(), 10);
     for (String resultId : resultsNotToExport) {
       warningMsg += String.format("\\n%s) %s: %s", ++count, idName, resultId);
+      if (maxID == count) {
+        warningMsg += String.format("\\n.... Total not exported: %s", resultsNotToExport.size());
+        break;
+      }
     }
     return warningMsg;
   }

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -13,12 +13,15 @@
  */
 package org.codice.ddf.catalog.ui.query.handlers;
 
+import static org.codice.ddf.catalog.ui.transformer.TransformerDescriptors.REQUIRED_ATTR;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.operation.QueryResponse;
@@ -38,6 +41,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -270,6 +274,26 @@ public class CqlTransformHandler implements Route {
                             .contains(result.getMetacard().getId()))
                 .collect(Collectors.toList());
 
+    List<String> resultsNotToExport = new ArrayList<>();
+    results =
+        queryResponseTransformer.getProperty(REQUIRED_ATTR) == null
+            ? results
+            : results
+                .stream()
+                .filter(
+                    result -> {
+                      Metacard metacard = result.getMetacard();
+                      for (String attr :
+                          (List<String>) queryResponseTransformer.getProperty(REQUIRED_ATTR)) {
+                        if (metacard.getAttribute(attr) == null) {
+                          resultsNotToExport.add(metacard.getId());
+                          return false;
+                        }
+                      }
+                      return true;
+                    })
+                .collect(Collectors.toList());
+
     QueryResponse combinedResponse =
         new QueryResponseImpl(
             new QueryRequestImpl(new QueryImpl(ECQL.toFilter(cqlRequests.get(0).getCql()))),
@@ -290,16 +314,68 @@ public class CqlTransformHandler implements Route {
       arguments = cswTransformArgumentsAdapter();
     }
 
-    attachFileToResponse(request, response, queryResponseTransformer, combinedResponse, arguments);
+    String warning = null;
+    if (resultsNotToExport.size() > 0) {
+      List<String> requiredAttrList = new ArrayList<>();
+      String idName = mapAliasAttributes(queryResponseTransformer, requiredAttrList, arguments);
+      if (results.size() == 0) {
+        LOGGER.debug("0 Results to export due to missing required field(s): {}", requiredAttrList);
+        response.status(HttpStatus.BAD_REQUEST_400);
+        return ImmutableMap.of(
+            "message", String.format("Result(s) missing required field(s): %s", requiredAttrList));
+      }
+      warning =
+          getWarningMessage(
+              String.format(
+                  "Following not exported, missing required field(s): %s", requiredAttrList),
+              idName,
+              resultsNotToExport);
+    }
+
+    attachFileToResponse(
+        request, response, queryResponseTransformer, combinedResponse, arguments, warning);
 
     return "";
+  }
+
+  private String getWarningMessage(
+      String warningMsg, String idName, List<String> resultsNotToExport) {
+    int count = 0;
+    for (String resultId : resultsNotToExport) {
+      warningMsg += String.format("\\n%s) %s: %s", ++count, idName, resultId);
+    }
+    return warningMsg;
+  }
+
+  private String mapAliasAttributes(
+      ServiceReference<QueryResponseTransformer> queryResponseTransformer,
+      List<String> requiredAttrList,
+      Map<String, Serializable> arguments) {
+    String idName = Metacard.ID;
+    if (arguments.get("columnAliasMap") != null) {
+      Map<String, Serializable> columnAliasMap =
+          (Map<String, Serializable>) arguments.get("columnAliasMap");
+      idName = columnAliasMap.get(idName) == null ? idName : (String) columnAliasMap.get(idName);
+      for (String attribute : (List<String>) queryResponseTransformer.getProperty(REQUIRED_ATTR)) {
+        if (StringUtils.isNotBlank((String) columnAliasMap.get(attribute))) {
+          requiredAttrList.add((String) columnAliasMap.get(attribute));
+        } else {
+          requiredAttrList.add(attribute);
+        }
+      }
+    }
+    if (requiredAttrList.isEmpty()) {
+      requiredAttrList.addAll((List<String>) queryResponseTransformer.getProperty(REQUIRED_ATTR));
+    }
+    return idName;
   }
 
   public List<ServiceReference> getQueryResponseTransformers() {
     return queryResponseTransformers;
   }
 
-  private void setHttpHeaders(Request request, Response response, BinaryContent content)
+  private void setHttpHeaders(
+      Request request, Response response, BinaryContent content, String warning)
       throws MimeTypeException {
     String mimeType = content.getMimeTypeValue();
 
@@ -313,6 +389,11 @@ public class CqlTransformHandler implements Route {
     if (containsGzip(request)) {
       LOGGER.trace("Request header accepts gzip");
       response.header(HttpHeaders.CONTENT_ENCODING, GZIP);
+    }
+
+    if (StringUtils.isNotBlank(warning)) {
+      LOGGER.trace("Response has warning: {}", warning);
+      response.header("warning", warning);
     }
 
     response.type(mimeType);
@@ -344,12 +425,13 @@ public class CqlTransformHandler implements Route {
       Response response,
       ServiceReference<QueryResponseTransformer> queryResponseTransformer,
       QueryResponse cqlQueryResponse,
-      Map<String, Serializable> arguments)
+      Map<String, Serializable> arguments,
+      String warning)
       throws CatalogTransformerException, IOException, MimeTypeException {
     BinaryContent content =
         bundleContext.getService(queryResponseTransformer).transform(cqlQueryResponse, arguments);
 
-    setHttpHeaders(request, response, content);
+    setHttpHeaders(request, response, content, warning);
 
     try (OutputStream servletOutputStream = response.raw().getOutputStream();
         InputStream resultStream = content.getInputStream()) {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/transformer/TransformerDescriptorApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/transformer/TransformerDescriptorApplication.java
@@ -65,7 +65,7 @@ public class TransformerDescriptorApplication implements SparkApplication {
           String id = req.params(":id");
           String type = req.params(":type").toLowerCase(Locale.US);
 
-          Map<String, String> descriptor;
+          Map<String, Object> descriptor;
 
           res.type("application/json");
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/transformer/TransformerDescriptors.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/transformer/TransformerDescriptors.java
@@ -29,6 +29,8 @@ import org.osgi.framework.ServiceReference;
  */
 public class TransformerDescriptors {
 
+  public static final String REQUIRED_ATTR = "required-attributes";
+
   private final List<ServiceReference> metacardTransformers;
 
   private final List<ServiceReference> queryResponseTransformers;
@@ -44,22 +46,22 @@ public class TransformerDescriptors {
     this.queryResponseTransformers = queryResponseTransformers;
   }
 
-  public List<Map<String, String>> getMetacardTransformers() {
+  public List<Map<String, Object>> getMetacardTransformers() {
     return getTransformerDescriptors(metacardTransformers, blackListedMetacardTransformerIds);
   }
 
-  public List<Map<String, String>> getQueryResponseTransformers() {
+  public List<Map<String, Object>> getQueryResponseTransformers() {
     return getTransformerDescriptors(
         queryResponseTransformers, blackListedQueryResponseTransformerIds);
   }
 
   @Nullable
-  public Map<String, String> getMetacardTransformer(String id) {
+  public Map<String, Object> getMetacardTransformer(String id) {
     return getTransformerDescriptor(metacardTransformers, blackListedMetacardTransformerIds, id);
   }
 
   @Nullable
-  public Map<String, String> getQueryResponseTransformer(String id) {
+  public Map<String, Object> getQueryResponseTransformer(String id) {
     return getTransformerDescriptor(
         queryResponseTransformers, blackListedQueryResponseTransformerIds, id);
   }
@@ -78,7 +80,7 @@ public class TransformerDescriptors {
   }
 
   @Nullable
-  private Map<String, String> getTransformerDescriptor(
+  private Map<String, Object> getTransformerDescriptor(
       List<ServiceReference> serviceReferences, Set<String> blacklist, String id) {
     for (ServiceReference serviceRef : serviceReferences) {
       Object idProperty = serviceRef.getProperty("id");
@@ -95,7 +97,7 @@ public class TransformerDescriptors {
     return null;
   }
 
-  private List<Map<String, String>> getTransformerDescriptors(
+  private List<Map<String, Object>> getTransformerDescriptors(
       List<ServiceReference> transformers, Set<String> blacklist) {
     return transformers
         .stream()
@@ -105,11 +107,22 @@ public class TransformerDescriptors {
         .collect(Collectors.toList());
   }
 
-  private Map<String, String> getTransformerDescriptor(ServiceReference serviceRef) {
-    return new ImmutableMap.Builder<String, String>()
+  private Map<String, Object> getTransformerDescriptor(ServiceReference serviceRef) {
+    return new ImmutableMap.Builder<String, Object>()
         .put("id", serviceRef.getProperty("id").toString())
         .put("displayName", getDisplayName(serviceRef))
+        .put(REQUIRED_ATTR, getRequiredAttributes(serviceRef))
         .build();
+  }
+
+  private Object getRequiredAttributes(ServiceReference serviceRef) {
+    Object requiredAttributes = serviceRef.getProperty(REQUIRED_ATTR);
+
+    if (requiredAttributes == null) {
+      return Collections.emptyList();
+    }
+
+    return requiredAttributes;
   }
 
   private String getDisplayName(ServiceReference serviceRef) {

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.query.handlers;
 
 import static junit.framework.TestCase.assertNull;
+import static org.codice.ddf.catalog.ui.transformer.TransformerDescriptors.REQUIRED_ATTR;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -27,12 +28,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.transform.QueryResponseTransformer;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +89,10 @@ public class CqlTransformHandlerTest {
   private static final String OTHER_RETURN_ID = "xml";
   private static final String MIME_TYPE = "application/vnd.google-earth.kml+xml";
   private static final String SAFE_BODY =
-      "{\"searches\":[{\"srcs\":[\"ddf.distribution\"],\"cql\":\"anyText ILIKE '*'\",\"count\":250}],\"count\":250,\"sorts\":[{\"attribute\":\"modified\",\"direction\":\"descending\"}],\"id\":\"7a491439-948e-431b-815e-a04f32fecec9\"}";
+      "{\"searches\":[{\"srcs\":[\"ddf.distribution\"],\"cql\":\"anyText ILIKE '*'\",\"count\":250}],\"count\":250,\"sorts\":[{\"attribute\":\"modified\",\"direction\":\"descending\"}],\"id\":\"7a491439-948e-431b-815e-a04f32fecec9\",\"args\":{\"columnAliasMap\":{\"location\":\"Location\"}}}";
+  private static final String SAFE_BODY_NO_ARGS =
+      "{\"searches\":[{\"srcs\":[\"ddf.distribution\"],\"cql\":\"anyText ILIKE '*'\",\"count\":250}],\"count\":250,\"sorts\":[{\"attribute\":\"modified\",\"direction\":\"descending\"}],\"id\":\"7a491439-948e-431b-815e-a04f32fecec9\",\"args\":{}}";
+
   private static final String CONTENT = "test";
   private static final String SERVICE_NOT_FOUND = "\"Service not found\"";
   private static final String SERVICE_SUCCESS = GSON.toJson("");
@@ -92,6 +100,9 @@ public class CqlTransformHandlerTest {
       "^attachment;filename=\"export-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?Z."
           + RETURN_ID
           + "\"$";
+  private static final String METACARD_ID1 = "7a491439-948e-431b-815e-a04f32fecec9";
+  private static final String METACARD_ID2 = "8cf7f8b689e8453abea53f5c99fb3c6f";
+  private static final String WARNING_HEADER = "Following not exported, missing required field(s)";
 
   private class MockResponse extends Response {
 
@@ -154,6 +165,8 @@ public class CqlTransformHandlerTest {
 
     when(mockServiceReference.getProperty(Core.ID)).thenReturn(RETURN_ID);
     when(mockServiceReference.getProperty("mime-type")).thenReturn(ImmutableList.of(MIME_TYPE));
+    when(mockServiceReference.getProperty(REQUIRED_ATTR))
+        .thenReturn(ImmutableList.of("location", "id"));
 
     MimeType mimeType = new MimeType(MIME_TYPE);
     binaryContent = new BinaryContentImpl(new ByteArrayInputStream(CONTENT.getBytes()), mimeType);
@@ -206,6 +219,78 @@ public class CqlTransformHandlerTest {
   }
 
   @Test
+  public void testServiceFoundWithValidResponseAndWarning() throws Exception {
+    List<Result> resultList =
+        createFakeMetacards(
+            METACARD_ID1,
+            "fakeMetacard1",
+            "POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))",
+            METACARD_ID2,
+            "fakeMetacard2",
+            null);
+    when(mockQueryResponse.getResults()).thenReturn(resultList);
+    when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(GZIP);
+    when(mockRequest.params(QUERY_PARAM)).thenReturn(RETURN_ID);
+
+    String res = GSON.toJson(cqlTransformHandler.handle(mockRequest, mockResponse));
+
+    assertThat(res, is(SERVICE_SUCCESS));
+    assertThat(mockResponse.status(), is(HttpStatus.OK_200));
+    assertThat(
+        mockResponse.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION),
+        matchesPattern(ATTACHMENT_REGEX));
+    assertThat(mockResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING), is(GZIP));
+    assertThat(mockResponse.type(), is(MIME_TYPE));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString(WARNING_HEADER));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString(METACARD_ID2));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString("Location"));
+  }
+
+  @Test
+  public void testNoArgsServiceFoundWithValidResponseAndWarning() throws Exception {
+    when(mockEndpointUtil.safeGetBody(mockRequest)).thenReturn(SAFE_BODY_NO_ARGS);
+    List<Result> resultList =
+        createFakeMetacards(
+            METACARD_ID1,
+            "fakeMetacard1",
+            "POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))",
+            METACARD_ID2,
+            "fakeMetacard2",
+            null);
+    when(mockQueryResponse.getResults()).thenReturn(resultList);
+    when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(GZIP);
+    when(mockRequest.params(QUERY_PARAM)).thenReturn(RETURN_ID);
+
+    String res = GSON.toJson(cqlTransformHandler.handle(mockRequest, mockResponse));
+
+    assertThat(res, is(SERVICE_SUCCESS));
+    assertThat(mockResponse.status(), is(HttpStatus.OK_200));
+    assertThat(
+        mockResponse.getHeaders().get(HttpHeaders.CONTENT_DISPOSITION),
+        matchesPattern(ATTACHMENT_REGEX));
+    assertThat(mockResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING), is(GZIP));
+    assertThat(mockResponse.type(), is(MIME_TYPE));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString(WARNING_HEADER));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString(METACARD_ID2));
+    assertThat(mockResponse.getHeaders().get("warning"), containsString("location"));
+  }
+
+  @Test
+  public void testServiceFoundWithResultsMissingRequiredAttributes() throws Exception {
+    List<Result> resultList =
+        createFakeMetacards(METACARD_ID1, "fakeMetacard1", null, null, null, null);
+    when(mockQueryResponse.getResults()).thenReturn(Arrays.asList(resultList.get(0)));
+    when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(GZIP);
+    when(mockRequest.params(QUERY_PARAM)).thenReturn(RETURN_ID);
+
+    String res = GSON.toJson(cqlTransformHandler.handle(mockRequest, mockResponse));
+
+    assertThat(res, containsString("Result(s) missing required field(s):"));
+    assertThat(mockResponse.status(), is(HttpStatus.BAD_REQUEST_400));
+    assertNull(mockResponse.getHeaders().get("warning"));
+  }
+
+  @Test
   public void testServiceFoundWithValidResponseNoGzip() throws Exception {
     when(mockRequest.headers(HttpHeaders.ACCEPT_ENCODING)).thenReturn(NO_GZIP);
 
@@ -220,5 +305,24 @@ public class CqlTransformHandlerTest {
         matchesPattern(ATTACHMENT_REGEX));
     assertNull(mockResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING));
     assertThat(mockResponse.type(), is(MIME_TYPE));
+  }
+
+  private List<Result> createFakeMetacards(
+      String id1, String title1, String wkt1, String id2, String title2, String wkt2) {
+    ResultImpl fakeResult1 = new ResultImpl();
+    MetacardImpl fakeMetacard1 = new MetacardImpl();
+    fakeMetacard1.setId(id1);
+    fakeMetacard1.setTitle(title1);
+    fakeMetacard1.setLocation(wkt1);
+    fakeResult1.setMetacard(fakeMetacard1);
+
+    ResultImpl fakeResult2 = new ResultImpl();
+    MetacardImpl fakeMetacard2 = new MetacardImpl();
+    fakeMetacard2.setId(id2);
+    fakeMetacard2.setTitle(title2);
+    fakeMetacard2.setLocation(wkt2);
+    fakeResult2.setMetacard(fakeMetacard2);
+
+    return Arrays.asList(fakeResult1, fakeResult2);
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/index.tsx
@@ -21,5 +21,4 @@ export {
   getDownloadBody,
   getStartIndex,
   getSrcCount,
-  limitToVisible,
 } from './table-export'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/index.tsx
@@ -21,4 +21,5 @@ export {
   getDownloadBody,
   getStartIndex,
   getSrcCount,
+  limitToVisible,
 } from './table-export'


### PR DESCRIPTION
ui portion of forward port of codice/ddf#6502

should be built off of codice/ddf#6511


---------------------
#### What does this PR do?
This PR addresses following issues -
Main Issue:
1.  When user tries to export a format that requires "location" attribute, they are left with nothing occurring (e.g. KML/KMZ).
**Fixed issue new behavior:**  If a Single result is selected to export, the option for the export type they do not qualify for will not be displayed (e.g. a result that has no location, will not show KML/KMZ as an export option. Note - this behavior is not true for table export, it always shows all available export options). If multiple results are selected and some has the required attribute and some do not, the file will export the one(s) with the required attribute and will show a warning banner with the id(s) of the ones that were not exported. For Table export if try to only export result(s) that do not have any location attribute, an error dialogue will be displayed, saying the missing attribute was not provided and nothing is exported.

Other issues:
1.  For table export, when a filter is applied to the results, and user select "Visible Results", exported item does not match Results that are actually present after the filter was applied.
2. ~~For the export in Inspector->Actions tab, CVS was not exporting.~~ resolved in https://github.com/codice/ddf/pull/6503
#### Who is reviewing it? 
@andrewzimmer 
@hayleynorton
@zta6 
@Lambeaux 
@mojogitoverhere 
@millerw8 
@cassandrabailey293

<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
• build / run / profile install / upload sample data
• Execute a search and either add or ensure at least one or some of the result(s) have a "location" attribute.

• For main issue 1: Test the different types of exports and ensure behaves as described in Fixed issue new behavior. Also ensure no regression for https://github.com/codice/ddf/pull/6496
1.  Table export (Note - All export option(s) are always shown even if the item to export does not have required attribute, it gets caught in back end, and responds with appropriate message)
		a. Via the "Export" button top far right. Can choose 3 different set of exports ("Visible Results", "All Results", "Specific Number of Results") for specific export type.
2.  All other exports (Note - These types of export only display options for items that has its required attributes present. e.g. KML/KMZ will only appear as option for result(s) that has  a "location attribute")
		a. Via an individual Result lower right three-dot menu ("Export as")
		b. Via three-dot menu on the search pane (has 2 types of exports: "Export Selected" and "Export Selected(Compressed)"). Also note, can select multiple result(s) to export.
		c. Via Inspector tab three-dot menu (can select single and/or multiple result(s))
		d. Via Inspector tab, Actions subtab (Actions subtab only appear when 1 Result is selected)

• For other issues 1:
1.   Filter the results you have so there is less item displayed and others are 
2.  Do a table export, with selecting "Visible Results", and can choose CSV or other format and clicking download
3.  Ensure only the visible results in table after filter was applied are visible
	
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

https://user-images.githubusercontent.com/65194214/106331988-1e8fbf00-6243-11eb-8f44-56bc6c213923.mp4


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
