### PR TITLE
Update location-old to handle point radius init

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -112,8 +112,7 @@ module.exports = Backbone.AssociatedModel.extend({
     }
     Backbone.AssociatedModel.prototype.set.call(this, key, value, options)
   },
-
-  initialize() {
+  initialize(props) {
     this.listenTo(
       this,
       'change:line change:polygon',
@@ -186,6 +185,15 @@ module.exports = Backbone.AssociatedModel.extend({
     })
     this.listenTo(this, 'EndExtent', this.drawingOff)
     this.listenTo(this, 'BeginExtent', this.drawingOn)
+    this.initializeValues(props)
+  },
+  initializeValues(props) {
+    if (props.type === 'POINTRADIUS' && props.lat && props.lon) {
+      if (!props.usng || !props.utmUpsEasting) {
+        // initializes dms/usng/utmUps using lat/lon
+        this.setRadiusLatLon()
+      }
+    }
   },
   drawingOff() {
     if (this.get('locationType') === 'dms') {
@@ -566,12 +574,7 @@ module.exports = Backbone.AssociatedModel.extend({
     const lat = this.get('lat'),
       lon = this.get('lon')
 
-    if (
-      (!Drawing.isDrawing() && this.get('locationType') !== 'latlon') ||
-      !this.isLatLonValid(lat, lon)
-    ) {
-      return
-    }
+    if (!this.isLatLonValid(lat, lon)) return
 
     this.setRadiusDmsFromMap()
 


### PR DESCRIPTION
As far as I can tell, initializing a location-old model doesn't propagate the initial values to the other coordinate types. So, if we pass lat and lon to it, utmpUps and usng won't be updated.

This enables propagation to other coordinate types when location-old is passed a point radius, which appears to be our only usecase for initializing location-old models with values.

For testing, it may just be easiest to copy this file into node_modules with the dev server running. 

1. Ingest metacards with geo data. [articles.zip](https://github.com/codice/ddf-ui/files/6656178/articles.zip)
2. Search for the metacards and select "Create Search From Location". This will populate the Point Radius geo in the search.
3. Verify that each coordinate system is populated.
![image](https://user-images.githubusercontent.com/22667297/122066920-ff379f80-cda7-11eb-8155-3cbde2b8695e.png)