### PR TITLE
Adds handling for doubled wrapped ids in cql parser

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.spec.tsx
@@ -208,5 +208,47 @@ describe('read & write parity for capabilities, as well as boolean logic', () =>
       )
       expect(filterToCheck.value).to.equal(value)
     })
+
+    it('it handles escaping _ in properties that are "id" (double wrapped!)', () => {
+      const value = '12123123_123213123'
+      const originalFilter = new FilterBuilderClass({
+        type: 'AND',
+        filters: [
+          new FilterClass({
+            type: '=',
+            property: '"id"',
+            value,
+          }),
+        ],
+      })
+      const cqlText = cql.write(originalFilter)
+      const newFilter = cql.read(cqlText)
+      const filterToCheck = newFilter.filters[0] as FilterClass
+      expect(cql.write(originalFilter), `Doesn't escape properly`).to.equal(
+        '("id" = \'12123123_123213123\')'
+      )
+      expect(filterToCheck.value).to.equal(value)
+    })
+
+    it(`it handles escaping _ in properties that are 'id' (double wrapped!)`, () => {
+      const value = '12123123_123213123'
+      const originalFilter = new FilterBuilderClass({
+        type: 'AND',
+        filters: [
+          new FilterClass({
+            type: '=',
+            property: `'id'`,
+            value,
+          }),
+        ],
+      })
+      const cqlText = cql.write(originalFilter)
+      const newFilter = cql.read(cqlText)
+      const filterToCheck = newFilter.filters[0] as FilterClass
+      expect(cql.write(originalFilter), `Doesn't escape properly`).to.equal(
+        '("id" = \'12123123_123213123\')'
+      )
+      expect(filterToCheck.value).to.equal(value)
+    })
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.tsx
@@ -382,7 +382,7 @@ function buildTree(postfix: Array<TokenType>): any {
     case 'VALUE': //works
       const match = tok.text.match(/^'(.*)'$/)
       if (match) {
-        if (postfix[0].text === 'id') {
+        if (unwrap(postfix[0].text) === 'id') {
           // don't escape ids
           return match[1].replace(/''/g, "'")
         } else {
@@ -525,9 +525,7 @@ function buildAst(tokens: TokenType[]) {
     const tok = tokens.shift() as TokenType
     switch (tok.type) {
       case 'PROPERTY':
-        // Remove single and double quotes if they exist in property name
-        tok.text = tok.text.replace(/^'|'$/g, '')
-        tok.text = tok.text.replace(/^"|"$/g, '')
+        tok.text = unwrap(tok.text)
       case 'GEOMETRY':
       case 'VALUE':
       case 'TIME':
@@ -623,6 +621,11 @@ function wrap(property: string): string {
   return wrapped
 }
 
+function unwrap(property: string): string {
+  // Remove single and double quotes if they exist in property name
+  return property.replace(/^'|'$/g, '').replace(/^"|"$/g, '')
+}
+
 // really could use some refactoring to enable better typing, right now it's recursive and calls itself with so many different types / return types
 function write(filter: any): any {
   switch (filter.type) {
@@ -708,14 +711,16 @@ function write(filter: any): any {
       let property =
         typeof filter.property === 'object'
           ? write(filter.property)
-          : wrap(filter.property)
+          : wrap(unwrap(filter.property)) // unwrap first, because technically only "" is supported (so swap '' for "")
 
       if (filter.value === null) {
         return `${property} ${filter.type}`
       }
 
       return `${property} ${filter.type} ${
-        filter.property === 'id' ? `'${filter.value}'` : write(filter.value)
+        unwrap(filter.property) === 'id'
+          ? `'${filter.value}'`
+          : write(filter.value)
       }` // don't escape ids
     // temporalClass
     case 'RELATIVE':


### PR DESCRIPTION
 - Adds on to https://github.com/codice/ddf-ui/pull/545
 - New test cases to handle "id" and 'id' cases, which are interspersed throughout the codebase.
 - Pulls the unwrap into a function, and turns 'id' in "id" technically, since that is what the backend supports. (see the comment left behind)