### PR TITLE
[4.2.x] Add structure for custom metacard update handling for summary view

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -17,7 +17,7 @@ import { SFC } from '../react-component/hoc/utils'
 import { providers, Props as ProviderProps } from './providers'
 import metacardInteractions from './metacard-interactions'
 import { LazyQueryResult } from '../js/model/LazyQueryResult/LazyQueryResult'
-import { ResultType } from '../js/model/Types'
+import { MetacardAttribute, ResultType } from '../js/model/Types'
 import { ValueTypes } from '../component/filter-builder/filter.structure'
 import { Suggestion } from '../react-component/location/gazetteer'
 
@@ -60,6 +60,15 @@ export type ExtensionPointsType = {
   ) => null | any
   handleFilter: (map: any, filter: any) => null | any
   suggester: (input: string) => null | Promise<Suggestion[]>
+  handleMetacardUpdate:
+    | (({
+        lazyResult,
+        attributesToUpdate,
+      }: {
+        lazyResult: LazyQueryResult
+        attributesToUpdate: MetacardAttribute[]
+      }) => Promise<void>)
+    | null
 }
 
 const ExtensionPoints: ExtensionPointsType = {
@@ -76,6 +85,7 @@ const ExtensionPoints: ExtensionPointsType = {
   serializeLocation: () => null,
   handleFilter: () => null,
   suggester: () => null,
+  handleMetacardUpdate: null,
 }
 
 export default ExtensionPoints

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Types.tsx
@@ -38,3 +38,8 @@ type ActionType = {
   title: string
   url: string
 }
+
+export type MetacardAttribute = {
+  attribute: string
+  values: any
+}


### PR DESCRIPTION
Downstream should handle this a bit differently. This adds the structure for an extension point. It also factors out the original method to make the extension swap a bit more understandable.

### Testing

1. Upload a resource
2. Navigate to search and search for that resource.
3. Select it and update an attribute (e.g. title) in the summary view (in the Inspector visualization)
4. Verify that the update works. This can be checked by making sure the attribute is updated - and refreshing to double check. And/or making sure the networkd request going out is going to the `metacards?storeId` endpoint

Note: this could be tested with downstream, but it's a bit more work.