### PR TITLE
[4.2.x] USNG Bbox drawing doesn't update the input values in search

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -684,10 +684,7 @@ module.exports = Backbone.AssociatedModel.extend({
       west !== undefined
     ) {
       this.set('bbox', [west, south, east, north].join(','), {
-        silent:
-          (this.get('locationType') === 'usng' ||
-            this.isLocationTypeUtmUps()) &&
-          !this.get('drawing'),
+        silent: this.isLocationTypeUtmUps() && !this.get('drawing'),
       })
     }
     this.set({


### PR DESCRIPTION
Backport of https://github.com/codice/ddf-ui/pull/586
![image](https://user-images.githubusercontent.com/4467636/117035643-6813fe00-acb9-11eb-9690-d1b8faa83bac.png)

The silent option passed to the change event after drawing when the usng tab is active was introduced to address an issue where a loop occurred when switching to the USNG tab of the location component from the lat/lon tab. 
https://github.com/codice/ddf/commit/3fc35872ebef39feb77f3031c5e82692a2dc4c97
https://github.com/codice/ddf/commit/3fc35872ebef39feb77f3031c5e82692a2dc4c97#diff-089bf8013be350ca9014bc41912b4f9e3ff12404d19fffb40fee24ee324ed14fR123
I verified that this behavior is no longer present when removing this conditional.