### PR TITLE
[4.2.x] 2D Map view zooms in when not active tab

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -376,6 +376,7 @@ export default function (
 
       map.getView().fit(extent, {
         size: map.getSize(),
+        maxZoom: map.getView().getZoom(),
         duration: 500,
         ...opts,
       })


### PR DESCRIPTION
#### Description

When the map view isn't the active tab, and we calculate its size (e.g. when running a search), it gets a bad zoom level and zooms all the way in. This adds the same zoom level as the other places where we zoom in.

#### Testing

1. Navigate to Search and open the 2D map and Inspector view - "tabbed" together with the Inspector view as the active view
2. Run the search and switch the 2D map tab
3. Verify that the 2D map isn't zoomed all the way in (example below)

###### Before

<img src=https://user-images.githubusercontent.com/22667297/114455822-03b9bf00-9b91-11eb-8bff-01ce8ea869d1.png height=50% width=50% />

###### After

<img src=https://user-images.githubusercontent.com/22667297/114455920-1df39d00-9b91-11eb-91eb-2277644f7c62.png height=50% width=50% />