### PR TITLE
Fixes datepickers not accounting for DST correctly, turns on tests in CI

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -70,7 +70,7 @@ export const DateHelpers = {
     DateProps: {
       generateOnChange: (onChange: (value: string) => void) => {
         return ((selectedDate, isUserChange) => {
-          if (onChange && selectedDate && isUserChange) {
+          if (selectedDate && isUserChange) {
             onChange(
               DateHelpers.Blueprint.converters.TimeshiftedDateToISO(
                 selectedDate
@@ -139,7 +139,7 @@ export const DateHelpers = {
           momentShiftedDate.add(originalDate.getMilliseconds(), 'milliseconds')
           const utcOffsetMinutesLocal = new Date().getTimezoneOffset()
           const utcOffsetMinutesTimezone = moment
-            .tz(DateHelpers.General.getTimeZone())
+            .tz(value, DateHelpers.General.getTimeZone()) // pass in the value, otherwise it won't account for daylight savings time!
             .utcOffset()
           const totalOffset = utcOffsetMinutesLocal + utcOffsetMinutesTimezone
           const momentWithOffset = momentShiftedDate.add(totalOffset, 'minutes')
@@ -178,7 +178,7 @@ export const DateHelpers = {
           momentShiftedDate.add(value.getMilliseconds(), 'milliseconds')
           const utcOffsetMinutesLocal = new Date().getTimezoneOffset()
           const utcOffsetMinutesTimezone = moment
-            .tz(DateHelpers.General.getTimeZone())
+            .tz(value, DateHelpers.General.getTimeZone()) // pass in the value, otherwise it won't account for daylight savings time!
             .utcOffset()
           const totalOffset = utcOffsetMinutesLocal + utcOffsetMinutesTimezone
           return momentShiftedDate

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -60,6 +60,12 @@ const data = {
     userFormat24: '14 Jan 2021 03:23:54.316 -03:30',
     userFormat12: '14 Jan 2021 03:23:54.316 am -03:30',
   },
+  // this is useful for testing daylist savings (date 1 is pre, this is post)
+  date5: {
+    timezone: 'America/St_Johns',
+    originalISO: '2021-04-15T05:53:54.316Z',
+    shiftedDate: new Date('2021-04-15T10:23:54.316Z'),
+  },
 }
 describe('verify date field works', () => {
   before(() => {
@@ -190,6 +196,25 @@ describe('verify date field works', () => {
     })
     expect(input.first().render().val()).to.equal(data.date2.parsedOutput)
     expect(input.last().render().val()).to.equal(data.date2.parsedOutput)
+  })
+  it(`should generate appropriately shifted ISO strings on change (DST)`, () => {
+    const wrapper = mount(
+      <DateRangeField
+        value={{
+          start: new Date().toISOString(),
+          end: new Date().toISOString(),
+        }}
+        onChange={(updatedValue) => {
+          expect(updatedValue.start).to.equal(data.date5.originalISO)
+          expect(updatedValue.end).to.equal(data.date5.originalISO)
+        }}
+      />
+    )
+    const dateFieldInstance = wrapper.children().get(0)
+    dateFieldInstance.props.onChange(
+      [data.date5.shiftedDate, data.date5.shiftedDate],
+      true
+    )
   })
   it(`should generate appropriately shifted ISO strings on change`, () => {
     const wrapper = mount(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -11,6 +11,7 @@ const Common = require('../../js/Common')
 //@ts-ignore
 import user from '../singletons/user-instance'
 import { ValueTypes } from '../filter-builder/filter.structure'
+import { DateHelpers } from './date-helpers'
 
 const UncontrolledDateRangeField = ({
   startingValue,
@@ -28,14 +29,12 @@ const UncontrolledDateRangeField = ({
   )
 }
 
-// do not rely on our own transforms for testing, rely on static data!
+// rely on static data when possible, but in these we can use the DateHelpers (a must for shifted date timezone testing)
 const data = {
   date1: {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-15T06:53:54.316Z',
     originalDate: new Date('2021-01-15T06:53:54.316Z'),
-    shiftedISO: '2021-01-15T10:23:54.316Z',
-    shiftedDate: new Date('2021-01-15T10:23:54.316Z'),
     userFormatISO: '2021-01-15T03:23:54.316-03:30',
     userFormat24: '15 Jan 2021 03:23:54.316 -03:30',
     userFormat12: '15 Jan 2021 03:23:54.316 am -03:30',
@@ -54,8 +53,6 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-14T06:53:54.316Z',
     originalDate: new Date('2021-01-14T06:53:54.316Z'),
-    shiftedISO: '2021-01-14T10:23:54.316Z',
-    shiftedDate: new Date('2021-01-14T10:23:54.316Z'),
     userFormatISO: '2021-01-14T03:23:54.316-03:30',
     userFormat24: '14 Jan 2021 03:23:54.316 -03:30',
     userFormat12: '14 Jan 2021 03:23:54.316 am -03:30',
@@ -63,8 +60,7 @@ const data = {
   // this is useful for testing daylist savings (date 1 is pre, this is post)
   date5: {
     timezone: 'America/St_Johns',
-    originalISO: '2021-04-15T05:53:54.316Z',
-    shiftedDate: new Date('2021-04-15T10:23:54.316Z'),
+    originalISO: '2021-04-15T05:53:54.316Z', // use the converter to find the appropriate shifted date
   },
 }
 describe('verify date field works', () => {
@@ -212,7 +208,14 @@ describe('verify date field works', () => {
     )
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
-      [data.date5.shiftedDate, data.date5.shiftedDate],
+      [
+        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+          data.date5.originalISO
+        ),
+        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+          data.date5.originalISO
+        ),
+      ],
       true
     )
   })
@@ -231,7 +234,14 @@ describe('verify date field works', () => {
     )
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
-      [data.date1.shiftedDate, data.date1.shiftedDate],
+      [
+        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+          data.date1.originalISO
+        ),
+        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+          data.date1.originalISO
+        ),
+      ],
       true
     )
   })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
@@ -57,6 +57,12 @@ const data = {
     maxFuture: moment().add(10, 'years').toISOString(),
     disallowedFuture: moment().add(11, 'years').toISOString(),
   },
+  // this is useful for testing daylist savings (date 1 is pre, this is post)
+  date4: {
+    timezone: 'America/St_Johns',
+    originalISO: '2021-04-15T05:53:54.316Z',
+    shiftedDate: new Date('2021-04-15T10:23:54.316Z'),
+  },
 }
 describe('verify date field works', () => {
   before(() => {
@@ -130,6 +136,18 @@ describe('verify date field works', () => {
       target: { value: data.date2.userSuppliedInput },
     })
     expect(input.render().val()).to.equal(data.date2.parsedOutput)
+  })
+  it(`should generate appropriately shifted ISO strings on change (DST)`, () => {
+    const wrapper = mount(
+      <DateField
+        value={new Date().toISOString()}
+        onChange={(updatedValue) => {
+          expect(updatedValue).to.equal(data.date4.originalISO)
+        }}
+      />
+    )
+    const dateFieldInstance = wrapper.children().get(0)
+    dateFieldInstance.props.onChange(data.date4.shiftedDate, true)
   })
   it(`should generate appropriately shifted ISO strings on change`, () => {
     const wrapper = mount(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
@@ -10,6 +10,7 @@ const Common = require('../../js/Common')
 
 //@ts-ignore
 import user from '../singletons/user-instance'
+import { DateHelpers } from './date-helpers'
 
 /**
  * Useful for seeing if updates are called correctly.
@@ -35,14 +36,12 @@ const UncontrolledDateField = ({
   )
 }
 
-// do not rely on our own transforms for testing, rely on static data!
+// rely on static data when possible, but in these we can use the DateHelpers (a must for shifted date timezone testing)
 const data = {
   date1: {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-15T06:53:54.316Z',
     originalDate: new Date('2021-01-15T06:53:54.316Z'),
-    shiftedISO: '2021-01-15T10:23:54.316Z',
-    shiftedDate: new Date('2021-01-15T10:23:54.316Z'),
     userFormatISO: '2021-01-15T03:23:54.316-03:30',
     userFormat24: '15 Jan 2021 03:23:54.316 -03:30',
     userFormat12: '15 Jan 2021 03:23:54.316 am -03:30',
@@ -61,7 +60,6 @@ const data = {
   date4: {
     timezone: 'America/St_Johns',
     originalISO: '2021-04-15T05:53:54.316Z',
-    shiftedDate: new Date('2021-04-15T10:23:54.316Z'),
   },
 }
 describe('verify date field works', () => {
@@ -147,7 +145,12 @@ describe('verify date field works', () => {
       />
     )
     const dateFieldInstance = wrapper.children().get(0)
-    dateFieldInstance.props.onChange(data.date4.shiftedDate, true)
+    dateFieldInstance.props.onChange(
+      DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+        data.date4.originalISO
+      ),
+      true
+    )
   })
   it(`should generate appropriately shifted ISO strings on change`, () => {
     const wrapper = mount(
@@ -159,7 +162,12 @@ describe('verify date field works', () => {
       />
     )
     const dateFieldInstance = wrapper.children().get(0)
-    dateFieldInstance.props.onChange(data.date1.shiftedDate, true)
+    dateFieldInstance.props.onChange(
+      DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
+        data.date1.originalISO
+      ),
+      true
+    )
   })
   it(`should not allow dates beyond max future`, () => {
     const wrapper = mount(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Base/subscribable.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Base/subscribable.spec.tsx
@@ -6,7 +6,7 @@ class ExampleClass extends Subscribable<'one' | 'two'> {
     setTimeout(() => {
       this._notifySubscribers('one')
       this._notifySubscribers('two')
-    }, 5000)
+    }, 500) // 2000ms is max before jest complains
   }
 }
 

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -75,24 +75,24 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>yarn build</id>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run build</arguments>
-                            <environmentVariables>
-                                <NODE_ENV>${buildEnv}</NODE_ENV>
-                            </environmentVariables>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>yarn test</id>
                         <goals>
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
                             <arguments>run test</arguments>
+                            <environmentVariables>
+                                <NODE_ENV>${buildEnv}</NODE_ENV>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn build</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run build</arguments>
                             <environmentVariables>
                                 <NODE_ENV>${buildEnv}</NODE_ENV>
                             </environmentVariables>

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -75,12 +75,24 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>build</id>
+                        <id>yarn build</id>
                         <goals>
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
                             <arguments>run build</arguments>
+                            <environmentVariables>
+                                <NODE_ENV>${buildEnv}</NODE_ENV>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn test</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run test</arguments>
                             <environmentVariables>
                                 <NODE_ENV>${buildEnv}</NODE_ENV>
                             </environmentVariables>


### PR DESCRIPTION
 - Turn on tests in CI
 - Adds tests / fix for daylight savings time offset
 - Fixes DST issue: We need to pass in the date to the offset calculation for moment, otherwise it won't take into account the daylight savings time shift as well for that timezone.
 - Swap build / test phases (The tgz generated from the build phase will be accidentally deleted if we don't.)


Screenshots:  
![Screen Shot 2021-03-24 at 2 53 10 PM](https://user-images.githubusercontent.com/11984853/112874502-e3114580-9077-11eb-9120-eacfe95f6d81.png)
 - Notice it's off by one hour from the selection in the datepicker.

![Screen Shot 2021-03-24 at 2 53 57 PM](https://user-images.githubusercontent.com/11984853/112874493-e1478200-9077-11eb-9376-257b5938b416.png)

Testing:
Verify that going across the dateline in either direction, the datepicker is always in sync with what is in the text box.  If you want, you can change you computer's time pref to test it more thoroughly.  