### PR TITLE
[4.1.x] Update set to use filterBuilderClass for saved searches

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -124,7 +124,7 @@ Query.Model = Backbone.AssociatedModel.extend({
     ) {
       // for backwards compatability
       try {
-        data.filterTree = JSON.parse(data.filterTree)
+        data.filterTree = new FilterBuilderClass(JSON.parse(data.filterTree))
       } catch (e) {
         data.filterTree = CQLUtils.transformCQLToFilter(data.cql)
       }
@@ -186,6 +186,9 @@ Query.Model = Backbone.AssociatedModel.extend({
     _.bindAll.apply(_, [this].concat(_.functions(this))) // underscore bindAll does not take array arg
     this.set('id', this.getId())
     const filterTree = this.get('filterTree')
+    if (filterTree && typeof filterTree === 'string') {
+      this.set('filterTree', JSON.parse(filterTree))
+    }
     // when we make drastic changes to filter tree it will be necessary to fall back to cql and reconstruct a filter tree that's compatible
     if (!filterTree || filterTree.id === undefined) {
       this.set('filterTree', cql.read(this.get('cql'))) // reconstruct
@@ -195,7 +198,8 @@ Query.Model = Backbone.AssociatedModel.extend({
         search: this,
       })
     } else {
-      this.set('filterTree', new FilterBuilderClass(filterTree)) // instantiate the class if everything is a-okay
+      const filterTreeBuilder = new FilterBuilderClass(filterTree)
+      this.set('filterTree', filterTreeBuilder) // instantiate the class if everything is a-okay
     }
     this.listenTo(
       this,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -123,11 +123,7 @@ Query.Model = Backbone.AssociatedModel.extend({
       typeof data.filterTree === 'string'
     ) {
       // for backwards compatability
-      try {
-        data.filterTree = new FilterBuilderClass(JSON.parse(data.filterTree))
-      } catch (e) {
-        data.filterTree = CQLUtils.transformCQLToFilter(data.cql)
-      }
+      data.filterTree = new FilterBuilderClass(JSON.parse(data.filterTree))
     }
     return Backbone.AssociatedModel.prototype.set.apply(this, arguments)
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -198,8 +198,7 @@ Query.Model = Backbone.AssociatedModel.extend({
         search: this,
       })
     } else {
-      const filterTreeBuilder = new FilterBuilderClass(filterTree)
-      this.set('filterTree', filterTreeBuilder) // instantiate the class if everything is a-okay
+      this.set('filterTree', new FilterBuilderClass(filterTree)) // instantiate the class if everything is a-okay
     }
     this.listenTo(
       this,


### PR DESCRIPTION
Whenever set was called we didn't wrap the update to the filterTree in a filterbuilderclass which leads to the incorrect cql being parsed from the filterTree. 

Hero:
Save Searches with NOT criteria (both Field and Group level) and ensure they are preserved when loading a search. 