### PR TITLE
Fix NPE when highlighting missing attribute

### DIFF
--- a/ui-backend/catalog-plugin-highlight/src/main/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPlugin.java
+++ b/ui-backend/catalog-plugin-highlight/src/main/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPlugin.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 /** Transforms solr highlights into an easily displayable format on the frontend */
 public class HighlightTransformPlugin implements PostQueryPlugin {
+
   private int bufferSize;
 
   public HighlightTransformPlugin() {
@@ -44,6 +45,7 @@ public class HighlightTransformPlugin implements PostQueryPlugin {
 
   @VisibleForTesting
   protected static class ProcessedHighlight {
+
     private String id;
     private List<Map<String, String>> highlights;
 
@@ -116,9 +118,12 @@ public class HighlightTransformPlugin implements PostQueryPlugin {
       String attributeName,
       Highlight highlight) {
     Attribute attribute = matchingResult.getMetacard().getAttribute(attributeName);
-    String value = (String) attribute.getValues().get(highlight.getValueIndex());
+    String value = null;
+    if (attribute != null && !attribute.getValues().isEmpty()) {
+      value = (String) attribute.getValues().get(highlight.getValueIndex());
+    }
 
-    if (!value.equals("REDACTED")) {
+    if (value != null && !value.equals("REDACTED")) {
       String highlightedString = createHighlightString(highlight, value, attributeName);
       processedHighlight.addHighlight(
           attributeName,
@@ -162,7 +167,9 @@ public class HighlightTransformPlugin implements PostQueryPlugin {
       int startIndex = highlight.getBeginIndex() - bufferSize;
       if (startIndex <= 0) {
         startBuffer = value.substring(0, highlight.getBeginIndex());
-      } else startBuffer = "...".concat(value.substring(startIndex, highlight.getBeginIndex()));
+      } else {
+        startBuffer = "...".concat(value.substring(startIndex, highlight.getBeginIndex()));
+      }
     }
     return startBuffer;
   }

--- a/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,8 +12,18 @@
  *
  **/
  -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-    <bean id="highlightTransformPlugin"
-          class="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransformPlugin"/>
-    <service ref="highlightTransformPlugin" interface="ddf.catalog.plugin.PostQueryPlugin"/>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+  xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+  <bean id="highlightTransformPlugin"
+    class="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransformPlugin">
+    <cm:managed-properties
+      persistent-id="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform"
+      update-strategy="container-managed"/>
+  </bean>
+  <service ref="highlightTransformPlugin" interface="ddf.catalog.plugin.PostQueryPlugin"/>
 </blueprint>

--- a/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+  <OCD name="Catalog UI Highlight Transform"
+    id="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform">
+    <AD description="Regex pattern to identify whether attribute data has been redacted"
+      name="Redacted Data Pattern" id="redactedPattern" type="String"
+      default="REDACTED"/>
+  </OCD>
+
+  <Designate pid="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform">
+    <Object ocdref="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform"/>
+  </Designate>
+
+</metatype:MetaData>

--- a/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
+++ b/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
@@ -33,6 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HighlightTransformPluginTest {
+
   QueryRequest request;
 
   private QueryResponse input;
@@ -70,8 +71,11 @@ public class HighlightTransformPluginTest {
     QueryResponse response = new QueryResponseImpl(request, Arrays.asList(result), 1);
     ResultAttributeHighlight resultAttributeHighlight =
         new ResultAttributeHighlightImpl("description", Arrays.asList(highlight));
+    ResultAttributeHighlight missingAttributeHighlight =
+        new ResultAttributeHighlightImpl("extra", Arrays.asList(new HighlightImpl(6, 20)));
     ResultHighlight resultHighlight =
-        new ResultHighlightImpl(id, Arrays.asList(resultAttributeHighlight));
+        new ResultHighlightImpl(
+            id, Arrays.asList(resultAttributeHighlight, missingAttributeHighlight));
 
     response
         .getProperties()

--- a/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
+++ b/ui-backend/catalog-plugin-highlight/src/test/java/org/codice/ddf/catalog/ui/plugin/highlight/HighlightTransformPluginTest.java
@@ -71,11 +71,8 @@ public class HighlightTransformPluginTest {
     QueryResponse response = new QueryResponseImpl(request, Arrays.asList(result), 1);
     ResultAttributeHighlight resultAttributeHighlight =
         new ResultAttributeHighlightImpl("description", Arrays.asList(highlight));
-    ResultAttributeHighlight missingAttributeHighlight =
-        new ResultAttributeHighlightImpl("extra", Arrays.asList(new HighlightImpl(6, 20)));
     ResultHighlight resultHighlight =
-        new ResultHighlightImpl(
-            id, Arrays.asList(resultAttributeHighlight, missingAttributeHighlight));
+        new ResultHighlightImpl(id, Arrays.asList(resultAttributeHighlight));
 
     response
         .getProperties()
@@ -87,6 +84,53 @@ public class HighlightTransformPluginTest {
     ArrayList<HighlightTransformPlugin.ProcessedHighlight> highlights =
         (ArrayList<HighlightTransformPlugin.ProcessedHighlight>)
             processedResponse.getProperties().get(Constants.QUERY_HIGHLIGHT_KEY);
+    assertThat(highlights.get(0).getId(), is("123456789"));
+    assertThat(highlights.get(0).getHighlights().get(0).get("attribute"), is("description"));
+    assertThat(
+        highlights.get(0).getHighlights().get(0).get("highlight"),
+        is("<span class=\"highlight\">Lorem</span> ipsum dol..."));
+  }
+
+  @Test
+  public void testProcessHighlightsRedacted() {
+    HighlightTransformPlugin highlightPlugin = new HighlightTransformPlugin(10);
+    highlightPlugin.setRedactedPattern("REDACTED.*");
+
+    String id = "123456789";
+    // Highlight the word "Lorem"
+    Highlight highlight = new HighlightImpl(0, 5);
+
+    Metacard metacard = new MetacardImpl();
+    metacard.setAttribute(new AttributeImpl("title", "REDACTED DATA"));
+    metacard.setAttribute(new AttributeImpl("description", value));
+    metacard.setAttribute(new AttributeImpl("id", "123456789"));
+    Result result = new ResultImpl(metacard);
+
+    QueryResponse response = new QueryResponseImpl(request, Arrays.asList(result), 1);
+    ResultAttributeHighlight resultAttributeHighlight =
+        new ResultAttributeHighlightImpl("description", Arrays.asList(highlight));
+    ResultAttributeHighlight missingAttributeHighlight =
+        new ResultAttributeHighlightImpl("extra", Arrays.asList(new HighlightImpl(6, 20)));
+    ResultAttributeHighlight redactedAttributeHighlight =
+        new ResultAttributeHighlightImpl("title", Arrays.asList(new HighlightImpl(10, 20)));
+
+    ResultHighlight resultHighlight =
+        new ResultHighlightImpl(
+            id,
+            Arrays.asList(
+                resultAttributeHighlight, missingAttributeHighlight, redactedAttributeHighlight));
+
+    response
+        .getProperties()
+        .put(Constants.QUERY_HIGHLIGHT_KEY, (Serializable) Arrays.asList(resultHighlight));
+
+    QueryResponse processedResponse = highlightPlugin.process(response);
+    assertThat(
+        processedResponse.getProperties().containsKey(Constants.QUERY_HIGHLIGHT_KEY), is(true));
+    ArrayList<HighlightTransformPlugin.ProcessedHighlight> highlights =
+        (ArrayList<HighlightTransformPlugin.ProcessedHighlight>)
+            processedResponse.getProperties().get(Constants.QUERY_HIGHLIGHT_KEY);
+    assertThat(highlights.size(), is(1));
     assertThat(highlights.get(0).getId(), is("123456789"));
     assertThat(highlights.get(0).getHighlights().get(0).get("attribute"), is("description"));
     assertThat(


### PR DESCRIPTION
When highlights are returned for attributes that have been removed from the resulting metacard or don't exist, an NPE would be thrown.  This PR adds a check to make sure the attribute and referenced value exists before processing the highlight.