### PR TITLE
Fix NPE when highlighting missing attribute

### DIFF
--- a/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,8 +12,18 @@
  *
  **/
  -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-    <bean id="highlightTransformPlugin"
-          class="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransformPlugin"/>
-    <service ref="highlightTransformPlugin" interface="ddf.catalog.plugin.PostQueryPlugin"/>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+  xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+  <bean id="highlightTransformPlugin"
+    class="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransformPlugin">
+    <cm:managed-properties
+      persistent-id="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform"
+      update-strategy="container-managed"/>
+  </bean>
+  <service ref="highlightTransformPlugin" interface="ddf.catalog.plugin.PostQueryPlugin"/>
 </blueprint>

--- a/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/ui-backend/catalog-plugin-highlight/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+  <OCD name="Catalog UI Highlight Transform"
+    id="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform">
+    <AD description="Regex pattern to identify whether attribute data has been redacted"
+      name="Redacted Data Pattern" id="redactedPattern" type="String"
+      default="REDACTED"/>
+  </OCD>
+
+  <Designate pid="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform">
+    <Object ocdref="org.codice.ddf.catalog.ui.plugin.highlight.HighlightTransform"/>
+  </Designate>
+
+</metatype:MetaData>


### PR DESCRIPTION
Forward port of #543 

When highlights are returned for attributes that have been removed from the resulting metacard or don't exist, an NPE would be thrown. This PR adds a check to make sure the attribute and referenced value exists before processing the highlight.