### PR TITLE
[4.1.x] Log when a user exports metacards

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -292,6 +292,7 @@ Implementation details
         <argument ref="blueprintBundleContext"/>
         <argument ref="endpointUtil"/>
         <argument ref="cqlQueryUtil"/>
+        <argument ref="securityLogger"/>
     </bean>
 
     <bean id="queryValidators" class="org.codice.ddf.catalog.ui.query.validate.QueryValidators"/>

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
@@ -30,6 +30,7 @@ import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.transform.QueryResponseTransformer;
+import ddf.security.audit.SecurityLogger;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -69,6 +70,7 @@ public class CqlTransformHandlerTest {
   @Mock private QueryResponseTransformer mockQueryResponseTransformer;
   @Mock private ServletOutputStream mockServletOutputStream;
   @Mock private HttpServletResponse mockHttpServletResponse;
+  @Mock private SecurityLogger securityLogger;
 
   private static final Gson GSON =
       new GsonBuilder()
@@ -159,7 +161,11 @@ public class CqlTransformHandlerTest {
 
     cqlTransformHandler =
         new CqlTransformHandler(
-            queryResponseTransformers, mockBundleContext, mockEndpointUtil, mockCqlQueryUtil);
+            queryResponseTransformers,
+            mockBundleContext,
+            mockEndpointUtil,
+            mockCqlQueryUtil,
+            securityLogger);
 
     when(mockEndpointUtil.safeGetBody(mockRequest)).thenReturn(SAFE_BODY);
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -13,6 +13,7 @@
  *
  **/
 import fetch from '../fetch'
+import { postAuditLog } from '../audit/audit-endpoint'
 
 export enum Transformer {
   Metacard = 'metacard',
@@ -85,9 +86,15 @@ export const exportResult = async (
   transformer: string,
   attributes: string
 ) => {
-  return await fetch(
+  const response = await fetch(
     `/services/catalog/sources/${source}/${id}?transform=${transformer}&columnOrder=${attributes}`
   )
+  await postAuditLog({
+    action: 'exported',
+    component: 'metacard',
+    items: [{ id, 'source-id': source }],
+  })
+  return response
 }
 
 export const exportResultSet = async (


### PR DESCRIPTION
Adds a security log for when a user exports results or individual metacards.
Testing:
1. Add another source - e.g. CSW loopback
2. Upload resources
3. Export results from both sources
4. Verify that the action is logged as follows
Individual export (metacard interactions): "`{user} export a metacard with id {id} and source {source}`"
Multiple items exported (export at the top of the page or multiple selected items export): "`{user} exporting metacards: [{ids}] from sources: [{sources}] to format: {selected_format}`"