### PR TITLE
Add extension point in revert so downstream projects can supply custom catalog properties

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -202,7 +202,7 @@ public class MetacardApplication implements SparkApplication {
 
   private final Security security;
 
-  private final OperationPropertySupplier operationPropertySupplier;
+  private OperationPropertySupplier operationPropertySupplier;
 
   private SubjectOperations subjectOperations;
 
@@ -225,8 +225,7 @@ public class MetacardApplication implements SparkApplication {
       SubjectIdentity subjectIdentity,
       WorkspaceService workspaceService,
       AssociatedQueryMetacardsHandler queryMetacardsHandler,
-      Security security,
-      OperationPropertySupplier operationPropertySupplier) {
+      Security security) {
     this.catalogFramework = catalogFramework;
     this.filterBuilder = filterBuilder;
     this.util = endpointUtil;
@@ -244,7 +243,14 @@ public class MetacardApplication implements SparkApplication {
     this.workspaceService = workspaceService;
     this.queryMetacardsHandler = queryMetacardsHandler;
     this.security = security;
+  }
+
+  public void addOperationPropertySupplier(OperationPropertySupplier operationPropertySupplier) {
     this.operationPropertySupplier = operationPropertySupplier;
+  }
+
+  public void removeOperationPropertySupplier(OperationPropertySupplier operationPropertySupplier) {
+    this.operationPropertySupplier = null;
   }
 
   private String getSubjectEmail() {
@@ -871,7 +877,9 @@ public class MetacardApplication implements SparkApplication {
           IngestException, ResourceNotFoundException, IOException, ResourceNotSupportedException {
     try {
       Map<String, Serializable> properties =
-          operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+          operationPropertySupplier == null
+              ? new HashMap<>()
+              : operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
 
       Metacard versionMetacard = util.getMetacardById(revertId, properties);
 
@@ -956,7 +964,9 @@ public class MetacardApplication implements SparkApplication {
       attemptDeleteDeletedMetacard(id);
       if (!alreadyCreated) {
         Map<String, Serializable> properties =
-            operationPropertySupplier.properties(OperationPropertySupplier.CREATE_TYPE);
+            operationPropertySupplier == null
+                ? new HashMap<>()
+                : operationPropertySupplier.properties(OperationPropertySupplier.CREATE_TYPE);
 
         catalogFramework.create(
             new CreateRequestImpl(Collections.singletonList(revertMetacard), properties));
@@ -1051,7 +1061,9 @@ public class MetacardApplication implements SparkApplication {
     Filter filter = filterBuilder.allOf(tags, deletion);
 
     Map<String, Serializable> properties =
-        operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+        operationPropertySupplier == null
+            ? new HashMap<>()
+            : operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
 
     QueryResponse response = null;
     try {
@@ -1165,7 +1177,9 @@ public class MetacardApplication implements SparkApplication {
 
   private List<Result> getMetacardHistory(String id, String sourceId) {
     Map<String, Serializable> properties =
-        operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+        operationPropertySupplier == null
+            ? new HashMap<>()
+            : operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
 
     Filter historyFilter =
         filterBuilder.attribute(Metacard.TAGS).is().equalTo().text(MetacardVersion.VERSION_TAG);

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -119,6 +119,7 @@ import org.codice.ddf.catalog.ui.metacard.associations.Associated;
 import org.codice.ddf.catalog.ui.metacard.edit.AttributeChange;
 import org.codice.ddf.catalog.ui.metacard.edit.MetacardChanges;
 import org.codice.ddf.catalog.ui.metacard.history.HistoryResponse;
+import org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier;
 import org.codice.ddf.catalog.ui.metacard.notes.NoteConstants;
 import org.codice.ddf.catalog.ui.metacard.notes.NoteMetacard;
 import org.codice.ddf.catalog.ui.metacard.notes.NoteUtil;
@@ -201,6 +202,8 @@ public class MetacardApplication implements SparkApplication {
 
   private final Security security;
 
+  private final OperationPropertySupplier operationPropertySupplier;
+
   private SubjectOperations subjectOperations;
 
   private SecurityLogger securityLogger;
@@ -222,7 +225,8 @@ public class MetacardApplication implements SparkApplication {
       SubjectIdentity subjectIdentity,
       WorkspaceService workspaceService,
       AssociatedQueryMetacardsHandler queryMetacardsHandler,
-      Security security) {
+      Security security,
+      OperationPropertySupplier operationPropertySupplier) {
     this.catalogFramework = catalogFramework;
     this.filterBuilder = filterBuilder;
     this.util = endpointUtil;
@@ -240,6 +244,7 @@ public class MetacardApplication implements SparkApplication {
     this.workspaceService = workspaceService;
     this.queryMetacardsHandler = queryMetacardsHandler;
     this.security = security;
+    this.operationPropertySupplier = operationPropertySupplier;
   }
 
   private String getSubjectEmail() {
@@ -403,7 +408,7 @@ public class MetacardApplication implements SparkApplication {
           String revertId = req.params(":revertid");
           String storeId = req.params(":storeId");
           Metacard versionMetacard = revert(id, revertId, storeId);
-          return util.metacardToJson(MetacardVersionImpl.toMetacard(versionMetacard, types));
+          return util.metacardToJson(MetacardVersionImpl.toMetacard(versionMetacard));
         });
 
     get(
@@ -865,7 +870,10 @@ public class MetacardApplication implements SparkApplication {
       throws UnsupportedQueryException, SourceUnavailableException, FederationException,
           IngestException, ResourceNotFoundException, IOException, ResourceNotSupportedException {
     try {
-      Metacard versionMetacard = util.getMetacardById(revertId);
+      Map<String, Serializable> properties =
+          operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+
+      Metacard versionMetacard = util.getMetacardById(revertId, properties);
 
       List<Result> queryResponse = getMetacardHistory(id, storeId);
       if (queryResponse.isEmpty()) {
@@ -940,14 +948,18 @@ public class MetacardApplication implements SparkApplication {
   private void revertMetacard(Metacard versionMetacard, String id, boolean alreadyCreated)
       throws SourceUnavailableException, IngestException {
     LOGGER.trace("Reverting metacard [{}] to version [{}]", id, versionMetacard.getId());
-    Metacard revertMetacard = MetacardVersionImpl.toMetacard(versionMetacard, types);
+    Metacard revertMetacard = MetacardVersionImpl.toMetacard(versionMetacard);
     Action action =
         Action.fromKey((String) versionMetacard.getAttribute(MetacardVersion.ACTION).getValue());
 
     if (DELETE_ACTIONS.contains(action)) {
       attemptDeleteDeletedMetacard(id);
       if (!alreadyCreated) {
-        catalogFramework.create(new CreateRequestImpl(revertMetacard));
+        Map<String, Serializable> properties =
+            operationPropertySupplier.properties(OperationPropertySupplier.CREATE_TYPE);
+
+        catalogFramework.create(
+            new CreateRequestImpl(Collections.singletonList(revertMetacard), properties));
       }
     } else {
       tryUpdate(
@@ -980,7 +992,7 @@ public class MetacardApplication implements SparkApplication {
             latestResource.getResource().getMimeTypeValue(),
             latestResource.getResource().getName(),
             latestResource.getResource().getSize(),
-            MetacardVersionImpl.toMetacard(versionMetacard, types));
+            MetacardVersionImpl.toMetacard(versionMetacard));
 
     // Try to delete the "deleted metacard" marker first.
     boolean alreadyCreated = false;
@@ -1038,9 +1050,14 @@ public class MetacardApplication implements SparkApplication {
     Filter deletion = filterBuilder.attribute(DeletedMetacard.DELETION_OF_ID).is().like().text(id);
     Filter filter = filterBuilder.allOf(tags, deletion);
 
+    Map<String, Serializable> properties =
+        operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+
     QueryResponse response = null;
     try {
-      response = catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter), false));
+      response =
+          catalogFramework.query(
+              new QueryRequestImpl(new QueryImpl(filter), false, null, properties));
     } catch (UnsupportedQueryException | SourceUnavailableException | FederationException e) {
       LOGGER.debug("Could not find the deleted metacard marker to delete", e);
     }
@@ -1147,6 +1164,9 @@ public class MetacardApplication implements SparkApplication {
   }
 
   private List<Result> getMetacardHistory(String id, String sourceId) {
+    Map<String, Serializable> properties =
+        operationPropertySupplier.properties(OperationPropertySupplier.QUERY_TYPE);
+
     Filter historyFilter =
         filterBuilder.attribute(Metacard.TAGS).is().equalTo().text(MetacardVersion.VERSION_TAG);
     Filter idFilter =
@@ -1165,7 +1185,9 @@ public class MetacardApplication implements SparkApplication {
                     SortBy.NATURAL_ORDER,
                     false,
                     TimeUnit.SECONDS.toMillis(10)),
-                sources));
+                false,
+                sources,
+                properties));
     return Lists.newArrayList(resultIterable);
   }
 

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/internal/OperationPropertySupplier.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/internal/OperationPropertySupplier.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard.internal;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/** Supply addititonal properties for catalog operations. This allows properties to be injected. */
+public interface OperationPropertySupplier {
+
+  String QUERY_TYPE = "query";
+
+  String CREATE_TYPE = "create";
+
+  /**
+   * Return properties for specific operation type (eg {@link #QUERY_TYPE} or {@link #CREATE_TYPE})
+   * to be added to the catalog operations.
+   */
+  Map<String, Serializable> properties(String type);
+}

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -179,10 +179,20 @@ public class EndpointUtil implements EndpointUtility {
 
   public Metacard getMetacardById(String id)
       throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-    return getMetacardById(id, null);
+    return getMetacardById(id, null, null);
+  }
+
+  public Metacard getMetacardById(String id, Map<String, Serializable> properties)
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    return getMetacardById(id, null, properties);
   }
 
   public Metacard getMetacardById(String id, String storeId)
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    return getMetacardById(id, storeId, null);
+  }
+
+  public Metacard getMetacardById(String id, String storeId, Map<String, Serializable> properties)
       throws UnsupportedQueryException, SourceUnavailableException, FederationException {
     Collection<String> storeIds;
     if (storeId == null) {
@@ -195,7 +205,8 @@ public class EndpointUtil implements EndpointUtility {
     Filter filter = filterBuilder.allOf(idFilter, tagsFilter);
 
     QueryResponse queryResponse =
-        catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter), storeIds));
+        catalogFramework.query(
+            new QueryRequestImpl(new QueryImpl(filter), false, storeIds, properties));
 
     if (queryResponse.getResults().isEmpty()) {
       throw new NotFoundException("Could not find metacard for id: " + id);
@@ -523,7 +534,7 @@ public class EndpointUtil implements EndpointUtility {
 
   public String metacardToJson(String id, String storeId)
       throws SourceUnavailableException, UnsupportedQueryException, FederationException {
-    return metacardToJson(getMetacardById(id, storeId));
+    return metacardToJson(getMetacardById(id, storeId, null));
   }
 
   public String metacardToJson(Metacard metacard) {

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -253,6 +253,11 @@ Implementation details
         <argument ref="catalogFramework"/>
     </bean>
 
+    <!-- Note: if we ever need to supply multiple instances of OperationPropertySupplier, then use the decorator
+     pattern by creating an instance of OperationPropertySupplier that is constructed from a list of suppliers,
+     which merges the results together. -->
+    <reference id="revertProperties" interface="org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier" filter="(type=revert)"/>
+
     <bean id="metacardApplication" class="org.codice.ddf.catalog.ui.metacard.MetacardApplication">
         <argument ref="catalogFramework"/>
         <argument ref="filterBuilder"/>
@@ -271,6 +276,7 @@ Implementation details
         <argument ref="queryWorkspaceService"/>
         <argument ref="queryMetacardsHandler"/>
         <argument ref="ddfSecurity" />
+        <argument ref="revertProperties"/>
         <property name="subjectOperations" ref="subjectOperations1" />
         <property name="securityLogger" ref="securityLogger" />
     </bean>

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -256,7 +256,15 @@ Implementation details
     <!-- Note: if we ever need to supply multiple instances of OperationPropertySupplier, then use the decorator
      pattern by creating an instance of OperationPropertySupplier that is constructed from a list of suppliers,
      which merges the results together. -->
-    <reference id="revertProperties" interface="org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier" filter="(type=revert)"/>
+    <reference id="revertProperties"
+               interface="org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier"
+               availability="optional"
+               filter="(type=revert)">
+        <reference-listener
+                ref="metacardApplication"
+                bind-method="addOperationPropertySupplier"
+                unbind-method="removeOperationPropertySupplier"/>
+    </reference>
 
     <bean id="metacardApplication" class="org.codice.ddf.catalog.ui.metacard.MetacardApplication">
         <argument ref="catalogFramework"/>
@@ -276,7 +284,6 @@ Implementation details
         <argument ref="queryWorkspaceService"/>
         <argument ref="queryMetacardsHandler"/>
         <argument ref="ddfSecurity" />
-        <argument ref="revertProperties"/>
         <property name="subjectOperations" ref="subjectOperations1" />
         <property name="securityLogger" ref="securityLogger" />
     </bean>

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
@@ -40,8 +40,10 @@ import java.util.function.Consumer;
 import javax.ws.rs.NotFoundException;
 import org.codice.ddf.catalog.ui.metacard.edit.AttributeChange;
 import org.codice.ddf.catalog.ui.metacard.edit.MetacardChanges;
+import org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.codice.ddf.security.Security;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -61,8 +63,16 @@ public class MetacardApplicationTest {
 
   private final EndpointUtil mockUtil = mock(EndpointUtil.class);
 
+  private final OperationPropertySupplier operationPropertySupplier =
+      mock(OperationPropertySupplier.class);
+
   private final MetacardApplicationUnderTest app =
-      new MetacardApplicationUnderTest(mockFramework, mockUtil);
+      new MetacardApplicationUnderTest(mockFramework, mockUtil, operationPropertySupplier);
+
+  @Before
+  public void setup() {
+    when(operationPropertySupplier.properties(any())).thenReturn(Collections.emptyMap());
+  }
 
   @Test(expected = NotFoundException.class)
   public void testPatchMetacardsWhenIdNotFound() throws Exception {
@@ -168,7 +178,9 @@ public class MetacardApplicationTest {
    */
   private static class MetacardApplicationUnderTest extends MetacardApplication {
     private MetacardApplicationUnderTest(
-        CatalogFramework catalogFramework, EndpointUtil endpointUtil) {
+        CatalogFramework catalogFramework,
+        EndpointUtil endpointUtil,
+        OperationPropertySupplier operationPropertySupplier) {
       super(
           catalogFramework,
           null,
@@ -186,7 +198,8 @@ public class MetacardApplicationTest {
           null,
           null,
           null,
-          mock(Security.class));
+          mock(Security.class),
+          operationPropertySupplier);
     }
 
     private void doPatchMetacards(List<MetacardChanges> metacardChanges) throws Exception {

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
@@ -40,10 +40,8 @@ import java.util.function.Consumer;
 import javax.ws.rs.NotFoundException;
 import org.codice.ddf.catalog.ui.metacard.edit.AttributeChange;
 import org.codice.ddf.catalog.ui.metacard.edit.MetacardChanges;
-import org.codice.ddf.catalog.ui.metacard.internal.OperationPropertySupplier;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.codice.ddf.security.Security;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -63,16 +61,8 @@ public class MetacardApplicationTest {
 
   private final EndpointUtil mockUtil = mock(EndpointUtil.class);
 
-  private final OperationPropertySupplier operationPropertySupplier =
-      mock(OperationPropertySupplier.class);
-
   private final MetacardApplicationUnderTest app =
-      new MetacardApplicationUnderTest(mockFramework, mockUtil, operationPropertySupplier);
-
-  @Before
-  public void setup() {
-    when(operationPropertySupplier.properties(any())).thenReturn(Collections.emptyMap());
-  }
+      new MetacardApplicationUnderTest(mockFramework, mockUtil);
 
   @Test(expected = NotFoundException.class)
   public void testPatchMetacardsWhenIdNotFound() throws Exception {
@@ -178,9 +168,7 @@ public class MetacardApplicationTest {
    */
   private static class MetacardApplicationUnderTest extends MetacardApplication {
     private MetacardApplicationUnderTest(
-        CatalogFramework catalogFramework,
-        EndpointUtil endpointUtil,
-        OperationPropertySupplier operationPropertySupplier) {
+        CatalogFramework catalogFramework, EndpointUtil endpointUtil) {
       super(
           catalogFramework,
           null,
@@ -198,8 +186,7 @@ public class MetacardApplicationTest {
           null,
           null,
           null,
-          mock(Security.class),
-          operationPropertySupplier);
+          mock(Security.class));
     }
 
     private void doPatchMetacards(List<MetacardChanges> metacardChanges) throws Exception {


### PR DESCRIPTION
A downstream project needs to set some extra properties for catalog query and catalog create operations during reverts. This PR adds an extension point to supply those properties. The solution is implemented so that it should be easy to expand its use to other parts of ddf-ui.

Testing Instructions: Make sure reverts are working as expected.

Note: this pr replaces https://github.com/codice/ddf-ui/pull/593
