### PR TITLE
Add polygon and linestring to location-old initialization

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -194,6 +194,8 @@ module.exports = Backbone.AssociatedModel.extend({
         // initializes dms/usng/utmUps using lat/lon
         this.updateCoordPointRadiusValues(props.lat, props.lon)
       }
+    } else {
+      this.setUsngDmsUtmWithLineOrPoly(this)
     }
   },
   updateCoordPointRadiusValues(lat, lon) {


### PR DESCRIPTION
Enables initialization for polygons and linestrings in location-old. This populates the other coordinate systems (dms, usng, utm) when a location is initialized.

Testing instructions:
- NOTE: this should be tested downstream

1. Create or ingest a resource with a linestring location and one with a polygon location.
2. Select "Create from location" on each resource and ensure that all coordinate systems are populated.