### PR TITLE
[4.1.x] Display AM/PM buttons when user prefers 12hr time format

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -14,9 +14,6 @@
  **/
 import * as React from 'react'
 import { DateInput } from '@blueprintjs/datetime'
-
-// @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
-import user from '../singletons/user-instance'
 import { DateHelpers, DefaultMaxDate, DefaultMinDate } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
@@ -25,6 +22,8 @@ import Grid from '@material-ui/core/Grid/Grid'
 import { NumberField } from './number'
 import TextField from '@material-ui/core/TextField/TextField'
 import MenuItem from '@material-ui/core/MenuItem/MenuItem'
+
+const user = require('../singletons/user-instance.js')
 
 type DateAroundProps = {
   value: ValueTypes['around']
@@ -70,6 +69,9 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
     <Grid container alignItems="stretch" direction="column" wrap="nowrap">
       <Grid item className="w-full pb-2">
         <DateInput
+          timePickerProps={{
+            useAmPm: user.getAmPmDisplay(),
+          }}
           className={MuiOutlinedInputBorderClasses}
           minDate={DefaultMinDate}
           maxDate={DefaultMaxDate}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -19,6 +19,8 @@ import { ValueTypes } from '../filter-builder/filter.structure'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
 
+const user = require('../singletons/user-instance.js')
+
 type Props = {
   value: ValueTypes['during']
   onChange: (value: ValueTypes['during']) => void
@@ -54,6 +56,9 @@ export const DateRangeField = ({
   }, [])
   return (
     <DateRangeInput
+      timePickerProps={{
+        useAmPm: user.getAmPmDisplay(),
+      }}
       allowSingleDayRange
       minDate={DefaultMinDate}
       maxDate={DefaultMaxDate}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -15,11 +15,11 @@
 import * as React from 'react'
 import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
 
-// @ts-ignore ts-migrate(7016) FIXME: Could not find a declaration file for module '../s... Remove this comment to see the full error message
-import user from '../singletons/user-instance'
 import { DateHelpers, DefaultMaxDate, DefaultMinDate } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
+
+const user = require('../singletons/user-instance.js')
 
 type DateFieldProps = {
   value: string
@@ -57,6 +57,9 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         placeholder={'M/D/YYYY'}
         shortcuts
         timePrecision="minute"
+        timePickerProps={{
+          useAmPm: user.getAmPmDisplay(),
+        }}
         popoverProps={{
           modifiers: {
             preventOverflow: { enabled: false },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -454,6 +454,12 @@ User.Response = Backbone.AssociatedModel.extend({
         this.get('user').get('preferences').get('dateTimeFormat')['datetimefmt']
       )
   },
+  getAmPmDisplay() {
+    return (
+      this.get('user').get('preferences').get('dateTimeFormat')['timefmt'] ===
+      Common.getDateTimeFormats()[12].timefmt
+    )
+  },
   getDateTimeFormat() {
     return this.get('user').get('preferences').get('dateTimeFormat')[
       'datetimefmt'


### PR DESCRIPTION
Adds a utility method to user that checks to see if the user's preferred format is 12 hour time- if it is, display AM/PM button on date pickers- otherwise allow them to enter time in 24 hour time.

Test by checking that all the date pickers support 12 and 24 hour time format input.
![Screen Shot 2021-03-08 at 11 11 12](https://user-images.githubusercontent.com/9013407/110363722-23911c80-8000-11eb-9696-a9a0de43f11b.png)
![Screen Shot 2021-03-08 at 11 10 47](https://user-images.githubusercontent.com/9013407/110363728-24c24980-8000-11eb-838b-c373b0d58825.png)
