### PR TITLE
[4.1.x] Adds warning icon when a source status is not successful to heartbeat

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -210,7 +210,8 @@ const QueryFeed = ({ selectionInterface }: Props) => {
   const statusBySource = Object.values(status)
   let resultMessage = '',
     pending = false,
-    failed = false
+    failed = false,
+    warnings = false
   if (statusBySource.length === 0) {
     resultMessage = 'Has not been run'
   } else {
@@ -233,6 +234,9 @@ const QueryFeed = ({ selectionInterface }: Props) => {
     }
 
     failed = sourcesThatHaveReturned.some((status) => !status.successful)
+    warnings = sourcesThatHaveReturned.some(
+      (status) => status.warnings && status.warnings.length > 0
+    )
     pending = isSearching
   }
 
@@ -287,7 +291,7 @@ const QueryFeed = ({ selectionInterface }: Props) => {
                     >
                       <span className="fa fa-heartbeat" />
                     </Button>
-                    {failed && (
+                    {warnings && (
                       <div className="absolute bottom-0 right-0 text-sm">
                         <ErrorIcon fontSize="inherit" color="error" />
                       </div>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -277,7 +277,7 @@ const QueryFeed = ({ selectionInterface }: Props) => {
             {({ handleClick }) => {
               return (
                 <div>
-                  <div style={{ position: 'relative' }}>
+                  <div className="relative">
                     <Button
                       data-id="heartbeat-button"
                       onClick={handleClick}
@@ -287,18 +287,11 @@ const QueryFeed = ({ selectionInterface }: Props) => {
                     >
                       <span className="fa fa-heartbeat" />
                     </Button>
-                    {failed && (
-                      <div
-                        style={{
-                          position: 'absolute',
-                          bottom: '0',
-                          right: '0',
-                          fontSize: '14px',
-                        }}
-                      >
+                    {
+                      <div className="absolute bottom-0 right-0 text-sm">
                         <ErrorIcon fontSize="inherit" color="error" />
                       </div>
-                    )}
+                    }
                   </div>
                 </div>
               )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -287,11 +287,11 @@ const QueryFeed = ({ selectionInterface }: Props) => {
                     >
                       <span className="fa fa-heartbeat" />
                     </Button>
-                    {
+                    {failed && (
                       <div className="absolute bottom-0 right-0 text-sm">
                         <ErrorIcon fontSize="inherit" color="error" />
                       </div>
-                    }
+                    )}
                   </div>
                 </div>
               )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -13,6 +13,7 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { Elevations } from '../theme/theme'
 import FilterListIcon from '@material-ui/icons/FilterList'
 import { fuzzyHits } from './fuzzy-results'
+import ErrorIcon from '@material-ui/icons/Error'
 
 type Props = {
   selectionInterface: any
@@ -275,15 +276,31 @@ const QueryFeed = ({ selectionInterface }: Props) => {
           >
             {({ handleClick }) => {
               return (
-                <Button
-                  data-id="heartbeat-button"
-                  onClick={handleClick}
-                  className="details-view is-button"
-                  title="Show the full status for the search."
-                  data-help="Show the full status for the search."
-                >
-                  <span className="fa fa-heartbeat" />
-                </Button>
+                <div>
+                  <div style={{ position: 'relative' }}>
+                    <Button
+                      data-id="heartbeat-button"
+                      onClick={handleClick}
+                      className="details-view is-button"
+                      title="Show the full status for the search."
+                      data-help="Show the full status for the search."
+                    >
+                      <span className="fa fa-heartbeat" />
+                    </Button>
+                    {failed && (
+                      <div
+                        style={{
+                          position: 'absolute',
+                          bottom: '0',
+                          right: '0',
+                          fontSize: '14px',
+                        }}
+                      >
+                        <ErrorIcon fontSize="inherit" color="error" />
+                      </div>
+                    )}
+                  </div>
+                </div>
               )
             }}
           </Dropdown>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
@@ -34,6 +34,7 @@ export class Status {
   cacheMessages: []
   hasReturned: boolean
   message: string
+  warnings: [string]
   constructor({ id }: { id: string }) {
     this.id = id
     this.count = 0


### PR DESCRIPTION
This icon is added when a source's returned status is not successful. 
<img width="265" alt="Screen Shot 2021-02-08 at 6 04 18 PM" src="https://user-images.githubusercontent.com/51682089/107302394-8fe92200-6a3a-11eb-9f31-4f16c687a1aa.png">
 Testing:
Configure a WFS source that points to an invalid destination. This should force an error for that source when you query. 