### PR TITLE
[4.1.x] Combine secondary filter in a filter builder class.

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -20,7 +20,6 @@ const properties = require('../properties.js')
 const QueryResponse = require('./QueryResponse.js')
 import Sources from '../../component/singletons/sources-instance'
 const Common = require('../Common.js')
-const CacheSourceSelector = require('../CacheSourceSelector.js')
 const announcement = require('../../component/announcement/index.jsx')
 const CQLUtils = require('../CQLUtils.js')
 import cql from '../cql'
@@ -47,10 +46,10 @@ function mixinEphemeralFilter(originalCQL) {
     .get('preferences')
     .get('resultFilter')
   if (ephermeralFilter) {
-    return {
+    return new FilterBuilderClass({
       filters: [ephermeralFilter, originalCQL],
       type: 'AND',
-    }
+    })
   } else {
     return originalCQL
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -41,16 +41,21 @@ function getEphemeralSort() {
 }
 
 function mixinEphemeralFilter(originalCQL) {
-  const ephermeralFilter = user
+  const ephemeralFilter = user
     .get('user')
     .get('preferences')
     .get('resultFilter')
-  if (ephermeralFilter) {
-    return new FilterBuilderClass({
-      filters: [ephermeralFilter, originalCQL],
-      type: 'AND',
-    })
-  } else {
+  try {
+    if (ephemeralFilter) {
+      return new FilterBuilderClass({
+        filters: [ephemeralFilter, originalCQL],
+        type: 'AND',
+      })
+    } else {
+      return originalCQL
+    }
+  } catch (err) {
+    console.error(err)
     return originalCQL
   }
 }


### PR DESCRIPTION
If the object being passed into cql.write is not an instance of FilterBuilderClass it will not be processed by the cql.uncollapseNOTs logic - preventing the NOT from being applied to the final CQL. This was the case with the pairing of the user's search criteria and the secondary filter - ephemeralFilter in Query.js.