### PR TITLE
[4.1.x] Adds comma delimiter to list values in result item and table results views

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
@@ -233,13 +233,13 @@ const RowComponent = ({
                             data-id={`${property}-value`}
                             style={{ wordBreak: 'break-word' }}
                           >
-                            {value.map((value: any, index: number) => {
+                            {value.map((curValue: any, index: number) => {
                               return (
-                                <span key={index} data-value={`${value}`}>
-                                  {value.toString().substring(0, 4) ===
+                                <span key={index} data-value={`${curValue}`}>
+                                  {curValue.toString().substring(0, 4) ===
                                   'http' ? (
                                     <a
-                                      href={`${value}`}
+                                      href={`${curValue}`}
                                       target="_blank"
                                       rel="noopener noreferrer"
                                     >
@@ -248,7 +248,12 @@ const RowComponent = ({
                                       })}
                                     </a>
                                   ) : (
-                                    `${value}`
+                                    `${
+                                      value.length > 1 &&
+                                      index < value.length - 1
+                                        ? curValue + ', '
+                                        : curValue
+                                    }`
                                   )}
                                 </span>
                               )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item.tsx
@@ -591,7 +591,7 @@ export const ResultItem = ({
                           }}
                         />
                       ) : (
-                        detail.value
+                        detail.value.join(', ')
                       )}
                     </span>
                   </PropertyComponent>


### PR DESCRIPTION
<img width="644" alt="Screen Shot 2021-02-10 at 6 32 16 PM" src="https://user-images.githubusercontent.com/51682089/107594085-547f5c80-6bce-11eb-8820-3dc861435b49.png">
<img width="1029" alt="Screen Shot 2021-02-10 at 6 32 04 PM" src="https://user-images.githubusercontent.com/51682089/107594087-55b08980-6bce-11eb-86d2-a6cc34968584.png">

How to Test:
Verify that resources with multi-value attributes have a comma to separate individual values.
Bonus if you enable highlighting. It's worth noting that highlights are not present in the table view and only display the matching item from a list of values on the result item view. 
