### PR TITLE
[4.2.x] Added AnyText and AnyGeo special sort case for Search Attribute

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -227,6 +227,10 @@ module.exports = new (Backbone.Model.extend({
     return metacardTypes.sort((a, b) => {
       const attrToCompareA = (a.alias || a.id).toLowerCase()
       const attrToCompareB = (b.alias || b.id).toLowerCase()
+      if (a.id == 'anyText') return -1
+      if (b.id == 'anyText') return 1
+      if (a.id == 'anyGeo') return -1
+      if (b.id == 'anyGeo') return 1
       if (attrToCompareA < attrToCompareB) {
         return -1
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -18,6 +18,7 @@ const Backbone = require('backbone')
 const _ = require('underscore')
 const properties = require('../../js/properties.js')
 const moment = require('moment')
+const PRIORITY_ATTRIBUTES = ['anyText', 'anyGeo']
 function transformEnumResponse(metacardTypes, response) {
   return _.reduce(
     response,
@@ -227,10 +228,8 @@ module.exports = new (Backbone.Model.extend({
     return metacardTypes.sort((a, b) => {
       const attrToCompareA = (a.alias || a.id).toLowerCase()
       const attrToCompareB = (b.alias || b.id).toLowerCase()
-      if (a.id == 'anyText') return -1
-      if (b.id == 'anyText') return 1
-      if (a.id == 'anyGeo') return -1
-      if (b.id == 'anyGeo') return 1
+      if (PRIORITY_ATTRIBUTES.includes(a.id)) return -1
+      if (PRIORITY_ATTRIBUTES.includes(b.id)) return 1
       if (attrToCompareA < attrToCompareB) {
         return -1
       }


### PR DESCRIPTION
Description
Adds a special case in the sorting of the list of search attributes that puts anyText and anyGeo at the top no matter the alias given.

Testing
1. Build and Install UI
2. Add aliases for anyTest and AnyGeo in the Admin UI under System>Catalog UI Search Attribute Aliases
-- anyText=Search - Any Text
-- anyGeo=Search - Any Geo
3. Verify that the new alias appears at the top of the list of search attributes in the advanced search menu
