### PR TITLE
[WIP] [4.2.x] Update result refresh

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ResultUtils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ResultUtils.js
@@ -16,9 +16,9 @@ const _ = require('underscore')
 const metacardDefinitions = require('../component/singletons/metacard-definitions.js')
 
 module.exports = {
-  refreshResult(result) {
+  refreshResult(result, metacardProperties) {
     const id = result.get('metacard').id
-    result.refreshData()
+    result.refreshData(metacardProperties)
   },
   updateResults(results, response) {
     const attributeMap = response.reduce(


### PR DESCRIPTION
Adds an option to specify metacardProperties when refreshing a result metacard. This is necessary due to solr occasionally not providing the latest version of data.