### PR TITLE
Adds case to geo filter generation

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -139,6 +139,7 @@ function generateAnyGeoFilter(property, model) {
           sanitizeForCql(JSON.stringify(bboxToCQLPolygon(model))) +
           ')',
       }
+    case 'POINT':
     case 'POINTRADIUS':
       return {
         type: 'DWITHIN',


### PR DESCRIPTION
Treats POINT the same as POINT RADIUS when creating a geo filter.

We don't appear to have point drawing in ddf-ui. This would need to be tested downstream.

We often treat points as point radii with a very small buffer, so they are effectively point radii.