### PR TITLE
increase websocket max text message size

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
@@ -45,6 +45,8 @@ public class JsonRpc implements WebSocket {
   private static final String METHOD = "method";
   private static final String ID = "id";
 
+  private static final int WS_MAX_TEXT_MSG_SIZE = 1_000_000;
+
   private static final Gson GSON =
       new GsonBuilder()
           .disableHtmlEscaping()
@@ -95,7 +97,7 @@ public class JsonRpc implements WebSocket {
 
   @Override
   public void onOpen(Session session) {
-    // no action required on open
+    session.getPolicy().setMaxTextMessageSize(WS_MAX_TEXT_MSG_SIZE);
   }
 
   @Override


### PR DESCRIPTION
A downstream project was experiencing trouble with searches using very large geometries. It was found that increasing the max text message size for web sockets fixed the problem. I decided to not make this configurable, but I could if the team believes it would be useful. I'm trying to not add yet-another-config.

Test by making sure searches using large geometries are working as expected.

