### PR TITLE
Fix saved search CQL filter value

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -263,6 +263,17 @@ export const useRenderOnAsyncTaskUpdate = ({
   return
 }
 
+const getCqlForFilterTree = (filterTree: any): string => {
+  if (typeof filterTree === 'string') {
+    try {
+      filterTree = JSON.parse(filterTree)
+    } catch (err) {
+      // Continue using string literal if string is not valid JSON.
+    }
+  }
+  return CQL.write(filterTree)
+}
+
 class RestoreTask extends AsyncTask {
   lazyResult: LazyQueryResult
   constructor({ lazyResult }: { lazyResult: LazyQueryResult }) {
@@ -360,7 +371,7 @@ class CreateSearchTask extends AsyncTask {
             attributes: {
               'metacard-tags': ['query'],
               ...this.data,
-              cql: CQL.write(this.data.filterTree),
+              cql: getCqlForFilterTree(this.data.filterTree),
             },
             metacardType: 'metacard.query',
           },
@@ -417,7 +428,7 @@ class SaveSearchTask extends AsyncTask {
               attributes: {
                 'metacard-tags': ['query'],
                 ...this.data,
-                cql: CQL.write(this.data.filterTree),
+                cql: getCqlForFilterTree(this.data.filterTree),
               },
               metacardType: 'metacard.query',
             },


### PR DESCRIPTION
When saving a search or updating a saved search in Intrigue, the CQL value was not being written correctly due to the filter tree being a string value and not an object. Added logic to attempt to parse the filter tree JSON if it is a string before calling cql.write() on the filter tree. 

Testing:
Save a search and update a saved search. Check the CQL filter value that gets stored for both of these actions and verify the value looks like valid CQL and not like a filter tree.