### PR TITLE
[4.1.x] Display location fields in user's preferred coordinate format

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -172,7 +172,7 @@
     "terraformer-wkt-parser": "1.1.0",
     "urijs": "1.19.1",
     "use-resize-observer": "6.1.0",
-    "usng.js": "0.4.4",
+    "usng.js": "0.4.5",
     "uuid": "2.0.2",
     "vis": "4.15.0",
     "wellknown": "https://github.com/connexta/wellknown.git#4d9ae612e7e308509ec76400b258c9db1581ea82",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -810,9 +810,6 @@ module.exports = Backbone.AssociatedModel.extend({
     }
 
     let utmUps = converter.LLtoUTMUPSObject(lat, lon)
-    const { zoneNumber, northing } = utmUps
-    const isUps = zoneNumber === 0
-    utmUps.northing = isUps || lat >= 0 ? northing : northing + northingOffset
 
     utmUps.hemisphere = lat >= 0 ? 'NORTHERN' : 'SOUTHERN'
     return utmUps

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/results-visual/result-item-row.tsx
@@ -34,6 +34,7 @@ import CheckBoxIcon from '@material-ui/icons/CheckBox'
 import { SelectionBackground } from './result-item'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import { TypedUserInstance } from '../singletons/TypedUser'
+import useCoordinateFormat from '../tabs/metacard/useCoordinateFormat'
 
 type ResultItemFullProps = {
   lazyResult: LazyQueryResult
@@ -102,6 +103,7 @@ const RowComponent = ({
   )
   const isLast = index === results.length - 1
   const { listenTo } = useBackbone()
+  const convertToFormat = useCoordinateFormat()
   useRerenderOnBackboneSync({ lazyResult })
 
   React.useEffect(() => {
@@ -116,7 +118,18 @@ const RowComponent = ({
   const imgsrc = Common.getImageSrc(thumbnail)
   React.useEffect(() => {
     measure()
-  }, [shownAttributes])
+  }, [shownAttributes, convertToFormat])
+
+  const getDisplayValue = (value: any, property: string) => {
+    if (value && metacardDefinitions.metacardTypes[property]) {
+      switch (metacardDefinitions.metacardTypes[property].type) {
+        case 'GEOMETRY':
+          return convertToFormat(value)
+      }
+    }
+    return value
+  }
+
   return (
     <React.Fragment>
       <div
@@ -236,8 +249,7 @@ const RowComponent = ({
                             {value.map((curValue: any, index: number) => {
                               return (
                                 <span key={index} data-value={`${curValue}`}>
-                                  {curValue.toString().substring(0, 4) ===
-                                  'http' ? (
+                                  {curValue.toString().startsWith('http') ? (
                                     <a
                                       href={`${curValue}`}
                                       target="_blank"
@@ -252,7 +264,7 @@ const RowComponent = ({
                                       value.length > 1 &&
                                       index < value.length - 1
                                         ? curValue + ', '
-                                        : curValue
+                                        : getDisplayValue(curValue, property)
                                     }`
                                   )}
                                 </span>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -58,4 +58,20 @@ export const TypedUserInstance = {
     })
     return attributesPossible.map((attr) => attr.id)
   },
+  getCoordinateFormat: (): string => {
+    let coordFormat = userInstance
+      .get('user')
+      ?.get('preferences')
+      ?.get('coordinateFormat')
+
+    if (!coordFormat) {
+      const defaultCoordFormat = userInstance
+        .get('user')
+        ?.defaults()
+        ?.preferences?.get('coordinateFormat')
+      coordFormat = defaultCoordFormat ?? 'degrees'
+    }
+
+    return coordFormat
+  },
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/coordinateConverter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/coordinateConverter.tsx
@@ -1,0 +1,57 @@
+import { TypedUserInstance } from '../../singletons/TypedUser'
+const mtgeo = require('mt-geo')
+const usngs = require('usng.js')
+const converter = new usngs.Converter()
+
+const usngPrecision = 6
+
+/**
+ * Converts wkt to the user's preferred coordinate format.
+ * Falls back to the wkt if the conversion fails.
+ */
+export const convertWktToPreferredCoordFormat = (wkt: string) => {
+  const coords = wkt.split(/\s/g)
+
+  if (coords.length !== 2) {
+    return wkt
+  }
+
+  // must be in number format for LLtoUTMUPS converter
+  const lon = parseFloat(coords[0])
+  const lat = parseFloat(coords[1])
+
+  if (isNaN(lon) || isNaN(lat)) {
+    return wkt
+  } else {
+    return convertCoordsToPreferred(lat, lon)
+  }
+}
+
+/**
+ * Converts coordinates from lat lon to a single string in
+ * the user's preferred format
+ */
+export const convertCoordsToPreferred = (lat: number, lon: number): string => {
+  const coordFormat = TypedUserInstance.getCoordinateFormat()
+
+  try {
+    switch (coordFormat) {
+      case 'degrees':
+        return `${mtgeo.toLat(lat)} ${mtgeo.toLon(lon)}`
+      case 'decimal':
+        return `${lat} ${lon}`
+      case 'mgrs':
+        // display dms format inUPSSpace
+        return converter.isInUPSSpace(lat)
+          ? `${mtgeo.toLat(lat)} ${mtgeo.toLon(lon)}`
+          : converter.LLtoUSNG(lat, lon, usngPrecision)
+      case 'utm':
+        return converter.LLtoUTMUPS(lat, lon)
+      case 'wkt':
+      default:
+        return `${lon} ${lat}`
+    }
+  } catch (e) {
+    return `${lon} ${lat}`
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/coordinateConverter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/coordinateConverter.tsx
@@ -41,10 +41,7 @@ export const convertCoordsToPreferred = (lat: number, lon: number): string => {
       case 'decimal':
         return `${lat} ${lon}`
       case 'mgrs':
-        // display dms format inUPSSpace
-        return converter.isInUPSSpace(lat)
-          ? `${mtgeo.toLat(lat)} ${mtgeo.toLon(lon)}`
-          : converter.LLtoUSNG(lat, lon, usngPrecision)
+        return converter.LLtoMGRSUPS(lat, lon, usngPrecision)
       case 'utm':
         return converter.LLtoUTMUPS(lat, lon)
       case 'wkt':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -36,6 +36,7 @@ import { displayHighlightedAttrInFull } from './highlightUtil'
 import DateTimePicker from '../../fields/date-time-picker'
 import Geometry from '../../../react-component/input-wrappers/geometry'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
+import useCoordinateFormat from './useCoordinateFormat'
 
 function getSummaryShown(): string[] {
   const userchoices = user
@@ -431,6 +432,7 @@ const AttributeComponent = ({
   let label = TypedMetacardDefs.getAlias({ attr })
   const { isNotWritable } = useCustomReadOnlyCheck()
   const dialogContext = useDialog()
+  const convertToFormat = useCoordinateFormat()
 
   const isUrl = (value: any) => {
     if (value && typeof value === 'string') {
@@ -556,6 +558,10 @@ const AttributeComponent = ({
                           case 'BOOLEAN':
                             return (
                               <Typography>{val ? 'true' : 'false'}</Typography>
+                            )
+                          case 'GEOMETRY':
+                            return (
+                              <Typography>{convertToFormat(val)}</Typography>
                             )
                           default:
                             if (lazyResult.highlights[attr]) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/useCoordinateFormat.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/useCoordinateFormat.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+import { convertWktToPreferredCoordFormat } from './coordinateConverter'
+import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
+const user = require('../../singletons/user-instance.js')
+
+const FLOATING_POINT_PAIR_REGEX = /[-+]?\d*\.?\d+\s[-+]?\d*\.?\d+/g
+
+/**
+ * Returns a function responsible for converting wkts to the user's preferred
+ * coordinate format
+ */
+const conversionHigherOrderFunction = () => (value: string) =>
+  value.replace(FLOATING_POINT_PAIR_REGEX, convertWktToPreferredCoordFormat)
+
+/**
+ * Provides a hook for converting wkts to the user's preferred
+ * coordinate format
+ */
+const useCoordinateFormat = () => {
+  const [convert, setConverter] = useState(conversionHigherOrderFunction)
+  const { listenTo } = useBackbone()
+
+  useEffect(() => {
+    const callback = () => setConverter(conversionHigherOrderFunction)
+
+    listenTo(
+      user.get('user').get('preferences'),
+      'change:coordinateFormat',
+      callback
+    )
+  }, [])
+
+  return convert
+}
+
+export default useCoordinateFormat

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-info/formatting.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-info/formatting.tsx
@@ -45,6 +45,7 @@ const formatter = {
       ? 'In UPS Space'
       : converter.LLtoUSNG(lat, lon, usngPrecision),
   utm: ({ lat, lon }: Coordinates) => converter.LLtoUTMUPS(lat, lon),
+  wkt: ({ lat, lon }: Coordinates) => `POINT (${lon} ${lat})`,
 }
 
 export const formatCoordinates = ({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/example-coordinates.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/example-coordinates.tsx
@@ -65,6 +65,7 @@ const defaultExamples = {
   decimal: `${exampleLat} ${exampleLon}`,
   mgrs: '4Q FL 23009 12331',
   utm: '14N 1925mE 1513mN',
+  wkt: 'POINT (50 40)',
 }
 
 const render = (props: Props) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-settings/presentation.tsx
@@ -46,6 +46,7 @@ const coordinateFormatOptions = [
   { label: 'Decimal', value: 'decimal' },
   { label: 'MGRS', value: 'mgrs' },
   { label: 'UTM/UPS', value: 'utm' },
+  { label: 'Well Known Text', value: 'wkt' },
 ]
 
 const render = ({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-user-settings/coordinate-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-user-settings/coordinate-settings.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import { useState } from 'react'
+import FormControl from '@material-ui/core/FormControl'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import RadioGroup from '@material-ui/core/RadioGroup'
+import Radio from '@material-ui/core/Radio'
+import Typography from '@material-ui/core/Typography'
+import { TypedUserInstance } from '../../component/singletons/TypedUser'
+const user = require('../../component/singletons/user-instance.js')
+
+const coordinateFormatOptions = [
+  { label: 'Degrees, Minutes, Seconds (DMS) (Lat/Lon)', value: 'degrees' },
+  { label: 'Decimal (Lat/Lon)', value: 'decimal' },
+  { label: 'MGRS', value: 'mgrs' },
+  { label: 'UTM/UPS (Lat/Lon)', value: 'utm' },
+  { label: 'Well Known Text (Lon/Lat)', value: 'wkt' },
+]
+
+const CoordinateSettings = () => {
+  const [coordFormat, setCoordFormat] = useState(
+    TypedUserInstance.getCoordinateFormat()
+  )
+
+  const updateCoordFormat = (coordinateFormat: string) => {
+    const preferences = user.get('user').get('preferences')
+    setCoordFormat(coordinateFormat)
+    preferences.set({ coordinateFormat })
+    preferences.savePreferences()
+  }
+
+  return (
+    <FormControl>
+      <Typography variant="h6">Coordinate System (CS)</Typography>
+      <RadioGroup
+        value={coordFormat}
+        onChange={(e) => updateCoordFormat(e.target.value)}
+      >
+        {coordinateFormatOptions.map((format) => (
+          <FormControlLabel
+            value={format.value}
+            control={<Radio size="small" color="primary" />}
+            label={<div className="text-sm">{format.label}</div>}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  )
+}
+
+export default CoordinateSettings

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-user-settings/map-user-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/map-user-settings/map-user-settings.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import MarionetteRegionContainer from '../marionette-region-container'
+import CoordinateSettings from './coordinate-settings'
+const MapLayerSettings = require('../../component/layers/layers.view.js')
+
+export const MapUserSettings = () => {
+  return (
+    <>
+      <CoordinateSettings />
+      <MarionetteRegionContainer view={MapLayerSettings} />
+    </>
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user-settings/user-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user-settings/user-settings.tsx
@@ -17,20 +17,17 @@ import { createGlobalStyle } from 'styled-components'
 import ThemeSettings from '../theme-settings'
 import AlertSettings from '../alert-settings'
 import SearchSettings from '../search-settings'
-const MapSettings = require('../../component/layers/layers.view.js')
 import TimeSettings from '../time-settings'
-
 import { hot } from 'react-hot-loader'
-import MarionetteRegionContainer from '../marionette-region-container'
 import Button from '@material-ui/core/Button'
 import ChevronRight from '@material-ui/icons/ChevronRight'
-
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
 import Divider from '@material-ui/core/Divider'
 import { useLocation } from 'react-router-dom'
 import queryString from 'query-string'
 import { Link } from '../../component/link/link'
+import { MapUserSettings } from '../map-user-settings/map-user-settings'
 
 const ThemeGlobalStyle = createGlobalStyle`
 .MuiBackdrop-root {
@@ -76,7 +73,7 @@ export const BaseSettings = {
   },
   Map: {
     component: () => {
-      return <MarionetteRegionContainer view={MapSettings} />
+      return <MapUserSettings />
     },
   },
   'Search Options': {

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -19904,9 +19904,10 @@ username@3.0.0:
     execa "^0.7.0"
     mem "^1.1.0"
 
-usng.js@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/usng.js/-/usng.js-0.4.4.tgz#4bcb8889d36d2720c851f486b9274a7d45c61aa6"
+usng.js@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/usng.js/-/usng.js-0.4.5.tgz#49301e131baa9f7f7ab36c0539472c1aa1ecdae7"
+  integrity sha512-JTJcFFDy/JqA5iiU8DqMOV5gJiL3ZdXH0hCKYaRMDbbredhFna5Ok4C1YDFU07mTGAgm+5FzHaaOzQnO/3BzWQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Displays the location fields in summary view and result table and list in the user's preferred coordinate format

Adds a setting to change the preferred coordinate format 

Adds WKT to the map coordinate dropdown

This pr also fixes and issue where we would sometimes try to use `.join` on non-arrays.

Testing:
1. Ingest some geo data. [Here](https://github.com/codice/ddf-ui/files/6028409/9_geo_files.zip) are some xml files with geo data.
2. Open the results and summary visualizations and show the location attribute in manage attributes
3. Select a result and, on the map, swap between coordinate settings
    ![image](https://user-images.githubusercontent.com/22667297/108834006-d4bc9f00-758a-11eb-9cf9-2af20f3ccdc9.png)
4. Switch between results list and table and swap coordinates settings to confirm the location updates
5. In the user settings, swap between coordinate formats an verify that the formats are updated
    ![image](https://user-images.githubusercontent.com/22667297/108834156-0afa1e80-758b-11eb-8515-68207d8b87e5.png)
6. You can also try more complex coordinates [from here](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
Bonus:  add other attributes types to confirm that the `.join` issue is fixed. Adding location in manage attributes should do it, but adding a few different attributes would help.


Note: coordinates are swapped in place, so they will still appear to look wkt-like

