### PR TITLE
[4.1.x] Allow date pickers to overflow and fix summary date picker

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -57,6 +57,12 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         placeholder={'M/D/YYYY'}
         shortcuts
         timePrecision="minute"
+        popoverProps={{
+          modifiers: {
+            preventOverflow: { enabled: false },
+            hide: { enabled: false },
+          },
+        }}
         {...(value
           ? {
               value: DateHelpers.Blueprint.DateProps.generateValue(value),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -36,7 +36,6 @@ import { displayHighlightedAttrInFull } from './highlightUtil'
 import DateTimePicker from '../../fields/date-time-picker'
 import Geometry from '../../../react-component/input-wrappers/geometry'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
-import { truncate } from 'lodash'
 
 function getSummaryShown(): string[] {
   const userchoices = user

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -36,6 +36,7 @@ import { displayHighlightedAttrInFull } from './highlightUtil'
 import DateTimePicker from '../../fields/date-time-picker'
 import Geometry from '../../../react-component/input-wrappers/geometry'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
+import { truncate } from 'lodash'
 
 function getSummaryShown(): string[] {
   const userchoices = user
@@ -456,6 +457,7 @@ const AttributeComponent = ({
               onClick={() => {
                 dialogContext.setProps({
                   open: true,
+                  disableEnforceFocus: true,
                   children: (
                     <Editor
                       attr={attr}


### PR DESCRIPTION
- Fixes an issue downstream with datepicker calendars in dialogs being rendered in the wrong place
- Fixes the summary datepicker calendar, which wouldn't allow time inputs

Testing:
- Verify date pickers works (field input, calendar input)
- Verify the summary tab datepicker works properly