### PR TITLE
Updates search type switching to immediately downgrade filterTree if necessary

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
@@ -179,7 +179,15 @@ type PropertyValueMapType = {
   [key: string]: any
 }
 
-function translateFilterToBasicMap(filter: any) {
+export function downgradeFilterTreeToBasic(
+  filter: FilterBuilderClass
+): FilterBuilderClass {
+  return constructFilterFromBasicFilter({
+    basicFilter: translateFilterToBasicMap(filter).propertyValueMap,
+  })
+}
+
+function translateFilterToBasicMap(filter: FilterBuilderClass) {
   const propertyValueMap = {
     anyDate: [],
     anyText: [],
@@ -260,7 +268,7 @@ function translateFilterToBasicMap(filter: any) {
   }
 }
 
-function getFilterTree(model: any) {
+function getFilterTree(model: any): FilterBuilderClass {
   if (typeof model.get('filterTree') === 'object') {
     return model.get('filterTree')
   }
@@ -348,6 +356,11 @@ const constructFilterFromBasicFilter = ({
   })
 }
 
+/**
+ * We want to reset the basic filter whenever the filter tree changes on the model.
+ *
+ * We also want to update the filter tree once whenver the component is first
+ */
 const useBasicFilterFromModel = ({ model }: QueryBasicProps) => {
   const [basicFilter, setBasicFilter] = React.useState(
     translateFilterToBasicMap(getFilterTree(model)).propertyValueMap
@@ -365,12 +378,12 @@ const useBasicFilterFromModel = ({ model }: QueryBasicProps) => {
       stopListening(model, 'change:filterTree', callback)
     }
   }, [model])
-  return [basicFilter, setBasicFilter]
+  return basicFilter
 }
 
 const QueryBasic = ({ model }: QueryBasicProps) => {
   const inputRef = React.useRef<HTMLDivElement>()
-  const [basicFilter] = useBasicFilterFromModel({ model })
+  const basicFilter = useBasicFilterFromModel({ model })
   const [typeAttributes] = React.useState(
     getAllValidValuesForMatchTypeAttribute()
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -34,6 +34,7 @@ import {
   FilterBuilderClass,
   FilterClass,
 } from '../../component/filter-builder/filter.structure'
+import { downgradeFilterTreeToBasic } from '../../component/query-basic/query-basic.view'
 const wreqr = require('../wreqr')
 const Query = {}
 
@@ -209,8 +210,14 @@ Query.Model = Backbone.AssociatedModel.extend({
         this.set('isOutdated', true)
       }
     )
+    // basically remove invalid filters when going from basic to advanced, and make it basic compatible
     this.listenTo(this, 'change:type', () => {
-      this.set('filterTree', cql.removeInvalidFilters(this.get('filterTree'))) // basically remove invalid filters when going from basic to advanced
+      if (this.get('type') === 'basic') {
+        const cleanedUpFilterTree = cql.removeInvalidFilters(
+          this.get('filterTree')
+        )
+        this.set('filterTree', downgradeFilterTreeToBasic(cleanedUpFilterTree))
+      }
     })
   },
   getSelectedSources() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
@@ -131,9 +131,11 @@ const LocationInput = ({ onChange, value }: any) => {
   const { listenTo, stopListening } = useBackbone()
   React.useEffect(() => {
     return () => {
-      // This is to facilitate clearing out the map, it isn't about the value
-      locationModel.set(locationModel.defaults())
-      wreqr.vent.trigger('search:drawend', locationModel)
+      setTimeout(() => {
+        // This is to facilitate clearing out the map, it isn't about the value, but we don't want the changeCallback to fire!
+        locationModel.set(locationModel.defaults())
+        wreqr.vent.trigger('search:drawend', locationModel)
+      }, 0)
     }
   }, [])
   React.useEffect(() => {


### PR DESCRIPTION
 - Updates the query model to immediately downgrade filterTrees when switching to basic.  This prevents an issue where if the user happened to not touch the form in anyway after switching, but instead clicked search, it would appear that other terms (visible on advanced) were still around.  Now the type switch downgrades immediately instead of waiting for the user to interact with the component and change something.
 - Also updates the location component to prevent a race condition where the onChangeCallback would be fired when it shouldn't (on destruction).  This would cause us to sometimes lose location information.  Now, it gets pushed onto the stack so that the listener has time to stopListening before we reset things.