### PR TITLE
Update location-old to handle point radius init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <name>DDF :: UI</name>
   <artifactId>catalog-ui</artifactId>
   <groupId>org.codice.ddf.search</groupId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.0.2</version>
 
   <organization>
     <name>Codice Foundation</name>
@@ -122,7 +122,7 @@
     <url>https://github.com/codice/ddf-ui</url>
     <connection>scm:git:https://github.com/codice/ddf-ui.git</connection>
     <developerConnection>scm:git:https://github.com/codice/ddf-ui.git</developerConnection>
-    <tag>catalog-ui-3.4.0</tag>
+    <tag>ddf-ui-5.0.2</tag>
   </scm>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <name>DDF :: UI</name>
   <artifactId>catalog-ui</artifactId>
   <groupId>org.codice.ddf.search</groupId>
-  <version>5.0.2</version>
+  <version>5.0.3-SNAPSHOT</version>
 
   <organization>
     <name>Codice Foundation</name>
@@ -122,7 +122,7 @@
     <url>https://github.com/codice/ddf-ui</url>
     <connection>scm:git:https://github.com/codice/ddf-ui.git</connection>
     <developerConnection>scm:git:https://github.com/codice/ddf-ui.git</developerConnection>
-    <tag>ddf-ui-5.0.2</tag>
+    <tag>catalog-ui-3.4.0</tag>
   </scm>
 
   <dependencyManagement>

--- a/ui-backend/audit/audit-api/pom.xml
+++ b/ui-backend/audit/audit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-api/pom.xml
+++ b/ui-backend/audit/audit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-application/pom.xml
+++ b/ui-backend/audit/audit-application/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-application/pom.xml
+++ b/ui-backend/audit/audit-application/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-logging/pom.xml
+++ b/ui-backend/audit/audit-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/audit-logging/pom.xml
+++ b/ui-backend/audit/audit-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>audit</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/ui-backend/audit/pom.xml
+++ b/ui-backend/audit/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <packaging>pom</packaging>
     <artifactId>audit</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.0.2</version>
     <name>DDF :: Catalog :: UI :: Audit</name>
 
     <modules>

--- a/ui-backend/audit/pom.xml
+++ b/ui-backend/audit/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>
     <artifactId>audit</artifactId>
-    <version>5.0.2</version>
+    <version>5.0.3-SNAPSHOT</version>
     <name>DDF :: Catalog :: UI :: Audit</name>
 
     <modules>

--- a/ui-backend/catalog-plugin-highlight/pom.xml
+++ b/ui-backend/catalog-plugin-highlight/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ui-backend/catalog-plugin-highlight/pom.xml
+++ b/ui-backend/catalog-plugin-highlight/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ui-backend/catalog-ui-enumeration/pom.xml
+++ b/ui-backend/catalog-ui-enumeration/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <packaging>bundle</packaging>
 

--- a/ui-backend/catalog-ui-enumeration/pom.xml
+++ b/ui-backend/catalog-ui-enumeration/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
 

--- a/ui-backend/catalog-ui-oauth/pom.xml
+++ b/ui-backend/catalog-ui-oauth/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ui-backend/catalog-ui-oauth/pom.xml
+++ b/ui-backend/catalog-ui-oauth/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ui-backend/catalog-ui-search-api/pom.xml
+++ b/ui-backend/catalog-ui-search-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <artifactId>catalog-ui-search-api</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search API</name>

--- a/ui-backend/catalog-ui-search-api/pom.xml
+++ b/ui-backend/catalog-ui-search-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-search-api</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search API</name>

--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <artifactId>catalog-ui-search</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search</name>

--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-search</artifactId>
     <name>DDF :: Catalog :: UI :: Catalog UI Search</name>

--- a/ui-backend/catalog-ui-splitter/pom.xml
+++ b/ui-backend/catalog-ui-splitter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <artifactId>catalog-ui-splitter</artifactId>
     <name>DDF :: Catalog :: UI :: Splitter</name>

