### PR TITLE
Removed function that was causing unexpected browser close

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
@@ -67,9 +67,7 @@ const SelectedResults = ({ selectionInterface }: any) => {
         <Paper>
           <LazyMetacardInteractions
             lazyResults={selectedResultsArray}
-            onClose={() => {
-              close()
-            }}
+            onClose={() => {}}
           />
         </Paper>
       </Popover>


### PR DESCRIPTION
###
What does this PR do, and why?
- Bugfix change for when opening DDF in a new tab, performing a metacard interaction on returned search result would close the current window.
- Removed unnecessary code that was introducing the bug
###
How should this be tested?
1. Create a simple HTML page to open DDF in a new tab
```
<html>
<body>
<a href="https://isr-cn2a-sys-01.aur.nciteglobal.com.au:8993/" target="_blank">Launch DDF</a>
</body>
</html>
```
 2.  Open the page with Chrome or Firefox, and click on the link.  This will open DDF.
 3.  Navigate to the search tab, and conduct a search that returns at least 1 result.
 4.  Select the result
 5.  Using the kebab menu at the top of the window (next to the heart), perform an action.
 6. The tab no longer closes.