### PR TITLE
Fix firefox specific issue with resize observer

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/menu-state/menu-state.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/menu-state/menu-state.tsx
@@ -24,6 +24,14 @@ export function useRerenderingRef<T>() {
   }
 }
 
+/**
+ * Firefox and Chrome differ slightly in implementation.  If only one entry, firefox returns that instead of an array!
+ */
+const getBorderBoxSizeFromEntry = (entry: ResizeObserverEntry) => {
+  const borderBoxSizeArray: ResizeObserverSize[] = []
+  return borderBoxSizeArray.concat(entry.borderBoxSize)
+}
+
 const useListenForChildUpdates = ({
   popoverRef,
   action,
@@ -39,7 +47,7 @@ const useListenForChildUpdates = ({
      */
     const widthCallback = (entries: ResizeObserverEntry[]) => {
       for (let entry of entries) {
-        for (let subentry of entry.borderBoxSize) {
+        for (let subentry of getBorderBoxSizeFromEntry(entry)) {
           if (subentry.inlineSize !== lastWidth) {
             lastWidth = subentry.inlineSize
             action.current?.updatePosition()
@@ -52,7 +60,7 @@ const useListenForChildUpdates = ({
      */
     const heightCallback = debounce((entries: ResizeObserverEntry[]) => {
       for (let entry of entries) {
-        for (let subentry of entry.borderBoxSize) {
+        for (let subentry of getBorderBoxSizeFromEntry(entry)) {
           if (subentry.blockSize !== lastHeight) {
             lastHeight = subentry.blockSize
             action.current?.updatePosition()


### PR DESCRIPTION
 - The spec states that the return value should be an array, but firefox will optimize and return the value itself if it's singular.  This update ensures the return is always an array.
 - This could only be seen when trying to access layers on the map in Firefox.  The dropdown could sometimes appear slightly offscreen unless the user triggered a resize themselves.
<img width="921" alt="Screen Shot 2021-06-18 at 1 00 12 PM" src="https://user-images.githubusercontent.com/11984853/122610839-235be080-d035-11eb-8d59-913247c52685.png">
