### PR TITLE
Update result refresh

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ResultUtils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ResultUtils.js
@@ -16,9 +16,8 @@ const _ = require('underscore')
 const metacardDefinitions = require('../component/singletons/metacard-definitions.js')
 
 module.exports = {
-  refreshResult(result) {
-    const id = result.get('metacard').id
-    result.refreshData()
+  refreshResult(result, metacardProperties) {
+    result.refreshData(metacardProperties)
   },
   updateResults(results, response) {
     const attributeMap = response.reduce(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QueryResult.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/QueryResult.js
@@ -155,7 +155,25 @@ module.exports = Backbone.AssociatedModel.extend({
       (action) => action.id.indexOf('catalog.data.metacard.map.') === 0
     )
   },
-  refreshData() {
+  refreshData(metacardProperties) {
+    if (metacardProperties !== undefined) {
+      const updatedResult = this.toJSON()
+      updatedResult.metacard.properties = metacardProperties
+      this.set(updatedResult)
+
+      const clearedAttributes = Object.keys(
+        this.get('metacard').get('properties').toJSON()
+      ).reduce((acc, cur) => {
+        return cur in metacardProperties ? acc : [cur, ...acc]
+      }, [])
+      clearedAttributes.forEach((attribute) => {
+        this.get('metacard').get('properties').unset(attribute)
+      })
+
+      this.trigger('refreshdata')
+      return
+    }
+
     //let solr flush
     setTimeout(() => {
       const metacard = this.get('metacard')


### PR DESCRIPTION
Forward port of https://github.com/codice/ddf-ui/pull/574

Adds an option to specify metacardProperties when refreshing a result metacard. This is necessary due to solr occasionally not providing the latest version of data. This code is the same as #572, except we skip the network call (since it may provide outdated data) if metacard properties are passed through and instead update the current model with the provided metacard properties.

Testing: Verify that the behavior of the history, archive, and overwrite tabs of the inspector view behave the same as before (These are the views that use the refreshData function).