### PR TITLE
[4.1.x] Add possible count to query feed

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -12,7 +12,7 @@ import { useLazyResultsStatusFromSelectionInterface } from '../selection-interfa
 import Tooltip from '@material-ui/core/Tooltip'
 import { Elevations } from '../theme/theme'
 import FilterListIcon from '@material-ui/icons/FilterList'
-import { fuzzyHits } from './fuzzy-results'
+import { fuzzyHits, fuzzyResultCount } from './fuzzy-results'
 import ErrorIcon from '@material-ui/icons/Error'
 
 type Props = {
@@ -207,6 +207,7 @@ const QueryFeed = ({ selectionInterface }: Props) => {
   } = useLazyResultsStatusFromSelectionInterface({
     selectionInterface,
   })
+
   const statusBySource = Object.values(status)
   let resultMessage = '',
     pending = false,
@@ -223,12 +224,18 @@ const QueryFeed = ({ selectionInterface }: Props) => {
       const results = statusBySource
         .filter((status) => status.hasReturned)
         .filter((status) => status.successful)
-        .reduce((amt, status) => {
-          amt = amt + status.count
-          return amt
-        }, 0)
 
-      resultMessage = `${results} hit${results === 1 ? '' : 's'}`
+      let available = 0
+      let possible = 0
+
+      results.forEach((result) => {
+        available += result.count
+        possible += result.hits
+      })
+
+      resultMessage = `${available} hit${
+        available === 1 ? '' : 's'
+      } out of ${fuzzyResultCount(possible)} possible`
     } else {
       resultMessage = 'Searching...'
     }


### PR DESCRIPTION
Adds the possible count to the query feed

![image](https://user-images.githubusercontent.com/22667297/108000491-50c15080-6fa7-11eb-9266-d26287919689.png)
![image](https://user-images.githubusercontent.com/22667297/108000575-7fd7c200-6fa7-11eb-8cbe-8eccc399de33.png)

Testing:

1. Ingest at two resources
2. In Settings, reduce your search results to 1
![image](https://user-images.githubusercontent.com/22667297/108000635-a8f85280-6fa7-11eb-9533-2a5025ba8ebf.png)
3. Search for your results and verify that you see a message like "1 hit out of < 10 possible"
4. In the admin UI -> Catalog UI Search, turn off fuzzy results
5. Search again and verify that you see a message like "1 hit out of 2 possible"