--- a/ui-backend/catalog-ui-splitter/pom.xml
+++ b/ui-backend/catalog-ui-splitter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-ui-splitter</artifactId>
     <name>DDF :: Catalog :: UI :: Splitter</name>

--- a/ui-backend/deprecatable-enumeration-api/pom.xml
+++ b/ui-backend/deprecatable-enumeration-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <artifactId>deprecatable-enumeration-api</artifactId>
     <name>DDF :: Catalog :: UI :: Deprecatable Enumeration API</name>

--- a/ui-backend/deprecatable-enumeration-api/pom.xml
+++ b/ui-backend/deprecatable-enumeration-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>deprecatable-enumeration-api</artifactId>
     <name>DDF :: Catalog :: UI :: Deprecatable Enumeration API</name>

--- a/ui-backend/intrigue-ui-app/pom.xml
+++ b/ui-backend/intrigue-ui-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: UI :: Search UI :: App</name>

--- a/ui-backend/intrigue-ui-app/pom.xml
+++ b/ui-backend/intrigue-ui-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: UI :: Search UI :: App</name>

--- a/ui-backend/javalin-utils/pom.xml
+++ b/ui-backend/javalin-utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>javalin-utils</artifactId>

--- a/ui-backend/javalin-utils/pom.xml
+++ b/ui-backend/javalin-utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>backend</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <artifactId>javalin-utils</artifactId>

--- a/ui-backend/pom.xml
+++ b/ui-backend/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>catalog-ui</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>
     <artifactId>backend</artifactId>
-    <version>5.0.2</version>
+    <version>5.0.3-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/ui-backend/pom.xml
+++ b/ui-backend/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.codice.ddf.search</groupId>
         <artifactId>catalog-ui</artifactId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>
     <artifactId>backend</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.0.2</version>
 
     <packaging>pom</packaging>
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -112,8 +112,7 @@ module.exports = Backbone.AssociatedModel.extend({
     }
     Backbone.AssociatedModel.prototype.set.call(this, key, value, options)
   },
-
-  initialize() {
+  initialize(props) {
     this.listenTo(
       this,
       'change:line change:polygon',
@@ -186,6 +185,15 @@ module.exports = Backbone.AssociatedModel.extend({
     })
     this.listenTo(this, 'EndExtent', this.drawingOff)
     this.listenTo(this, 'BeginExtent', this.drawingOn)
+    this.initializeValues(props)
+  },
+  initializeValues(props) {
+    if (props.type === 'POINTRADIUS' && props.lat && props.lon) {
+      if (!props.usng || !props.utmUpsEasting) {
+        // initializes dms/usng/utmUps using lat/lon
+        this.setRadiusLatLon()
+      }
+    }
   },
   drawingOff() {
     if (this.get('locationType') === 'dms') {
@@ -566,12 +574,7 @@ module.exports = Backbone.AssociatedModel.extend({
     const lat = this.get('lat'),
       lon = this.get('lon')
 
-    if (
-      (!Drawing.isDrawing() && this.get('locationType') !== 'latlon') ||
-      !this.isLatLonValid(lat, lon)
-    ) {
-      return
-    }
+    if (!this.isLatLonValid(lat, lon)) return
 
     this.setRadiusDmsFromMap()
 

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-ui</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2</version>
+        <version>5.0.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-ui</artifactId>
         <groupId>org.codice.ddf.search</groupId>
-        <version>5.0.2-SNAPSHOT</version>
+        <version>5.0.2</version>
     </parent>
 
     <groupId>org.codice.ddf.search</groupId>


### PR DESCRIPTION
As far as I can tell, initializing a location-old model doesn't propagate the initial values to the other coordinate types. So, if we pass lat and lon to it, utmpUps and usng won't be updated.

This enables propagation to other coordinate types when location-old is passed a point radius, which appears to be our only usecase for initializing location-old models with values.