### PR TITLE
[4.1.x] Fix setting Point Radius USNG/MGRS radius

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -228,8 +228,8 @@ const PointRadiusUsngMgrs = (props) => {
           type="number"
           value={String(radius)}
           onChange={(value) => {
-            setRadiusError(validateGeo('radius', value))
             setState({ ['radius']: value })
+            setRadiusError(validateGeo('radius', { value, units: radiusUnits }))
           }}
         />
       </Units>


### PR DESCRIPTION
Fixes issue where the point radius mgrs radius field was uneditable

Testing:
1. Open 2d and 3d maps
2. Select Location -> Point-Radius and draw a point radius on the map
3. Swap to the USNG/MGRS tab and verify that you can edit the radius field and that the map updates
4. Try switching units
Bonus: swap to advanced search and try the same thing

![image](https://user-images.githubusercontent.com/22667297/108130142-651b5100-706c-11eb-937b-9e2397e95346.png)