### PR TITLE
[4.2.x] Update source selector / sources button

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/source-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/source-selector.tsx
@@ -10,7 +10,8 @@ import Grid from '@material-ui/core/Grid'
 import HomeIcon from '@material-ui/icons/Home'
 import CloudIcon from '@material-ui/icons/Cloud'
 import WarningIcon from '@material-ui/icons/Warning'
-import CheckIcon from '@material-ui/icons/Check'
+import CheckBoxIcon from '@material-ui/icons/CheckBox'
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
 import Chip from '@material-ui/core/Chip'
 import _ from 'lodash'
 type Props = {
@@ -293,13 +294,11 @@ const SourceSelector = ({ search }: Props) => {
           <Grid container alignItems="stretch" direction="row" wrap="nowrap">
             <Grid container direction="row" alignItems="center">
               <Grid item className="pr-2">
-                <CheckIcon
-                  className={
-                    shouldBeSelected({ srcId: 'all', sources })
-                      ? ''
-                      : 'invisible'
-                  }
-                />
+                {shouldBeSelected({ srcId: 'all', sources }) ? (
+                  <CheckBoxIcon />
+                ) : (
+                  <CheckBoxOutlineBlankIcon />
+                )}
               </Grid>
               <Grid item>All</Grid>
             </Grid>
@@ -307,20 +306,24 @@ const SourceSelector = ({ search }: Props) => {
         </MenuItem>
         {availableLocalSources.length > 0 ? (
           <MenuItem data-id="onsite-option" value="local">
-            <Grid container alignItems="stretch" direction="row" wrap="nowrap">
-              <Grid item className="pr-2">
-                <CheckIcon
-                  className={
-                    shouldBeSelected({ srcId: 'local', sources })
-                      ? ''
-                      : 'invisible'
-                  }
-                />
-              </Grid>
+            <Grid
+              container
+              alignItems="stretch"
+              direction="row"
+              wrap="nowrap"
+              className="pl-3"
+            >
               <Grid item className="pr-2">
                 <Swath className="w-1 h-full" />
               </Grid>
               <Grid container direction="row" alignItems="center">
+                <Grid item className="pr-2">
+                  {shouldBeSelected({ srcId: 'local', sources }) ? (
+                    <CheckBoxIcon />
+                  ) : (
+                    <CheckBoxOutlineBlankIcon />
+                  )}
+                </Grid>
                 <Grid item>Fast (onsite)</Grid>
                 <Grid item className="pl-2">
                   <HomeIcon />
@@ -342,20 +345,19 @@ const SourceSelector = ({ search }: Props) => {
                     alignItems="stretch"
                     direction="row"
                     wrap="nowrap"
+                    className="pl-6"
                   >
-                    <Grid item className="pr-2">
-                      <CheckIcon
-                        className={
-                          shouldBeSelected({ srcId: source.id, sources })
-                            ? ''
-                            : 'invisible'
-                        }
-                      />
-                    </Grid>
-                    <Grid item className="pl-2 pr-3">
+                    <Grid item className="pl-3 pr-3">
                       <Swath className="w-1 h-full" />
                     </Grid>
                     <Grid container direction="row" alignItems="center">
+                      <Grid item className="pr-2">
+                        {shouldBeSelected({ srcId: source.id, sources }) ? (
+                          <CheckBoxIcon />
+                        ) : (
+                          <CheckBoxOutlineBlankIcon />
+                        )}
+                      </Grid>
                       <Grid item>
                         <div
                           className={
@@ -378,20 +380,24 @@ const SourceSelector = ({ search }: Props) => {
           : null}
         {availableRemoteSources.length > -1 ? (
           <MenuItem data-id="offsite-option" value="remote">
-            <Grid container alignItems="stretch" direction="row" wrap="nowrap">
-              <Grid item className="pr-2">
-                <CheckIcon
-                  className={
-                    shouldBeSelected({ srcId: 'remote', sources })
-                      ? ''
-                      : 'invisible'
-                  }
-                />
-              </Grid>
+            <Grid
+              container
+              alignItems="stretch"
+              direction="row"
+              wrap="nowrap"
+              className="pl-3"
+            >
               <Grid item className="pr-2">
                 <Swath className="w-1 h-full" />
               </Grid>
               <Grid container direction="row" alignItems="center">
+                <Grid item className="pr-2">
+                  {shouldBeSelected({ srcId: 'remote', sources }) ? (
+                    <CheckBoxIcon />
+                  ) : (
+                    <CheckBoxOutlineBlankIcon />
+                  )}
+                </Grid>
                 <Grid item>Slow (offsite)</Grid>
                 <Grid item className="pl-2">
                   <CloudIcon />
@@ -413,20 +419,19 @@ const SourceSelector = ({ search }: Props) => {
                     alignItems="stretch"
                     direction="row"
                     wrap="nowrap"
+                    className="pl-6"
                   >
-                    <Grid item className="pr-2">
-                      <CheckIcon
-                        className={
-                          shouldBeSelected({ srcId: source.id, sources })
-                            ? ''
-                            : 'invisible'
-                        }
-                      />
-                    </Grid>
-                    <Grid item className="pl-2 pr-2">
+                    <Grid item className="pl-3 pr-3">
                       <Swath className="w-1 h-full" />
                     </Grid>
                     <Grid container direction="row" alignItems="center">
+                      <Grid item className="pr-2">
+                        {shouldBeSelected({ srcId: source.id, sources }) ? (
+                          <CheckBoxIcon />
+                        ) : (
+                          <CheckBoxOutlineBlankIcon />
+                        )}
+                      </Grid>
                       <Grid item>
                         <div
                           className={

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/sources-info.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/sources-info.tsx
@@ -1,19 +1,56 @@
+import Button from '@material-ui/core/Button'
+import Grid from '@material-ui/core/Grid'
+import Paper from '@material-ui/core/Paper'
+import Popover from '@material-ui/core/Popover'
+import StorageIcon from '@material-ui/icons/Storage'
 import * as React from 'react'
 import { hot } from 'react-hot-loader'
-import StorageIcon from '@material-ui/icons/Storage'
-import Grid from '@material-ui/core/Grid'
-import { Link } from '../../component/link/link'
-import Button from '@material-ui/core/Button'
-import Tooltip from '@material-ui/core/Tooltip'
-import SourcesPage from '../../react-component/sources'
-import Paper from '@material-ui/core/Paper'
-import { Elevations } from '../theme/theme'
 import ExtensionPoints from '../../extension-points'
+import SourcesPage from '../../react-component/sources'
+import { Elevations } from '../theme/theme'
 
 const SourcesInfo = () => {
+  const [anchorEl, setAnchorEl] = React.useState(null)
+
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const open = Boolean(anchorEl)
+
   return (
-    <Tooltip
-      title={
+    <React.Fragment>
+      <Button
+        data-id="sources-button"
+        fullWidth
+        variant="text"
+        color="primary"
+        onClick={handleClick}
+      >
+        <Grid container direction="row" alignItems="center" wrap="nowrap">
+          <Grid item className="pr-1">
+            <StorageIcon className="Mui-text-text-primary" />
+          </Grid>
+          <Grid item>Sources</Grid>
+        </Grid>
+      </Button>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
         <Paper elevation={Elevations.overlays} className="min-w-120">
           {ExtensionPoints.customSourcesPage ? (
             <ExtensionPoints.customSourcesPage />
@@ -21,25 +58,8 @@ const SourcesInfo = () => {
             <SourcesPage />
           )}
         </Paper>
-      }
-    >
-      <Button
-        data-id="sources-button"
-        fullWidth
-        component={Link}
-        to="/sources"
-        variant="text"
-        color="primary"
-        target="_blank"
-      >
-        <Grid container direction="row" alignItems="center" wrap="nowrap">
-          <Grid item>
-            <StorageIcon />
-          </Grid>
-          <Grid item>Sources</Grid>
-        </Grid>
-      </Button>
-    </Tooltip>
+      </Popover>
+    </React.Fragment>
   )
 }
 


### PR DESCRIPTION
Changes sources button to display sources on click instead of on hover, and adds scrolling to the popover. 
![image](https://user-images.githubusercontent.com/4467636/112686360-14e59a80-8e33-11eb-9f48-2c391602a615.png)


Updates appearance of source selector based on this mockup
![image](https://user-images.githubusercontent.com/4467636/112370110-3b240280-8c9a-11eb-81df-c7c2b43bbdea.png)

old: 
![image](https://user-images.githubusercontent.com/4467636/112686476-39da0d80-8e33-11eb-99ac-bf9de3a65cfb.png)

updated:
![image](https://user-images.githubusercontent.com/4467636/112686533-50806480-8e33-11eb-8d85-de0df9fc2bf4.png)

