### PR TITLE
[4.2.x] Update table export to use transformFilterTree instead of deleted getEphemeralMixinCql

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -27,6 +27,7 @@ import {
   DownloadInfo,
 } from '../../react-component/utils/export'
 import saveFile from '../../react-component/utils/save-file'
+import { DEFAULT_USER_QUERY_OPTIONS } from '../../js/model/TypedQuery'
 const announcement = require('../../component/announcement/index.jsx')
 const properties = require('../../js/properties.js')
 const contentDisposition = require('content-disposition')
@@ -190,7 +191,10 @@ export const getDownloadBody = (downloadInfo: DownloadInfo) => {
   )
 
   const query = selectionInterface.getCurrentQuery()
-  const cql = query.getEphemeralMixinCql(query.get('filterTree'))
+  const cql = DEFAULT_USER_QUERY_OPTIONS.transformFilterTree({
+    originalFilterTree: query.get('filterTree'),
+    queryRef: query,
+  })
   const srcs = getSrcs(selectionInterface)
   const sorts = getSorts(selectionInterface)
   const phonetics = query.get('phonetics')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/TypedQuery.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/TypedQuery.tsx
@@ -13,7 +13,7 @@
  *
  **/
 import React from 'react'
-import { FilterBuilderClass as QueryModel } from '../../component/filter-builder/filter.structure'
+import { FilterBuilderClass } from '../../component/filter-builder/filter.structure'
 import { useListenTo } from '../../component/selection-checkbox/useBackbone.hook'
 import { TypedUserInstance } from '../../component/singletons/TypedUser'
 import cql from '../cql'
@@ -55,7 +55,7 @@ export type QueryOptions = {
     originalFilterTree,
     queryRef,
   }: {
-    originalFilterTree: QueryModel
+    originalFilterTree: FilterBuilderClass
     queryRef: Backbone.Model<any>
   }) => string
   /**
@@ -91,11 +91,13 @@ export const Query = (
   return new UntypedQuery.Model(attributes, mergedOptions)
 }
 
-function mixinEphemeralFilter(originalCQL: QueryModel): QueryModel {
+function mixinEphemeralFilter(
+  originalCQL: FilterBuilderClass
+): FilterBuilderClass {
   const ephemeralFilter = TypedUserInstance.getEphemeralFilter()
   try {
     if (ephemeralFilter) {
-      return new QueryModel({
+      return new FilterBuilderClass({
         filters: [ephemeralFilter, originalCQL],
         type: 'AND',
       })


### PR DESCRIPTION
- Updates the table export component to no longer reference the deleted internal method of query.  Instead, it uses the transformFilterTree function in TypedQuery.


To Test:
Verify that you can export results to csv, and then verify that adding a temporary filter (above the visuals on the right) and exporting will export the correct results. 

<img width="1207" alt="Screen Shot 2021-05-11 at 9 27 55 AM" src="https://user-images.githubusercontent.com/11984853/117851795-850d7b80-b23b-11eb-9b58-d9b8f7b3b83d.png">
