### PR TITLE
[4.1.x] Add source id to audit log

### DIFF
--- a/ui-backend/audit/audit-api/pom.xml
+++ b/ui-backend/audit/audit-api/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>security-core-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditItemBasic.java
+++ b/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditItemBasic.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.audit.api;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.annotations.SerializedName;
+
+public class AuditItemBasic {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("source-id")
+  private String sourceId;
+
+  private AuditItemBasic() {
+    // Implementation not needed
+  }
+
+  @VisibleForTesting
+  public AuditItemBasic(String id, String sourceId) {
+    this.id = id;
+    this.sourceId = sourceId;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getSourceId() {
+    return sourceId;
+  }
+}

--- a/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditItemRequestBasic.java
+++ b/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditItemRequestBasic.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.audit.api;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
+public class AuditItemRequestBasic {
+
+  @SerializedName("action")
+  private String action;
+
+  @SerializedName("component")
+  private String component;
+
+  @SerializedName("items")
+  private List<AuditItemBasic> items;
+
+  private AuditItemRequestBasic() {
+    // implementation not needed
+  }
+
+  public String getAction() {
+    return action;
+  }
+
+  public String getComponent() {
+    return component;
+  }
+
+  public List<AuditItemBasic> getItems() {
+    return items;
+  }
+}

--- a/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditRequestBasic.java
+++ b/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditRequestBasic.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.catalog.audit.application;
+package org.codice.ddf.catalog.audit.api;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.Set;

--- a/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditService.java
+++ b/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/AuditService.java
@@ -13,6 +13,8 @@ package org.codice.ddf.catalog.audit.api;
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 
+import java.util.List;
+
 /**
  * This interface represents a service that will be used to log an event that occurred from a
  * particular user or a set or users.
@@ -24,6 +26,13 @@ public interface AuditService {
    * @param ids the set of metacard id of the object
    */
   void log(String action, String component, String... ids) throws AuditException;
+
+  /**
+   * @param action past tense verb defining the user interaction such as 'clicked' or 'viewed'
+   * @param component the UI object that caused the event
+   * @param items List of objects to log
+   */
+  void log(String action, String component, List<AuditItemBasic> items) throws AuditException;
 
   /**
    * @param action future tense verb defining the user interaction such as 'will click' or 'will

--- a/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditHandler.java
+++ b/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditHandler.java
@@ -15,9 +15,11 @@ package org.codice.ddf.catalog.audit.application;
 
 import io.javalin.Context;
 import io.javalin.Handler;
-import java.util.Set;
+import java.util.List;
 import org.apache.http.HttpStatus;
 import org.codice.ddf.catalog.audit.api.AuditException;
+import org.codice.ddf.catalog.audit.api.AuditItemBasic;
+import org.codice.ddf.catalog.audit.api.AuditItemRequestBasic;
 import org.codice.ddf.catalog.audit.api.AuditService;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -35,12 +37,11 @@ public class AuditHandler implements Handler {
 
   @Override
   public void handle(@NotNull Context context) throws AuditException {
-    AuditRequestBasic requestBasic = context.bodyAsClass(AuditRequestBasic.class);
+    AuditItemRequestBasic requestBasic = context.bodyAsClass(AuditItemRequestBasic.class);
 
     try {
-      Set<String> ids = requestBasic.getIds();
-      auditService.log(
-          requestBasic.getAction(), requestBasic.getComponent(), ids.toArray(new String[0]));
+      List<AuditItemBasic> items = requestBasic.getItems();
+      auditService.log(requestBasic.getAction(), requestBasic.getComponent(), items);
       context.status(HttpStatus.SC_OK);
     } catch (AuditException e) {
       LOGGER.error("Unable to log the user's action. Error message: {}", e.getLocalizedMessage());

--- a/ui-backend/audit/audit-logging/src/test/java/org/codice/ddf/catalog/audit/logging/AuditLoggerTest.java
+++ b/ui-backend/audit/audit-logging/src/test/java/org/codice/ddf/catalog/audit/logging/AuditLoggerTest.java
@@ -16,9 +16,11 @@ package org.codice.ddf.catalog.audit.logging;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.ImmutableList;
 import ddf.security.audit.SecurityLogger;
 import java.util.Arrays;
 import org.codice.ddf.catalog.audit.api.AuditException;
+import org.codice.ddf.catalog.audit.api.AuditItemBasic;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +38,12 @@ public class AuditLoggerTest {
   private final String ID_2 = "id2";
   private final String EXCEPTION = "exception";
   private final String[] IDS = Arrays.asList(ID_1, ID_2).toArray(new String[0]);
+  private final AuditItemBasic validItem = new AuditItemBasic("id", "sourceId");
+  private final AuditItemBasic emptyIdItem = new AuditItemBasic("", "sourceId");
+  private final AuditItemBasic emptySourceItem = new AuditItemBasic("id", "");
+  private final AuditItemBasic nullIdItem = new AuditItemBasic(null, "sourceId");
+  private final AuditItemBasic nullSourceItem = new AuditItemBasic("id", null);
+
   private Throwable cause;
 
   private AuditLogger auditLogger;
@@ -45,6 +53,53 @@ public class AuditLoggerTest {
   public void setup() {
     auditLogger = new AuditLogger(securityLogger);
     cause = new Throwable();
+  }
+
+  @Test
+  public void testAuditLogWithItem() throws AuditException {
+    auditLogger.log(ACTION, COMPONENT, ImmutableList.of(validItem));
+    verify(securityLogger, Mockito.times(1))
+        .audit(any(String.class), ArgumentMatchers.<String>any());
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogWithEmptyIdItem() throws AuditException {
+    auditLogger.log(ACTION, COMPONENT, ImmutableList.of(emptyIdItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogWithEmptySourceItem() throws AuditException {
+    auditLogger.log(ACTION, COMPONENT, ImmutableList.of(emptySourceItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogWithNullIdItem() throws AuditException {
+    auditLogger.log(ACTION, COMPONENT, ImmutableList.of(nullIdItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogWithNullSourceItem() throws AuditException {
+    auditLogger.log(ACTION, COMPONENT, ImmutableList.of(nullSourceItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogItemWithEmptyAction() throws AuditException {
+    auditLogger.log("", COMPONENT, ImmutableList.of(validItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogItemWithNullAction() throws AuditException {
+    auditLogger.log(null, COMPONENT, ImmutableList.of(validItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogItemWithEmptyComponent() throws AuditException {
+    auditLogger.log(ACTION, "", ImmutableList.of(validItem));
+  }
+
+  @Test(expected = AuditException.class)
+  public void testAuditLogItemWithNullComponent() throws AuditException {
+    auditLogger.log("", null, ImmutableList.of(validItem));
   }
 
   @Test

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/audit/audit-endpoint.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/audit/audit-endpoint.tsx
@@ -1,33 +1,24 @@
 import fetch from '../fetch'
 
+export type AuditItem = {
+  id: String
+  'source-id'?: String
+}
+
 export type AuditLog = {
   action: string
   component: string
-  ids: Set<string> | string
+  items: AuditItem[]
 }
 
-export const postAuditLog = async ({ action, component, ids }: AuditLog) => {
-  if (typeof ids === 'string') {
-    const idSet = new Set<string>()
-    idSet.add(ids)
-    const body = {
-      action: action,
-      component: component,
-      ids: idSet,
-    }
-    await fetch(`./internal/audit/`, {
-      method: 'POST',
-      body: JSON.stringify(body),
-    })
-  } else {
-    const body = {
-      action: action,
-      component: component,
-      ids: ids,
-    }
-    await fetch(`./internal/audit/`, {
-      method: 'POST',
-      body: JSON.stringify(body),
-    })
+export const postAuditLog = async ({ action, component, items }: AuditLog) => {
+  const body = {
+    action,
+    component,
+    items,
   }
+  await fetch(`./internal/audit/`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
 }


### PR DESCRIPTION
Add source id to the inspector audit log

Testing:

1. Ingest a resource
2. Open the security log
3. Search for resource and select it. Verify a message like `{user} selected a resource with id {id} and source {source-id}"` shows up in the log
4. Unselect the resource and verify a {user} unselected a resource with id {id} and source {source-id}" shows up in the log