### PR TITLE
[4.1.x] Fix start index for export operations and rename visible to current page

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -188,7 +188,9 @@ export const getDownloadBody = (downloadInfo: DownloadInfo) => {
     getExportCount({ exportSize, selectionInterface, customExportCount }),
     properties.exportResultLimit
   )
-  const cql = selectionInterface.getCurrentQuery().get('cql')
+
+  const query = selectionInterface.getCurrentQuery()
+  const cql = query.getEphemeralMixinCql(query.get('filterTree'))
   const srcs = getSrcs(selectionInterface)
   const sorts = getSorts(selectionInterface)
   const args = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -15,6 +15,7 @@
 import * as React from 'react'
 import { useEffect, useState } from 'react'
 import TableExport from '../../react-component/table-export'
+import Sources from '../../component/singletons/sources-instance'
 import {
   getExportOptions,
   Transformer,
@@ -47,20 +48,18 @@ type Source = {
 
 export function getStartIndex(
   // @ts-ignore ts-migrate(6133) FIXME: 'src' is declared but its value is never read.
-  src: any,
+  src: string,
   // @ts-ignore ts-migrate(6133) FIXME: 'exportSize' is declared but its value is never re... Remove this comment to see the full error message
   exportSize: any,
   selectionInterface: any
 ) {
-  // @ts-ignore ts-migrate(6133) FIXME: 'result' is declared but its value is never read.
-  const result = selectionInterface.getCurrentQuery().get('result')
-  return 1
-  //todo fix this
-  // return exportSize === 'visible'
-  //   ? Object.values(result.get('lazyResults').status as { [key: string]: any })
-  //       .find((status: any) => status.id === src)
-  //       .get('start')
-  //   : 1
+  const srcIndexMap = selectionInterface.getCurrentQuery()
+    .nextIndexForSourceGroup
+
+  if (src === Sources.localCatalog) {
+    return srcIndexMap['local']
+  }
+  return srcIndexMap[src]
 }
 function getSrcs(selectionInterface: any) {
   return selectionInterface.getCurrentQuery().getSelectedSources()
@@ -72,7 +71,7 @@ export function getSrcCount(
   selectionInterface: any
 ) {
   const result = selectionInterface.getCurrentQuery().get('result')
-  return exportSize === 'visible'
+  return exportSize === 'currentPage'
     ? Object.values(
         result.get('lazyResults').status as {
           [key: string]: any
@@ -93,7 +92,7 @@ function getSearches(
   count: any,
   selectionInterface: any
 ): any {
-  if (exportSize !== 'visible') {
+  if (exportSize !== 'currentPage') {
     return srcs.length > 0
       ? [
           {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -253,6 +253,9 @@ Query.Model = Backbone.AssociatedModel.extend({
     }
     return sourceArray
   },
+  getEphemeralMixinCql(cqlFilterTree) {
+    return cql.write(mixinEphemeralFilter(cqlFilterTree))
+  },
   buildSearchData() {
     const data = this.toJSON()
     data.sources = this.getSelectedSources()
@@ -388,8 +391,8 @@ Query.Model = Backbone.AssociatedModel.extend({
     } else if (options.limitToHistoric) {
       cqlFilterTree = limitToHistoric(cqlFilterTree)
     }
-    cqlFilterTree = mixinEphemeralFilter(cqlFilterTree)
-    let cqlString = cql.write(cqlFilterTree)
+
+    let cqlString = this.getEphemeralMixinCql(cqlFilterTree)
 
     this.currentIndexForSourceGroup = this.nextIndexForSourceGroup
     const localSearchToRun = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
@@ -45,8 +45,8 @@ export default hot(module)(
       this.state = {
         exportSizes: [
           {
-            label: 'Visible Results',
-            value: 'visible',
+            label: 'Current Page',
+            value: 'currentPage',
           },
           {
             label: 'All Results',


### PR DESCRIPTION
Updates the logic to get the current index for a given source allowing exports to use the appropriate start index. 
Also renames it to "current page" to make it clear the current items presented will be exported. 