### PR TITLE
G-9437 Include the cacheId for table exports

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -93,6 +93,7 @@ function getSearches(
   count: any,
   selectionInterface: any
 ): any {
+  const cacheId = selectionInterface.getCurrentQuery().get('cacheId')
   if (exportSize !== 'currentPage') {
     return srcs.length > 0
       ? [
@@ -100,6 +101,7 @@ function getSearches(
             srcs,
             cql,
             count,
+            cacheId,
           },
         ]
       : []
@@ -112,6 +114,7 @@ function getSearches(
       cql,
       start,
       count: srcCount,
+      cacheId,
     }
   })
 }


### PR DESCRIPTION
Downstream projects need the cacheId, since they may have sources that cache results by the ID.

Forward port of https://github.com/codice/ddf/pull/6593