### PR TITLE
Replace error icon removed in merge conflict

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -13,6 +13,7 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { Elevations } from '../theme/theme'
 import FilterListIcon from '@material-ui/icons/FilterList'
 import { fuzzyHits, fuzzyResultCount } from './fuzzy-results'
+import ErrorIcon from '@material-ui/icons/Error'
 
 type Props = {
   selectionInterface: any


### PR DESCRIPTION
The error icon was removed in a merge conflict.

This just needs a passing test.