### PR TITLE
Adds protection against missing model or empty lists for expand metacard interaction

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { HashRouter as Router } from 'react-router-dom'
+import ExpandInteraction from './expand-interaction'
+import Enzyme, { mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+Enzyme.configure({ adapter: new Adapter() })
+import { expect } from 'chai'
+import Backbone from 'backbone'
+
+describe('smoke test', () => {
+  it('it handles undefined', () => {
+    const wrapper = mount(
+      <Router>
+        <ExpandInteraction
+          onClose={() => {}}
+          model={undefined}
+          listenTo={() => {}}
+          stopListening={() => {}}
+          listenToOnce={() => {}}
+        />
+      </Router>
+    )
+    expect(wrapper.html()).to.eq('')
+  })
+
+  it('it handles empty array', () => {
+    const wrapper = mount(
+      <Router>
+        <ExpandInteraction
+          onClose={() => {}}
+          model={new Backbone.Collection()}
+          listenTo={() => {}}
+          stopListening={() => {}}
+          listenToOnce={() => {}}
+        />
+      </Router>
+    )
+    expect(wrapper.html()).to.eq('')
+  })
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
@@ -22,7 +22,7 @@ import { Link } from '../../component/link/link'
 const ExpandMetacard = (props: Props) => {
   const isRouted = router && router.toJSON().name === 'openMetacard'
 
-  if (isRouted || props.model.length > 1) {
+  if (isRouted || !props.model || props.model.length !== 1) {
     return null
   }
   let id = props.model.first().get('metacard').get('properties').get('id')


### PR DESCRIPTION
Forward port of: https://github.com/codice/ddf-ui/pull/547 

- Adds tests that exercise a missing model, as well as an empty list being passed.
 - This would happen if the multiselect menu happened to be open, and then the selection changed to be either undefined or empty suddenly (select two, open menu, while open deselect everything).

https://user-images.githubusercontent.com/11984853/112079621-bb812100-8b3d-11eb-845a-9edda8a0ce51.mov