### PR TITLE
[4.2.x] Add support for deprecated enumerations for queries

### DIFF
--- a/ui-backend/catalog-ui-enumeration/pom.xml
+++ b/ui-backend/catalog-ui-enumeration/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>jsr305</artifactId>
             <version>${jsr305.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.search</groupId>
+            <artifactId>deprecatable-enumeration-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ui-backend/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
+++ b/ui-backend/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
@@ -16,6 +16,7 @@ package org.codice.ddf.catalog.ui.enumeration;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 import com.google.common.collect.Sets;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeInjector;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.codice.ddf.catalog.ui.enumeration.api.DeprecatableEnumeration;
 
 /** This class is Experimental and subject to change */
 public class ExperimentalEnumerationExtractor {
@@ -40,17 +42,21 @@ public class ExperimentalEnumerationExtractor {
 
   private final List<AttributeInjector> attributeInjectors;
 
+  private final List<DeprecatableEnumeration> deprecatableEnumerations;
+
   /**
-   * @param attributeValidatorRegistry
-   * @param metacardTypes
    * @deprecated This constructor does not take into account injected attributes. The other
    *     constructor {@link #ExperimentalEnumerationExtractor(AttributeValidatorRegistry, List,
-   *     List)} should be used.
+   *     List, List)} should be used.
    */
   @Deprecated
   public ExperimentalEnumerationExtractor(
       AttributeValidatorRegistry attributeValidatorRegistry, List<MetacardType> metacardTypes) {
-    this(attributeValidatorRegistry, metacardTypes, Collections.emptyList());
+    this(
+        attributeValidatorRegistry,
+        metacardTypes,
+        Collections.emptyList(),
+        Collections.emptyList());
   }
 
   /**
@@ -61,10 +67,12 @@ public class ExperimentalEnumerationExtractor {
   public ExperimentalEnumerationExtractor(
       AttributeValidatorRegistry attributeValidatorRegistry,
       List<MetacardType> metacardTypes,
-      List<AttributeInjector> attributeInjectors) {
+      List<AttributeInjector> attributeInjectors,
+      List<DeprecatableEnumeration> deprecatableEnumerations) {
     this.attributeValidatorRegistry = attributeValidatorRegistry;
     this.metacardTypes = metacardTypes;
     this.attributeInjectors = attributeInjectors;
+    this.deprecatableEnumerations = deprecatableEnumerations;
   }
 
   public Map<String, Set<String>> getAttributeEnumerations(String attribute) {
@@ -83,11 +91,30 @@ public class ExperimentalEnumerationExtractor {
                     .flatMap(Set::stream)
                     .distinct()
                     .collect(Collectors.toMap(o -> o, o -> avr.getSuggestedValues())))
-        .reduce(
-            (m1, m2) -> {
-              m2.entrySet().forEach(e -> m1.merge(e.getKey(), e.getValue(), Sets::union));
-              return m1;
-            })
+        .reduce(this::union)
+        .orElseGet(HashMap::new);
+  }
+
+  public Map<String, Set<String>> getDeprecatedEnumerations(@Nullable String metacardType) {
+    if (isBlank(metacardType)) {
+      metacardType = MetacardImpl.BASIC_METACARD.getName();
+    }
+    MetacardType type = getTypeFromName(metacardType);
+
+    if (type == null) {
+      return new HashMap<>();
+    }
+
+    type = applyInjectors(type, attributeInjectors);
+
+    return type.getAttributeDescriptors()
+        .stream()
+        .map(this::toDeprecatedEnumeration)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .filter(this::isNotEmpty)
+        .map(this::toMap)
+        .reduce(this::union)
         .orElseGet(HashMap::new);
   }
 
@@ -122,12 +149,36 @@ public class ExperimentalEnumerationExtractor {
                     .flatMap(Set::stream)
                     .distinct()
                     .collect(Collectors.toMap(o -> o, o -> avr.getSuggestedValues())))
-        .reduce(
-            (m1, m2) -> {
-              m2.entrySet().forEach(e -> m1.merge(e.getKey(), e.getValue(), Sets::union));
-              return m1;
-            })
+        .reduce(this::union)
         .orElseGet(HashMap::new);
+  }
+
+  private Optional<DeprecatableEnumeration> toDeprecatedEnumeration(
+      AttributeDescriptor attributeDescriptor) {
+    return getDeprecatedAttributeEnumerations(attributeDescriptor.getName());
+  }
+
+  private boolean isNotEmpty(DeprecatableEnumeration deprecatableEnumeration) {
+    return !deprecatableEnumeration.getDeprecatedValues().isEmpty();
+  }
+
+  private Map<String, Set<String>> union(
+      Map<String, Set<String>> firstMap, Map<String, Set<String>> secondMap) {
+    secondMap.forEach((key, value) -> firstMap.merge(key, value, Sets::union));
+    return firstMap;
+  }
+
+  private Map<String, Set<String>> toMap(DeprecatableEnumeration deprecatableEnumeration) {
+    Map<String, Set<String>> map = new HashMap<>();
+    map.put(deprecatableEnumeration.getAttribute(), deprecatableEnumeration.getDeprecatedValues());
+    return map;
+  }
+
+  private Optional<DeprecatableEnumeration> getDeprecatedAttributeEnumerations(String attribute) {
+    return deprecatableEnumerations
+        .stream()
+        .filter(deprecatableEnumeration -> deprecatableEnumeration.getAttribute().equals(attribute))
+        .findFirst();
   }
 
   @Nullable

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -626,6 +626,11 @@ public class MetacardApplication implements SparkApplication {
         util::getJson);
 
     get(
+        "/enumerations/deprecated/:type",
+        APPLICATION_JSON,
+        (req, res) -> util.getJson(enumExtractor.getDeprecatedEnumerations(req.params(":type"))));
+
+    get(
         "/enumerations/metacardtype/:type",
         APPLICATION_JSON,
         (req, res) -> util.getJson(enumExtractor.getEnumerations(req.params(":type"))));

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -230,6 +230,7 @@ Implementation details
         <argument ref="defaultAttributeValidatorRegistry"/>
         <argument ref="metacardTypes"/>
         <argument ref="attributeInjectors"/>
+        <argument ref="deprecatableEnumerations"/>
     </bean>
 
     <bean id="workspacePersistentStore"

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/consumes.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/consumes.xml
@@ -143,6 +143,10 @@ Services (OSGi) that catalog-ui-search CONSUMES from DDF
     <reference id="csvQueryResponseTransformer"
                interface="ddf.catalog.transform.QueryResponseTransformer" filter="(id=csv)"/>
 
+    <reference-list id="deprecatableEnumerations"
+                    interface="org.codice.ddf.catalog.ui.enumeration.api.DeprecatableEnumeration"
+                    availability="optional"/>
+
     <!--
     =============================================================
     QUERY APPLICATION

--- a/ui-backend/deprecatable-enumeration-api/pom.xml
+++ b/ui-backend/deprecatable-enumeration-api/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.ddf.search</groupId>
+        <artifactId>backend</artifactId>
+        <version>4.1.14</version>
+    </parent>
+    <artifactId>deprecatable-enumeration-api</artifactId>
+    <name>DDF :: Catalog :: UI :: Deprecatable Enumeration API</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            org.codice.ddf.catalog.ui.enumeration.api
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ui-backend/deprecatable-enumeration-api/pom.xml
+++ b/ui-backend/deprecatable-enumeration-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>4.1.14</version>
+        <version>4.1.16-SNAPSHOT</version>
     </parent>
     <artifactId>deprecatable-enumeration-api</artifactId>
     <name>DDF :: Catalog :: UI :: Deprecatable Enumeration API</name>

--- a/ui-backend/deprecatable-enumeration-api/src/main/java/org/codice/ddf/catalog/ui/enumeration/api/DeprecatableEnumeration.java
+++ b/ui-backend/deprecatable-enumeration-api/src/main/java/org/codice/ddf/catalog/ui/enumeration/api/DeprecatableEnumeration.java
@@ -1,0 +1,13 @@
+/* Copyright (c) Connexta, LLC */
+package org.codice.ddf.catalog.ui.enumeration.api;
+
+import java.util.Set;
+
+public interface DeprecatableEnumeration {
+
+  /** Get an unmodifable set of deprecated values. */
+  Set<String> getDeprecatedValues();
+
+  /** The name of the attribute. */
+  String getAttribute();
+}

--- a/ui-backend/intrigue-ui-app/src/main/resources/features.xml
+++ b/ui-backend/intrigue-ui-app/src/main/resources/features.xml
@@ -62,6 +62,7 @@
         <bundle>mvn:org.codice.ddf.search/audit-application/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.search/audit-logging/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.search/catalog-plugin-highlight/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.search/deprecatable-enumeration-api/${project.version}</bundle>
     </feature>
 
     <feature name="javalin" version="${project.version}" description="Javalin Web Framework">

--- a/ui-backend/pom.xml
+++ b/ui-backend/pom.xml
@@ -24,5 +24,6 @@
         <module>intrigue-ui-app</module>
         <module>audit</module>
         <module>javalin-utils</module>
+        <module>deprecatable-enumeration-api</module>
     </modules>
 </project>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -153,12 +153,23 @@ module.exports = new (Backbone.Model.extend({
       }
     )
   },
+  getDeprecatedEnumForMetacardDefinition(metacardDefinition) {
+    $.get('./internal/enumerations/deprecated/' + metacardDefinition).then(
+      (response) => {
+        _.extend(
+          this.deprecatedEnums,
+          transformEnumResponse(this.metacardTypes, response)
+        )
+      }
+    )
+  },
   addMetacardDefinition(metacardDefinitionName, metacardDefinition) {
     if (
       Object.keys(this.metacardDefinitions).indexOf(metacardDefinitionName) ===
       -1
     ) {
       this.getEnumForMetacardDefinition(metacardDefinitionName)
+      this.getDeprecatedEnumForMetacardDefinition(metacardDefinitionName)
       this.metacardDefinitions[metacardDefinitionName] = metacardDefinition
       for (const type in metacardDefinition) {
         if (metacardDefinition.hasOwnProperty(type)) {
@@ -246,4 +257,5 @@ module.exports = new (Backbone.Model.extend({
   metacardTypes: _.extendOwn({}, metacardStartingTypesWithTemporal()),
   validation: {},
   enums: properties.enums,
+  deprecatedEnums: {},
 }))()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/metacardDefinitions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/metacardDefinitions.tsx
@@ -100,6 +100,9 @@ export const TypedMetacardDefs = {
   getEnum({ attr }: { attr: string }) {
     return metacardDefinitions.enums[attr] as string[] | undefined
   },
+  getDeprecatedEnum({ attr }: { attr: string }) {
+    return metacardDefinitions.deprecatedEnums[attr] as string[] | undefined
+  },
   typesFetched() {
     return metacardDefinitions.typesFetched as boolean
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -117,13 +117,24 @@ const FilterInput = ({ filter, setFilter }: Props) => {
   }
   const textValue = value as string
   const enumForAttr = MetacardDefinitions.getEnum({ attr: filter.property })
-  if (enumForAttr) {
+  const deprecatedEnumForAttr = MetacardDefinitions.getDeprecatedEnum({
+    attr: filter.property,
+  })
+
+  if (enumForAttr || deprecatedEnumForAttr) {
+    let allEnumForAttr = [] as string[]
+    if (enumForAttr) {
+      allEnumForAttr = allEnumForAttr.concat(enumForAttr)
+    }
+    if (deprecatedEnumForAttr) {
+      allEnumForAttr = allEnumForAttr.concat(deprecatedEnumForAttr)
+    }
     return (
       <Autocomplete
         // @ts-ignore fullWidth does exist on Autocomplete
         fullWidth
         size="small"
-        options={enumForAttr}
+        options={allEnumForAttr}
         onChange={(_e: any, newValue: string) => {
           onChange(newValue)
         }}


### PR DESCRIPTION
Update the query form to allow the user to search by deprecated enumeration values.

The solution is the ui backend has an interface for deprecated values and looks for published instances via blueprint. Downstream projects can then publish services for the interface for attributes that have deprecated values. It would have been preferred to add the concept of deprecated values to the ddf validation framework, but it was determined that change ddf was too involved. 