### PR TITLE
Add structure for custom metacard update handling for summary view

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -37,6 +37,8 @@ import DateTimePicker from '../../fields/date-time-picker'
 import Geometry from '../../../react-component/input-wrappers/geometry'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
 import useCoordinateFormat from './useCoordinateFormat'
+import { MetacardAttribute } from '../../../js/model/Types'
+import ExtensionPoints from '../../../extension-points'
 
 function getSummaryShown(): string[] {
   const userchoices = user
@@ -135,6 +137,39 @@ enum Mode {
   Normal = 'normal',
   Saving = 'saving',
   BadInput = 'bad-input',
+}
+
+const handleMetacardUpdate = ({
+  lazyResult,
+  attributes,
+  onSuccess,
+  onFailure,
+}: {
+  lazyResult: LazyQueryResult
+  attributes: MetacardAttribute[]
+  onSuccess: () => void
+  onFailure: () => void
+}) => {
+  const payload = [
+    {
+      ids: [lazyResult.plain.metacard.properties.id],
+      attributes,
+    },
+  ]
+  setTimeout(() => {
+    $.ajax({
+      url: `./internal/metacards?storeId=${lazyResult.plain.metacard.properties['source-id']}`,
+      type: 'PATCH',
+      data: JSON.stringify(payload),
+      contentType: 'application/json',
+    }).then(
+      (response: any) => {
+        ResultUtils.updateResults(lazyResult.getBackbone(), response)
+        onSuccess()
+      },
+      () => onFailure()
+    )
+  }, 1000)
 }
 
 export const Editor = ({
@@ -360,34 +395,34 @@ export const Editor = ({
             } catch (err) {
               console.error(err)
             }
-            const payload = [
-              {
-                ids: [lazyResult.plain.metacard.properties.id],
-                attributes: [
-                  {
-                    attribute: attr,
-                    values: transformedValues,
-                  },
-                ],
-              },
-            ]
-            setTimeout(() => {
-              $.ajax({
-                url: `./internal/metacards?storeId=${lazyResult.plain.metacard.properties['source-id']}`,
-                type: 'PATCH',
-                data: JSON.stringify(payload),
-                contentType: 'application/json',
+
+            const attributes = [{ attribute: attr, values: transformedValues }]
+
+            const onSuccess = () =>
+              setTimeout(() => {
+                addSnack('Successfully updated.')
+                onSave()
+              }, 1000)
+
+            const onFailure = () =>
+              setTimeout(() => {
+                addSnack('Failed to update.', { status: 'error' })
+                onSave()
+              }, 1000)
+
+            if (ExtensionPoints.handleMetacardUpdate) {
+              ExtensionPoints.handleMetacardUpdate({
+                lazyResult,
+                attributesToUpdate: attributes,
+              }).then(onSuccess, onFailure)
+            } else {
+              handleMetacardUpdate({
+                lazyResult,
+                attributes,
+                onSuccess,
+                onFailure,
               })
-                .then((response: any) => {
-                  ResultUtils.updateResults(lazyResult.getBackbone(), response)
-                })
-                .always(() => {
-                  setTimeout(() => {
-                    addSnack('Successfully updated.')
-                    onSave()
-                  }, 1000)
-                })
-            }, 1000)
+            }
           }}
         >
           Save

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -17,7 +17,7 @@ import { SFC } from '../react-component/hoc/utils'
 import { providers, Props as ProviderProps } from './providers'
 import metacardInteractions from './metacard-interactions'
 import { LazyQueryResult } from '../js/model/LazyQueryResult/LazyQueryResult'
-import { ResultType } from '../js/model/Types'
+import { MetacardAttribute, ResultType } from '../js/model/Types'
 import { ValueTypes } from '../component/filter-builder/filter.structure'
 import { Suggestion } from '../react-component/location/gazetteer'
 
@@ -60,6 +60,15 @@ export type ExtensionPointsType = {
   ) => null | any
   handleFilter: (map: any, filter: any) => null | any
   suggester: (input: string) => null | Promise<Suggestion[]>
+  handleMetacardUpdate:
+    | (({
+        lazyResult,
+        attributesToUpdate,
+      }: {
+        lazyResult: LazyQueryResult
+        attributesToUpdate: MetacardAttribute[]
+      }) => Promise<void>)
+    | null
 }
 
 const ExtensionPoints: ExtensionPointsType = {
@@ -76,6 +85,7 @@ const ExtensionPoints: ExtensionPointsType = {
   serializeLocation: () => null,
   handleFilter: () => null,
   suggester: () => null,
+  handleMetacardUpdate: null,
 }
 
 export default ExtensionPoints

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Types.tsx
@@ -42,3 +42,8 @@ type ActionType = {
   title: string
   url: string
 }
+
+export type MetacardAttribute = {
+  attribute: string
+  values: any
+}


### PR DESCRIPTION
Fwd port for #576 

This pr cleans up the failure state a bit, so we don't "successfully fail".