### PR TITLE
Refactor search to allow more complex paging scenarios and start conversion to typescript of the model, adds generic async tasks, adds support for count (page size) to query

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -13,7 +13,7 @@
     "test": "yarn publish:build && ace bundle --env=test && ace test",
     "start:test": "ace start --env=test",
     "storybook": "ace storybook",
-    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
+    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle",
     "build:transpile": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
     "postbuild": "yarn publish:build && npm pack ./dist && move-cli catalog-ui-search-5.0.0.tgz dist/catalog-ui-search.tgz && ace package",
     "m2": "yarn install:m2",

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -13,7 +13,7 @@
     "test": "yarn publish:build && ace bundle --env=test && ace test",
     "start:test": "ace start --env=test",
     "storybook": "ace storybook",
-    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle",
+    "build": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
     "build:transpile": "node --max_old_space_size=16384 ./node_modules/@connexta/ace/bin.js bundle --tsTranspileOnly true",
     "postbuild": "yarn publish:build && npm pack ./dist && move-cli catalog-ui-search-5.0.0.tgz dist/catalog-ui-search.tgz && ace package",
     "m2": "yarn install:m2",
@@ -62,6 +62,7 @@
     "@types/enzyme": "3.10.8",
     "@types/enzyme-adapter-react-16": "1.0.2",
     "@types/lodash.debounce": "4.0.6",
+    "@types/lodash.isequalwith": "4.4.7",
     "@types/mocha": "8.0.3",
     "@types/moment-timezone": "0.5.30",
     "@types/react": "16.8.23",
@@ -96,7 +97,7 @@
     "ts-migrate": "^0.1.19",
     "ts-migrate-plugins": "^0.1.19",
     "ts-migrate-server": "^0.1.18",
-    "tslib": "2.2.0",
+    "tslib": "2.4.0",
     "utility-types": "3.10.0"
   },
   "dependencies": {
@@ -141,6 +142,7 @@
     "lodash": "4.17.15",
     "lodash.get": "4.4.2",
     "lodash.debounce": "4.0.8",
+    "lodash.isequalwith": "4.4.0",
     "mt-geo": "1.0.1",
     "openlayers": "4.6.5",
     "plotly.js": "1.16.0",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
@@ -276,6 +276,20 @@ const AsyncTasksComponent = () => {
                 </div>
               )
             }
+            if (AsyncTasks.isCreateTask(asyncTask)) {
+              return (
+                <div className="bg-black p-2">
+                  Creating '{asyncTask.data.title}'
+                </div>
+              )
+            }
+            if (AsyncTasks.isSaveTask(asyncTask)) {
+              return (
+                <div className="bg-black p-2">
+                  Saving '{asyncTask.data.title}'
+                </div>
+              )
+            }
             return null
           })}
         </div>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-bar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-bar.tsx
@@ -19,7 +19,8 @@ import {
   getRandomId,
   Option,
 } from './boolean-search-utils'
-import { IconButton, InputProps } from '@material-ui/core'
+import IconButton from '@material-ui/core/IconButton'
+import { InputProps } from '@material-ui/core/Input'
 import ClearIcon from '@material-ui/icons/Clear'
 import SearchIcon from '@material-ui/icons/Search'
 const properties = require('../../js/properties.js')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/phonetics.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/phonetics.tsx
@@ -3,9 +3,10 @@ import { hot } from 'react-hot-loader'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
+import { QueryType } from '../../js/model/Query'
 
 type Props = {
-  model: Backbone.Model
+  model: QueryType
 }
 
 const Phonetics = ({ model }: Props) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.tsx
@@ -23,9 +23,10 @@ import Phonetics from './phonetics'
 import Spellcheck from './spellcheck'
 import { hot } from 'react-hot-loader'
 import { Memo } from '../memo/memo'
+import { QueryType } from '../../js/model/Query'
 
 type Props = {
-  model: Backbone.Model
+  model: QueryType
 }
 
 /**

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/spellcheck.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-settings/spellcheck.tsx
@@ -3,9 +3,10 @@ import { hot } from 'react-hot-loader'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
+import { QueryType } from '../../js/model/Query'
 
 type Props = {
-  model: Backbone.Model
+  model: QueryType
 }
 
 const Spellcheck = ({ model }: Props) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/selection-interface.model.js
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/selection-interface.model.js
@@ -16,7 +16,7 @@
 const _ = require('underscore')
 const Backbone = require('backbone')
 const Metacard = require('../../js/model/Metacard.js')
-const QueryModel = require('../../js/model/Query.js')
+import { Query as QueryModel } from '../../js/model/Query'
 const QueryResponse = require('../../js/model/QueryResponse.js')
 const QueryResult = require('../../js/model/QueryResult.js')
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -118,6 +118,9 @@ export const TypedUserInstance = {
   canWrite: (result: LazyQueryResult): boolean => {
     return userInstance.canWrite(result.plain.metacard.properties)
   },
+  getResultCount: (): number => {
+    return userInstance.get('user').get('preferences').get('resultCount')
+  },
 }
 
 export function useActingRole<T extends string>(): T {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -8,6 +8,28 @@ import CQL from '../../cql'
 
 type PlainMetacardPropertiesType = LazyQueryResult['plain']['metacard']['properties']
 
+export const convertToBackendCompatibleForm = ({
+  properties,
+}: {
+  properties: PlainMetacardPropertiesType
+}) => {
+  const duplicatedProperties = JSON.parse(JSON.stringify(properties))
+  Object.keys(duplicatedProperties).forEach((key) => {
+    if (typeof duplicatedProperties[key] !== 'string') {
+      if (duplicatedProperties[key].constructor === Array) {
+        duplicatedProperties[key] = (duplicatedProperties[key] as any[]).map(
+          (value) => {
+            return value.toString()
+          }
+        )
+      } else {
+        duplicatedProperties[key] = duplicatedProperties[key].toString()
+      }
+    }
+  })
+  return duplicatedProperties
+}
+
 type AsyncSubscriptionsType = 'update'
 /**
  *  Provides a singleton for tracking async tasks in the UI
@@ -479,7 +501,7 @@ class CreateTask extends AsyncTask {
         metacards: [
           {
             attributes: {
-              ...this.data,
+              ...convertToBackendCompatibleForm({ properties: this.data }),
             },
             metacardType: this.metacardType,
           },
@@ -538,7 +560,7 @@ class SaveTask extends AsyncTask {
           metacards: [
             {
               attributes: {
-                ...this.data,
+                ...convertToBackendCompatibleForm({ properties: this.data }),
               },
               metacardType: this.metacardType,
             },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -40,6 +40,37 @@ class AsyncTasksClass extends Subscribable<'add' | 'remove' | 'update'> {
     this.add(newTask)
     return newTask
   }
+  create({
+    data,
+    metacardType,
+  }: {
+    data: PlainMetacardPropertiesType
+    metacardType: string
+  }) {
+    const newTask = new CreateTask({ data, metacardType })
+    this.add(newTask)
+    return newTask
+  }
+  save({
+    lazyResult,
+    data,
+    metacardType,
+  }: {
+    data: PlainMetacardPropertiesType
+    lazyResult: LazyQueryResult
+    metacardType: string
+  }) {
+    const existingTask = this.list
+      .filter(SaveTask.isInstanceOf)
+      .find((task) => task.lazyResult === lazyResult)
+    if (existingTask) {
+      existingTask.update({ data })
+      return existingTask
+    }
+    const newTask = new SaveTask({ lazyResult, data, metacardType })
+    this.add(newTask)
+    return newTask
+  }
   createSearch({ data }: { data: PlainMetacardPropertiesType }) {
     const newTask = new CreateSearchTask({ data })
     this.add(newTask)
@@ -68,6 +99,12 @@ class AsyncTasksClass extends Subscribable<'add' | 'remove' | 'update'> {
   }
   isDeleteTask(task: AsyncTask): task is DeleteTask {
     return DeleteTask.isInstanceOf(task)
+  }
+  isCreateTask(task: AsyncTask): task is CreateTask {
+    return CreateTask.isInstanceOf(task)
+  }
+  isSaveTask(task: AsyncTask): task is SaveTask {
+    return SaveTask.isInstanceOf(task)
   }
   isCreateSearchTask(task: AsyncTask): task is CreateSearchTask {
     return CreateSearchTask.isInstanceOf(task)
@@ -152,6 +189,76 @@ export const useRestoreSearchTask = ({ id }: { id?: string }) => {
             )
           })
         : null
+      setTask(relevantTask || null)
+    }
+    const unsub = AsyncTasks.subscribeTo({
+      subscribableThing: 'update',
+      callback: () => {
+        updateTask()
+      },
+    })
+    updateTask()
+    return () => {
+      unsub()
+    }
+  }, [id])
+
+  return task
+}
+
+// allow someone to see if one exists, and sub to updates
+export const useCreateTaskBasedOnParams = () => {
+  const { id } = useParams<{ id?: string }>()
+  const task = useCreateTask({ id })
+  return task
+}
+
+// allow someone to see if one exists, and sub to updates
+export const useCreateTask = ({ id }: { id?: string }) => {
+  const [task, setTask] = React.useState(null as null | CreateTask)
+  useRenderOnAsyncTasksAddOrRemove()
+  React.useEffect(() => {
+    const updateTask = () => {
+      const relevantTask = AsyncTasks.list
+        .filter(CreateTask.isInstanceOf)
+        .find((task) => {
+          return task.data.id === id
+        })
+      setTask(relevantTask || null)
+    }
+    const unsub = AsyncTasks.subscribeTo({
+      subscribableThing: 'update',
+      callback: () => {
+        updateTask()
+      },
+    })
+    updateTask()
+    return () => {
+      unsub()
+    }
+  }, [id])
+
+  return task
+}
+
+// allow someone to see if one exists, and sub to updates
+export const useSaveTaskBasedOnParams = () => {
+  const { id } = useParams<{ id?: string }>()
+  const task = useSaveTask({ id })
+  return task
+}
+
+// allow someone to see if one exists, and sub to updates
+export const useSaveTask = ({ id }: { id?: string }) => {
+  const [task, setTask] = React.useState(null as null | SaveTask)
+  useRenderOnAsyncTasksAddOrRemove()
+  React.useEffect(() => {
+    const updateTask = () => {
+      const relevantTask = AsyncTasks.list
+        .filter(SaveTask.isInstanceOf)
+        .find((task) => {
+          return task.data.id === id
+        })
       setTask(relevantTask || null)
     }
     const unsub = AsyncTasks.subscribeTo({
@@ -342,6 +449,121 @@ class DeleteTask extends AsyncTask {
   }
   static isInstanceOf(task: any): task is DeleteTask {
     return task.constructor === DeleteTask
+  }
+}
+
+class CreateTask extends AsyncTask {
+  metacardType: string
+  data: LazyQueryResult['plain']['metacard']['properties']
+  constructor({
+    data,
+    metacardType,
+  }: {
+    data: LazyQueryResult['plain']['metacard']['properties']
+    metacardType: string
+  }) {
+    super()
+    this.metacardType = metacardType
+    this.data = data
+    this.data.id = Common.generateUUID()
+    setTimeout(() => {
+      this.attemptSave()
+    }, 1000)
+  }
+  attemptSave() {
+    const payload = {
+      id: '1',
+      jsonrpc: '2.0',
+      method: 'ddf.catalog/create',
+      params: {
+        metacards: [
+          {
+            attributes: {
+              ...this.data,
+            },
+            metacardType: this.metacardType,
+          },
+        ],
+      },
+    }
+
+    fetch('/direct', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }).then(() => {
+      this._notifySubscribers('update')
+    })
+  }
+  static isInstanceOf(task: any): task is CreateTask {
+    return task.constructor === CreateTask
+  }
+}
+
+class SaveTask extends AsyncTask {
+  metacardType: string
+  lazyResult: LazyQueryResult
+  data: PlainMetacardPropertiesType
+  controller: AbortController
+  timeoutid: number | undefined
+  constructor({
+    lazyResult,
+    data,
+    metacardType,
+  }: {
+    lazyResult: LazyQueryResult
+    data: PlainMetacardPropertiesType
+    metacardType: string
+  }) {
+    super()
+    this.metacardType = metacardType
+    this.lazyResult = lazyResult
+    this.data = data
+    this.controller = new AbortController()
+    this.attemptSave()
+  }
+  update({ data }: { data: PlainMetacardPropertiesType }) {
+    clearTimeout(this.timeoutid)
+    this.controller.abort()
+    this.data = data
+    this.attemptSave()
+  }
+  attemptSave() {
+    this.controller = new AbortController()
+    this.timeoutid = window.setTimeout(() => {
+      const payload = {
+        id: '1',
+        jsonrpc: '2.0',
+        method: 'ddf.catalog/create',
+        params: {
+          metacards: [
+            {
+              attributes: {
+                ...this.data,
+              },
+              metacardType: this.metacardType,
+            },
+          ],
+        },
+      }
+
+      fetch('/direct', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        signal: this.controller.signal,
+      }).then(() => {
+        this.lazyResult.refreshDataOverNetwork()
+        const unsub = this.lazyResult.subscribeTo({
+          subscribableThing: 'backboneSync',
+          callback: () => {
+            this._notifySubscribers('update')
+            unsub()
+          },
+        })
+      })
+    }, 3000)
+  }
+  static isInstanceOf(task: any): task is SaveTask {
+    return task.constructor === SaveTask
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -591,8 +591,8 @@ class CreateSearchTask extends AsyncTask {
         metacards: [
           {
             attributes: {
-              'metacard-tags': ['query'],
               ...this.data,
+              'metacard-tags': ['query'],
               cql: getCqlForFilterTree(this.data.filterTree),
             },
             metacardType: 'metacard.query',
@@ -648,8 +648,8 @@ class SaveSearchTask extends AsyncTask {
           metacards: [
             {
               attributes: {
-                'metacard-tags': ['query'],
                 ...this.data,
+                'metacard-tags': ['query'],
                 cql: getCqlForFilterTree(this.data.filterTree),
               },
               metacardType: 'metacard.query',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -465,7 +465,7 @@ class CreateTask extends AsyncTask {
     super()
     this.metacardType = metacardType
     this.data = data
-    this.data.id = Common.generateUUID()
+    this.data.id = this.data.id || Common.generateUUID()
     setTimeout(() => {
       this.attemptSave()
     }, 1000)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
@@ -13,13 +13,6 @@
  *
  **/
 
-import { isEqualWith } from 'lodash'
-import {
-  FilterBuilderClass,
-  FilterClass,
-  isFilterBuilderClass,
-} from '../../component/filter-builder/filter.structure'
-
 // slowly seperate out methods from Query model (which has a lot of dependencies) to here, where we can import them in a spec and test them
 
 export type IndexForSourceGroupType = {
@@ -350,7 +343,6 @@ export const getConstrainedFinalPageForSourceGroup = ({
   const maxFinalPageIndexForSourceGroup = Math.max(
     ...Object.values(finalPageForSourceGroup)
   )
-  console.log(maxFinalPageIndexForSourceGroup)
   return Object.keys(finalPageForSourceGroup).reduce(
     (blob, sourceName) => {
       if (blob[sourceName] < maxFinalPageIndexForSourceGroup) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
@@ -1,0 +1,365 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import { isEqualWith } from 'lodash'
+import {
+  FilterBuilderClass,
+  FilterClass,
+  isFilterBuilderClass,
+} from '../../component/filter-builder/filter.structure'
+
+// slowly seperate out methods from Query model (which has a lot of dependencies) to here, where we can import them in a spec and test them
+
+export type IndexForSourceGroupType = {
+  [key: string]: number
+}
+
+export type SourceStatus = {
+  id: string
+  count: number
+  hasReturned: boolean
+  hits: number
+  elapsed: number
+  successful: boolean
+  warnings: []
+}
+
+// key is going to be id in SourceStatus
+export type QueryStatus = {
+  [key: string]: SourceStatus
+}
+
+// given a current status, list of sources, and function to determine local, calculate next page
+/**
+ *  We use the current status + current index to calculate next index.
+ *  Local sources get grouped into a single index.
+ *
+ *  If current index is blank it's assumed to be the start.
+ *
+ *  We throw an error if status is provided while current index is blank, as that doesn't make sense.
+ *
+ *  Notice that a good chunk of the logic is dedicated to ensuring we don't go beyond hits.
+ *  Locally this doesn't matter, but remote sources tend to throw errors if we do.
+ */
+export const calculateNextIndexForSourceGroupNextPage = ({
+  queryStatus = {},
+  sources,
+  isLocal,
+  currentIndexForSourceGroup,
+}: {
+  queryStatus: QueryStatus
+  sources: Array<string>
+  isLocal: (id: string) => boolean
+  currentIndexForSourceGroup: IndexForSourceGroupType
+}): IndexForSourceGroupType => {
+  if (
+    Object.keys(queryStatus).length > 0 &&
+    Object.keys(currentIndexForSourceGroup).length === 0
+  ) {
+    throw 'Invalid invocation:  queryStatus cannot be provided if currentIndexForSourceGroup is not'
+  }
+  const federatedSources = sources.filter((id) => {
+    return !isLocal(id)
+  })
+  const maxLocalStart = Math.max(
+    1,
+    Object.values(queryStatus)
+      .filter((indiviualStatus) => isLocal(indiviualStatus.id))
+      .filter((indiviualStatus) => indiviualStatus.hits !== undefined)
+      .reduce((blob, status) => {
+        return blob + status.hits
+      }, 1)
+  )
+  return Object.values(queryStatus).reduce(
+    (blob, indiviualStatus) => {
+      if (isLocal(indiviualStatus.id)) {
+        blob['local'] = Math.min(
+          maxLocalStart,
+          blob['local'] + indiviualStatus.count
+        )
+      } else {
+        blob[indiviualStatus.id] = Math.min(
+          indiviualStatus.hits !== undefined ? indiviualStatus.hits + 1 : 1,
+          blob[indiviualStatus.id] + indiviualStatus.count
+        )
+      }
+      return blob
+    },
+    {
+      local: 1,
+      ...federatedSources.reduce((blob, id) => {
+        blob[id] = 1
+        return blob
+      }, {} as { [key: string]: number }),
+      ...currentIndexForSourceGroup,
+    } as { [key: string]: number }
+  )
+}
+
+export const getMaxIndexForSourceGroup = ({
+  queryStatus,
+  isLocal,
+}: {
+  queryStatus: QueryStatus
+  isLocal: (id: string) => boolean
+}): IndexForSourceGroupType => {
+  if (Object.keys(queryStatus).length === 0) {
+    console.log(
+      'Invalid invocation:  queryStatus is required to determine max index for a query'
+    )
+    return {}
+  }
+  const maxLocalStart = Math.max(
+    1,
+    Object.values(queryStatus)
+      .filter((indiviualStatus) => isLocal(indiviualStatus.id))
+      .filter((indiviualStatus) => indiviualStatus.hits !== undefined)
+      .reduce((blob, status) => {
+        return blob + status.hits
+      }, 0)
+  )
+  return Object.values(queryStatus).reduce(
+    (blob, indiviualStatus) => {
+      if (!isLocal(indiviualStatus.id)) {
+        blob[indiviualStatus.id] = indiviualStatus.hits
+      }
+      return blob
+    },
+    {
+      local: maxLocalStart,
+    } as { [key: string]: number }
+  )
+}
+
+export const hasPreviousPageForSourceGroup = ({
+  currentIndexForSourceGroup,
+}: {
+  currentIndexForSourceGroup: IndexForSourceGroupType
+}): boolean => {
+  return (
+    Object.values(currentIndexForSourceGroup).length > 0 &&
+    Object.values(currentIndexForSourceGroup).some((start) => start !== 1)
+  )
+}
+
+export const getNextPageForSourceGroup = ({
+  currentIndexForSourceGroup,
+  sources,
+  isLocal,
+  count,
+}: {
+  sources: Array<string>
+  isLocal: (id: string) => boolean
+  currentIndexForSourceGroup: IndexForSourceGroupType
+  count: number
+}): IndexForSourceGroupType => {
+  if (Object.keys(currentIndexForSourceGroup).length > 0) {
+    return Object.keys(currentIndexForSourceGroup).reduce(
+      (blob, key) => {
+        blob[key] = blob[key] + count
+        return blob
+      },
+      { ...currentIndexForSourceGroup } as IndexForSourceGroupType
+    )
+  } else {
+    return sources.reduce(
+      (blob, sourceName) => {
+        if (!isLocal(sourceName)) {
+          blob[sourceName] = 1
+        }
+        return blob
+      },
+      {
+        local: 1,
+      } as IndexForSourceGroupType
+    )
+  }
+}
+
+export const hasNextPageForSourceGroup = ({
+  queryStatus,
+  isLocal,
+  currentIndexForSourceGroup,
+  count,
+}: {
+  queryStatus: QueryStatus
+  isLocal: (id: string) => boolean
+  currentIndexForSourceGroup: IndexForSourceGroupType
+  count: number
+}): boolean => {
+  if (!queryStatus) {
+    return false
+  }
+
+  const maxIndexforSourceGroup = getMaxIndexForSourceGroup({
+    queryStatus,
+    isLocal,
+  })
+
+  return Object.keys(maxIndexforSourceGroup).some((key) => {
+    return (
+      currentIndexForSourceGroup[key] + count - 1 < maxIndexforSourceGroup[key]
+    )
+  })
+}
+
+export const getPreviousPageForSourceGroup = ({
+  currentIndexForSourceGroup,
+  count,
+}: {
+  currentIndexForSourceGroup: IndexForSourceGroupType
+  count: number
+}): IndexForSourceGroupType => {
+  return Object.keys(currentIndexForSourceGroup).reduce(
+    (blob, key) => {
+      blob[key] = Math.max(1, blob[key] - count)
+      return blob
+    },
+    { ...currentIndexForSourceGroup } as IndexForSourceGroupType
+  )
+}
+
+export const getFirstPageForSourceGroup = ({
+  sources,
+  isLocal,
+}: {
+  sources: Array<string>
+  isLocal: (id: string) => boolean
+}): IndexForSourceGroupType => {
+  return calculateNextIndexForSourceGroupNextPage({
+    sources,
+    isLocal,
+    queryStatus: {},
+    currentIndexForSourceGroup: {},
+  })
+}
+
+export const getFinalPageForSourceGroup = ({
+  queryStatus,
+  isLocal,
+  count,
+}: {
+  queryStatus: QueryStatus
+  isLocal: (id: string) => boolean
+  count: number
+}): IndexForSourceGroupType => {
+  if (!queryStatus) {
+    return {}
+  }
+  const maxIndexforSourceGroup = getMaxIndexForSourceGroup({
+    queryStatus,
+    isLocal,
+  })
+  return Object.keys(maxIndexforSourceGroup).reduce(
+    (blob, sourceName) => {
+      let remainderOnFinalPage = maxIndexforSourceGroup[sourceName] % count
+      remainderOnFinalPage =
+        remainderOnFinalPage === 0 ? count : remainderOnFinalPage
+      blob[sourceName] =
+        maxIndexforSourceGroup[sourceName] - remainderOnFinalPage + 1
+      return blob
+    },
+    {
+      ...maxIndexforSourceGroup,
+    } as { [key: string]: number }
+  )
+}
+
+export type QueryStartAndEndType = {
+  start: number
+  end: number
+  hits: number
+}
+
+export const getCurrentStartAndEndForSourceGroup = ({
+  queryStatus,
+  currentIndexForSourceGroup,
+}: {
+  queryStatus: QueryStatus
+  currentIndexForSourceGroup: IndexForSourceGroupType
+}): QueryStartAndEndType => {
+  if (!queryStatus) {
+    return {
+      start: 0,
+      end: 0,
+      hits: 0,
+    }
+  }
+  const relativeStart = Object.keys(currentIndexForSourceGroup).reduce(
+    (_blob, key) => {
+      return currentIndexForSourceGroup[key]
+    },
+    0
+  )
+
+  const start =
+    relativeStart === 1
+      ? relativeStart
+      : Object.keys(queryStatus).reduce((blob, key) => {
+          return (
+            blob +
+            Math.min(
+              queryStatus[key].hits,
+              currentIndexForSourceGroup[key] |
+                currentIndexForSourceGroup['local']
+            )
+          )
+        }, 0)
+
+  const end = Object.keys(queryStatus).reduce((blob, key) => {
+    return blob + queryStatus[key].count
+  }, start - 1)
+
+  const hits = Object.keys(queryStatus).reduce((blob, key) => {
+    return blob + queryStatus[key].hits
+  }, 0)
+
+  return {
+    start,
+    end: Math.max(start, end),
+    hits,
+  }
+}
+
+export const getConstrainedFinalPageForSourceGroup = ({
+  queryStatus,
+  isLocal,
+  count,
+}: {
+  queryStatus: QueryStatus
+  isLocal: (id: string) => boolean
+  count: number
+}): IndexForSourceGroupType => {
+  const finalPageForSourceGroup = getFinalPageForSourceGroup({
+    queryStatus,
+    isLocal,
+    count,
+  })
+  const maxFinalPageIndexForSourceGroup = Math.max(
+    ...Object.values(finalPageForSourceGroup)
+  )
+  console.log(maxFinalPageIndexForSourceGroup)
+  return Object.keys(finalPageForSourceGroup).reduce(
+    (blob, sourceName) => {
+      if (blob[sourceName] < maxFinalPageIndexForSourceGroup) {
+        blob[sourceName] = maxFinalPageIndexForSourceGroup
+      }
+      return blob
+    },
+    {
+      ...finalPageForSourceGroup,
+    } as { [key: string]: number }
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.shared-types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.shared-types.tsx
@@ -24,5 +24,6 @@ export type QueryAttributesType = {
   filterTree?: FilterBuilderClass
   sources?: string[]
   sorts?: SortType[]
+  count?: number
   [key: string]: any // slowly build out the proper type, then remove this (leave for now so we don't accidentally leave something off)
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.spec.tsx
@@ -1,0 +1,1433 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { expect } from 'chai'
+
+import {
+  calculateNextIndexForSourceGroupNextPage,
+  getMaxIndexForSourceGroup,
+} from './Query.methods'
+
+describe('calculation of next index', () => {
+  const Examples: Array<
+    Parameters<typeof calculateNextIndexForSourceGroupNextPage>[0] & {
+      return: ReturnType<typeof calculateNextIndexForSourceGroupNextPage>
+    }
+  > = [
+    {
+      sources: ['Geoserver', 'DDF'],
+      queryStatus: {},
+      isLocal: (id: string) => {
+        return ['DDF'].includes(id)
+      },
+      return: { local: 1, Geoserver: 1 },
+      currentIndexForSourceGroup: {},
+    },
+    {
+      sources: ['Geoserver', 'DDF'],
+      queryStatus: {
+        Geoserver: {
+          id: 'Geoserver',
+          count: 1,
+          hasReturned: true,
+          hits: 9535,
+          elapsed: 1486,
+          successful: true,
+          warnings: [],
+        },
+        DDF: {
+          id: 'DDF',
+          count: 1,
+          hasReturned: true,
+          hits: 31,
+          elapsed: 496,
+          successful: true,
+          warnings: [],
+        },
+      },
+      isLocal: (id: string) => {
+        return ['DDF'].includes(id)
+      },
+      return: {
+        local: 2,
+        Geoserver: 2,
+      },
+      currentIndexForSourceGroup: { local: 1, Geoserver: 1 },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {},
+      return: {
+        local: 1,
+        WINDOWS: 1,
+        LINUX: 1,
+        REACT: 1,
+      },
+      currentIndexForSourceGroup: {},
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {},
+      return: {
+        local: 1,
+        WINDOWS: 1,
+        LINUX: 1,
+        REACT: 1,
+      },
+      currentIndexForSourceGroup: {},
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 103,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 3,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 170,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 65,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 534,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 554,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 524,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 13,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 4,
+        WINDOWS: 4,
+        LINUX: 4,
+        REACT: 4,
+      },
+      currentIndexForSourceGroup: {
+        local: 1,
+        WINDOWS: 1,
+        LINUX: 1,
+        REACT: 1,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 20,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 3,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 125,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 60,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 313,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 354,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 308,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 27,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 7,
+        WINDOWS: 7,
+        LINUX: 7,
+        REACT: 7,
+      },
+      currentIndexForSourceGroup: {
+        local: 4,
+        WINDOWS: 4,
+        LINUX: 4,
+        REACT: 4,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 28,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 2,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 152,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 1,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 50,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 366,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 450,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 418,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 18,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 10,
+        WINDOWS: 10,
+        LINUX: 10,
+        REACT: 10,
+      },
+      currentIndexForSourceGroup: {
+        local: 7,
+        WINDOWS: 7,
+        LINUX: 7,
+        REACT: 7,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 19,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 0,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 160,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 50,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 380,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 450,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 366,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 14,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 14,
+        WINDOWS: 19,
+        LINUX: 19,
+        REACT: 19,
+      },
+      currentIndexForSourceGroup: {
+        local: 14,
+        WINDOWS: 16,
+        LINUX: 16,
+        REACT: 16,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 45,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2754,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 204,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 5276,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 1,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 106,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 6997,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 250,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 10776,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 6934,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 112,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 251,
+        WINDOWS: 251,
+        LINUX: 251,
+        REACT: 251,
+      },
+      currentIndexForSourceGroup: {
+        local: 1,
+        WINDOWS: 1,
+        LINUX: 1,
+        REACT: 1,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2480,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 250,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 13515,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 61,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 3959,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 1,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 627,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 3880,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 80,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 501,
+        WINDOWS: 501,
+        LINUX: 252,
+        REACT: 501,
+      },
+      currentIndexForSourceGroup: {
+        local: 251,
+        WINDOWS: 251,
+        LINUX: 251,
+        REACT: 251,
+      },
+    },
+    {
+      sources: [
+        'READREADREAD',
+        'LISTENLISTENLISTEN',
+        'TALKTALKTALK',
+        'WINDOWS',
+        'LINUX',
+        'REACT',
+        'MACBOOK',
+      ],
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2371,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 250,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 26071,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 115,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 3635,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 0,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 937,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 3580,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 84,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 751,
+        WINDOWS: 751,
+        LINUX: 252,
+        REACT: 751,
+      },
+      currentIndexForSourceGroup: {
+        local: 501,
+        WINDOWS: 501,
+        LINUX: 252,
+        REACT: 501,
+      },
+    },
+  ]
+  it('passes snapshot test cases', (done) => {
+    Examples.forEach((example) => {
+      console.log(example)
+      expect(
+        JSON.stringify(
+          calculateNextIndexForSourceGroupNextPage({
+            queryStatus: example.queryStatus,
+            currentIndexForSourceGroup: example.currentIndexForSourceGroup,
+            sources: example.sources,
+            isLocal: example.isLocal,
+          })
+        ),
+        `Next index for sources not calculated correctly`
+      ).to.equal(JSON.stringify(example.return))
+    })
+    done()
+  })
+})
+
+describe('calculation of max index', () => {
+  const Examples: Array<
+    Parameters<typeof getMaxIndexForSourceGroup>[0] & {
+      return: ReturnType<typeof getMaxIndexForSourceGroup>
+    }
+  > = [
+    {
+      queryStatus: {
+        Geoserver: {
+          id: 'Geoserver',
+          count: 1,
+          hasReturned: true,
+          hits: 9535,
+          elapsed: 1486,
+          successful: true,
+          warnings: [],
+        },
+        DDF: {
+          id: 'DDF',
+          count: 1,
+          hasReturned: true,
+          hits: 31,
+          elapsed: 496,
+          successful: true,
+          warnings: [],
+        },
+      },
+      isLocal: (id: string) => {
+        return ['DDF'].includes(id)
+      },
+      return: {
+        local: 31,
+        Geoserver: 9535,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 103,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 3,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 170,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 65,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 534,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 554,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 524,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 13,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 13,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 20,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 3,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 125,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 60,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 313,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 354,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 308,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 27,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 13,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 28,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 2,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 152,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 1,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 50,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 366,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 450,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 418,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 18,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 13,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 19,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 0,
+          hasReturned: true,
+          hits: 12,
+          elapsed: 160,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 50,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 3,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 380,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 3,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 450,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 3,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 366,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 0,
+          elapsed: 14,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 13,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 45,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2754,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 204,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 5276,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 1,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 106,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 6997,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 250,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 10776,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 6934,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 112,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 2000,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2480,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 250,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 13515,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 61,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 3959,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 1,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 627,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 3880,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 80,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 2000,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+    {
+      isLocal: (id: string) => {
+        return [
+          'TALKTALKTALK',
+          'READREADREAD',
+          'LISTENLISTENLISTEN',
+          'MACBOOK',
+        ].includes(id)
+      },
+      queryStatus: {
+        READREADREAD: {
+          id: 'READREADREAD',
+          count: 0,
+          hasReturned: true,
+          hits: 145,
+          elapsed: 2371,
+          successful: true,
+          warnings: [],
+        },
+        LISTENLISTENLISTEN: {
+          id: 'LISTENLISTENLISTEN',
+          count: 250,
+          hasReturned: true,
+          hits: 1850,
+          elapsed: 26071,
+          successful: true,
+          warnings: [],
+        },
+        TALKTALKTALK: {
+          id: 'TALKTALKTALK',
+          count: 0,
+          hasReturned: true,
+          hits: 1,
+          elapsed: 115,
+          successful: true,
+          warnings: [],
+        },
+        WINDOWS: {
+          id: 'WINDOWS',
+          count: 250,
+          hasReturned: true,
+          hits: 10440,
+          elapsed: 3635,
+          successful: true,
+          warnings: [],
+        },
+        LINUX: {
+          id: 'LINUX',
+          count: 0,
+          hasReturned: true,
+          hits: 251,
+          elapsed: 937,
+          successful: true,
+          warnings: [],
+        },
+        REACT: {
+          id: 'REACT',
+          count: 250,
+          hasReturned: true,
+          hits: 102176,
+          elapsed: 3580,
+          successful: true,
+          warnings: [],
+        },
+        MACBOOK: {
+          id: 'MACBOOK',
+          count: 0,
+          hasReturned: true,
+          hits: 4,
+          elapsed: 84,
+          successful: true,
+          warnings: [],
+        },
+      },
+      return: {
+        local: 2000,
+        WINDOWS: 10440,
+        LINUX: 251,
+        REACT: 102176,
+      },
+    },
+  ]
+
+  it('passes snapshot test cases', (done) => {
+    Examples.forEach((example) => {
+      console.log(example)
+      expect(
+        JSON.stringify(
+          getMaxIndexForSourceGroup({
+            queryStatus: example.queryStatus,
+            isLocal: example.isLocal,
+          })
+        ),
+        `Max index for sources not calculated correctly`
+      ).to.equal(JSON.stringify(example.return))
+    })
+    done()
+  })
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -32,10 +32,8 @@ import {
 } from '../../component/filter-builder/filter.structure'
 import { downgradeFilterTreeToBasic } from '../../component/query-basic/query-basic.view'
 import {
-  calculateNextIndexForSourceGroupNextPage,
   getConstrainedFinalPageForSourceGroup,
   getCurrentStartAndEndForSourceGroup,
-  getFinalPageForSourceGroup,
   getNextPageForSourceGroup,
   getPreviousPageForSourceGroup,
   hasNextPageForSourceGroup,
@@ -482,10 +480,10 @@ Query.Model = Backbone.AssociatedModel.extend({
         method: 'POST',
         processData: false,
         timeout: properties.timeout,
-        success(model: any, response: any, options: any) {
+        success(_model: any, response: any, options: any) {
           response.options = options
         },
-        error(model: any, response: any, options: any) {
+        error(_model: any, response: any, options: any) {
           if (response.status === 401) {
             const providerUrl = response.responseJSON.url
             const sourceId = response.responseJSON.id
@@ -581,38 +579,6 @@ Query.Model = Backbone.AssociatedModel.extend({
       currentIndexForSourceGroup: this.currentIndexForSourceGroup,
       count: this.get('count'),
     })
-    // const currentStatus = this.get('result')
-    //   ? this.get('result').get('lazyResults').status
-    //   : {}
-    // const harvestedSources = Sources.getHarvested()
-    // const isLocal = (id: any) => {
-    //   return harvestedSources.includes(id)
-    // }
-    // const maxIndexSeenLocal =
-    //   (Object.values(currentStatus)
-    //     .filter((status: any) => isLocal(status.id))
-    //     .reduce((amt: any, status: any) => {
-    //       amt = amt + status.count
-    //       return amt
-    //     }, 0) as number) + this.currentIndexForSourceGroup.local
-    // const maxIndexPossibleLocal = Object.values(currentStatus)
-    //   .filter((status: any) => isLocal(status.id))
-    //   .reduce((amt: number, status: any) => {
-    //     amt = amt + status.hits
-    //     return amt
-    //   }, 0) as number
-    // if (maxIndexSeenLocal <= maxIndexPossibleLocal) {
-    //   return true
-    // }
-
-    // return Object.values(currentStatus)
-    //   .filter((status: any) => !isLocal(status.id))
-    //   .some((status: any) => {
-    //     const maxIndexPossible = status.hits
-    //     const count = status.count
-    //     const maxIndexSeen = count + this.currentIndexForSourceGroup[status.id]
-    //     return maxIndexSeen <= maxIndexPossible
-    //   })
   },
   getNextServerPage() {
     this.setNextIndexForSourceGroupToNextPage(this.getSelectedSources())

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -21,7 +21,6 @@ import Sources from '../../component/singletons/sources-instance'
 const Common = require('../Common.js')
 const announcement = require('../../component/announcement/index.jsx')
 import cql from '../cql'
-const user = require('../../component/singletons/user-instance.js')
 const _merge = require('lodash/merge')
 require('backbone-associations')
 import React from 'react'
@@ -32,10 +31,71 @@ import {
   FilterClass,
 } from '../../component/filter-builder/filter.structure'
 import { downgradeFilterTreeToBasic } from '../../component/query-basic/query-basic.view'
+import {
+  calculateNextIndexForSourceGroupNextPage,
+  getConstrainedFinalPageForSourceGroup,
+  getCurrentStartAndEndForSourceGroup,
+  getFinalPageForSourceGroup,
+  getNextPageForSourceGroup,
+  getPreviousPageForSourceGroup,
+  hasNextPageForSourceGroup,
+  hasPreviousPageForSourceGroup,
+  IndexForSourceGroupType,
+  QueryStartAndEndType,
+} from './Query.methods'
 const wreqr = require('../wreqr')
-const Query = {}
 
-function limitToDeleted(cqlFilterTree) {
+export type QueryType = {
+  constructor: (_attributes: any, options: any) => void
+  set: (p1: any, p2?: any) => void
+  toJSON: () => any
+  defaults: () => any
+  resetToDefaults: (overridenDefaults: any) => void
+  applyDefaults: () => void
+  revert: () => void
+  isLocal: () => boolean
+  _handleDeprecatedFederation: (attributes: any) => void
+  initialize: (attributes: any) => void
+  getSelectedSources: () => Array<any>
+  buildSearchData: () => any
+  isOutdated: () => boolean
+  startSearchIfOutdated: () => void
+  updateCqlBasedOnFilterTree: () => void
+  startSearchFromFirstPage: (options?: any, done?: any) => void
+  startSearch: (options?: any, done?: any) => void
+  currentSearches: Array<any>
+  cancelCurrentSearches: () => void
+  clearResults: () => void
+  setSources: (sources: any) => void
+  setColor: (color: any) => void
+  getColor: () => any
+  color: () => any
+  currentIndexForSourceGroup: IndexForSourceGroupType
+  nextIndexForSourceGroup: IndexForSourceGroupType
+  pastIndexesForSourceGroup: Array<IndexForSourceGroupType>
+  getPreviousServerPage: () => void
+  hasPreviousServerPage: () => boolean
+  hasNextServerPage: () => boolean
+  getNextServerPage: () => void
+  getHasFirstServerPage: () => boolean
+  getFirstServerPage: () => void
+  getHasLastServerPage: () => boolean
+  getLastServerPage: () => void
+  resetCurrentIndexForSourceGroup: () => void
+  setNextIndexForSourceGroupToPrevPage: () => void
+  setNextIndexForSourceGroupToNextPage: (sources: string[]) => void
+  getCurrentStartAndEndForSourceGroup: () => QueryStartAndEndType
+  [key: string]: any
+}
+
+export const Query = {} as {
+  Model: {
+    new (..._args: any): QueryType
+  }
+}
+export default Query
+
+function limitToDeleted(cqlFilterTree: any) {
   return new FilterBuilderClass({
     type: 'AND',
     filters: [
@@ -54,7 +114,7 @@ function limitToDeleted(cqlFilterTree) {
   })
 }
 
-function limitToHistoric(cqlFilterTree) {
+function limitToHistoric(cqlFilterTree: any) {
   return new FilterBuilderClass({
     type: 'AND',
     filters: [
@@ -78,21 +138,22 @@ Query.Model = Backbone.AssociatedModel.extend({
     },
   ],
   // override constructor slightly to ensure options are available on the self ref immediately
-  constructor(attributes, options) {
+  constructor(_attributes: any, options: any) {
     if (
       !options ||
       !options.transformDefaults ||
       !options.transformFilterTree ||
-      !options.transformSorts
+      !options.transformSorts ||
+      !options.transformCount
     ) {
       throw new Error(
-        'Options for transformDefaults, transformFilterTree, and transformSorts must be provided'
+        'Options for transformDefaults, transformFilterTree, transformSorts, and transformCount must be provided'
       )
     }
     this.options = options
     return Backbone.AssociatedModel.apply(this, arguments)
   },
-  set(data) {
+  set(data: any) {
     if (
       typeof data === 'object' &&
       data.filterTree !== undefined &&
@@ -107,7 +168,7 @@ Query.Model = Backbone.AssociatedModel.extend({
     }
     return Backbone.AssociatedModel.prototype.set.apply(this, arguments)
   },
-  toJSON(...args) {
+  toJSON(...args: any) {
     const json = Backbone.AssociatedModel.prototype.toJSON.call(this, ...args)
     if (typeof json.filterTree === 'object') {
       json.filterTree = JSON.stringify(json.filterTree)
@@ -146,7 +207,7 @@ Query.Model = Backbone.AssociatedModel.extend({
   /**
    *  Add filterTree in here, since initialize is only run once (and defaults can't have filterTree)
    */
-  resetToDefaults(overridenDefaults) {
+  resetToDefaults(overridenDefaults: any) {
     const defaults = _.omit(
       {
         ...this.defaults(),
@@ -175,14 +236,14 @@ Query.Model = Backbone.AssociatedModel.extend({
   isLocal() {
     return this.get('isLocal')
   },
-  _handleDeprecatedFederation(attributes) {
+  _handleDeprecatedFederation(attributes: any) {
     if (attributes && attributes.federation) {
       console.error(
         'Attempt to set federation on a search.  This attribute is deprecated.  Did you mean to set sources?'
       )
     }
   },
-  initialize(attributes) {
+  initialize(attributes: any) {
     _.bindAll.apply(_, [this].concat(_.functions(this))) // underscore bindAll does not take array arg
     const filterTree = this.get('filterTree')
     if (filterTree && typeof filterTree === 'string') {
@@ -202,7 +263,7 @@ Query.Model = Backbone.AssociatedModel.extend({
     this._handleDeprecatedFederation(attributes)
     this.listenTo(
       this,
-      'change:cql change:filterTree change:sources change:sorts change:spellcheck change:phonetics',
+      'change:cql change:filterTree change:sources change:sorts change:spellcheck change:phonetics change:count',
       () => {
         this.set('isOutdated', true)
       }
@@ -213,7 +274,10 @@ Query.Model = Backbone.AssociatedModel.extend({
         const cleanedUpFilterTree = cql.removeInvalidFilters(
           this.get('filterTree')
         )
-        this.set('filterTree', downgradeFilterTreeToBasic(cleanedUpFilterTree))
+        this.set(
+          'filterTree',
+          downgradeFilterTreeToBasic(cleanedUpFilterTree as any)
+        )
       }
     })
   },
@@ -226,16 +290,16 @@ Query.Model = Backbone.AssociatedModel.extend({
     if (selectedSources.includes('local')) {
       sourceArray = sourceArray
         .concat(Sources.getHarvested())
-        .filter((src) => src !== 'local')
+        .filter((src: any) => src !== 'local')
     }
     if (selectedSources.includes('remote')) {
       sourceArray = sourceArray
         .concat(
           _.pluck(Sources.toJSON(), 'id').filter(
-            (src) => !Sources.getHarvested().includes(src)
+            (src: any) => !Sources.getHarvested().includes(src)
           )
         )
-        .filter((src) => src !== 'remote')
+        .filter((src: any) => src !== 'remote')
     }
     return sourceArray
   },
@@ -243,7 +307,10 @@ Query.Model = Backbone.AssociatedModel.extend({
     const data = this.toJSON()
     data.sources = this.getSelectedSources()
 
-    data.count = user.get('user').get('preferences').get('resultCount')
+    data.count = this.options.transformCount({
+      originalCount: this.get('count'),
+      queryRef: this,
+    })
 
     data.sorts = this.options.transformSorts({
       originalSorts: this.get('sorts'),
@@ -299,12 +366,13 @@ Query.Model = Backbone.AssociatedModel.extend({
       this.set('cql', cql.write(filterTree))
     }
   },
-  startSearchFromFirstPage(options, done) {
+  startSearchFromFirstPage(options: any, done: any) {
     this.updateCqlBasedOnFilterTree()
     this.resetCurrentIndexForSourceGroup()
     this.startSearch(options, done)
   },
-  startSearch(options, done) {
+  startSearch(options: any, done: any) {
+    console.log(this)
     this.trigger('panToShapesExtent')
     this.set('isOutdated', false)
     if (this.get('cql') === '') {
@@ -326,8 +394,8 @@ Query.Model = Backbone.AssociatedModel.extend({
     let selectedSources = data.sources
     const harvestedSources = Sources.getHarvested()
 
-    const isHarvested = (id) => harvestedSources.includes(id)
-    const isFederated = (id) => !harvestedSources.includes(id)
+    const isHarvested = (id: any) => harvestedSources.includes(id)
+    const isFederated = (id: any) => !harvestedSources.includes(id)
     if (options.limitToDeleted) {
       selectedSources = data.sources.filter(isHarvested)
     }
@@ -336,7 +404,7 @@ Query.Model = Backbone.AssociatedModel.extend({
       result.get('lazyResults').reset({
         sorts: this.get('sorts'),
         sources: selectedSources,
-        transformSorts: ({ originalSorts }) => {
+        transformSorts: ({ originalSorts }: any) => {
           return this.options.transformSorts({ originalSorts, queryRef: this })
         },
       })
@@ -380,7 +448,7 @@ Query.Model = Backbone.AssociatedModel.extend({
 
     const federatedSearchesToRun = selectedSources
       .filter(isFederated)
-      .map((source) => ({
+      .map((source: any) => ({
         ...data,
         cql: cqlString,
         srcs: [source],
@@ -414,10 +482,10 @@ Query.Model = Backbone.AssociatedModel.extend({
         method: 'POST',
         processData: false,
         timeout: properties.timeout,
-        success(model, response, options) {
+        success(model: any, response: any, options: any) {
           response.options = options
         },
-        error(model, response, options) {
+        error(model: any, response: any, options: any) {
           if (response.status === 401) {
             const providerUrl = response.responseJSON.url
             const sourceId = response.responseJSON.id
@@ -428,7 +496,7 @@ Query.Model = Backbone.AssociatedModel.extend({
                 href: providerUrl,
                 target: '_blank',
                 style: {
-                  color: `${(props) =>
+                  color: `${(props: any) =>
                     readableColor(props.theme.negativeColor)}`,
                 },
               },
@@ -451,7 +519,7 @@ Query.Model = Backbone.AssociatedModel.extend({
   },
   currentSearches: [],
   cancelCurrentSearches() {
-    this.currentSearches.forEach((request) => {
+    this.currentSearches.forEach((request: any) => {
       request.abort('Canceled')
     })
     const result = this.get('result')
@@ -466,9 +534,9 @@ Query.Model = Backbone.AssociatedModel.extend({
       result: undefined,
     })
   },
-  setSources(sources) {
-    const sourceArr = []
-    sources.each((src) => {
+  setSources(sources: any) {
+    const sourceArr = [] as any
+    sources.each((src: any) => {
       if (src.get('available') === true) {
         sourceArr.push(src.get('id'))
       }
@@ -479,7 +547,7 @@ Query.Model = Backbone.AssociatedModel.extend({
       this.set('sources', '')
     }
   },
-  setColor(color) {
+  setColor(color: any) {
     this.set('color', color)
   },
   getColor() {
@@ -489,51 +557,87 @@ Query.Model = Backbone.AssociatedModel.extend({
     return this.get('color')
   },
   getPreviousServerPage() {
-    this.setNextIndexForSourceGroupToPrevPage()
+    this.nextIndexForSourceGroup = getPreviousPageForSourceGroup({
+      currentIndexForSourceGroup: this.currentIndexForSourceGroup,
+      count: this.get('count'),
+    })
+    // this.setNextIndexForSourceGroupToPrevPage()
     this.startSearch()
   },
   /**
    * Much simpler than seeing if a next page exists
    */
   hasPreviousServerPage() {
-    return this.pastIndexesForSourceGroup.length > 0
+    return hasPreviousPageForSourceGroup({
+      currentIndexForSourceGroup: this.currentIndexForSourceGroup,
+    })
   },
   hasNextServerPage() {
-    const currentStatus = this.get('result')
-      ? this.get('result').get('lazyResults').status
-      : {}
-    const harvestedSources = Sources.getHarvested()
-    const isLocal = (id) => {
-      return harvestedSources.includes(id)
-    }
-    const maxIndexSeenLocal =
-      Object.values(currentStatus)
-        .filter((status) => isLocal(status.id))
-        .reduce((amt, status) => {
-          amt = amt + status.count
-          return amt
-        }, 0) + this.currentIndexForSourceGroup.local
-    const maxIndexPossibleLocal = Object.values(currentStatus)
-      .filter((status) => isLocal(status.id))
-      .reduce((amt, status) => {
-        amt = amt + status.hits
-        return amt
-      }, 0)
-    if (maxIndexSeenLocal <= maxIndexPossibleLocal) {
-      return true
-    }
+    return hasNextPageForSourceGroup({
+      queryStatus: this.get('result')?.get('lazyResults')?.status,
+      isLocal: (id) => {
+        return Sources.getHarvested().includes(id)
+      },
+      currentIndexForSourceGroup: this.currentIndexForSourceGroup,
+      count: this.get('count'),
+    })
+    // const currentStatus = this.get('result')
+    //   ? this.get('result').get('lazyResults').status
+    //   : {}
+    // const harvestedSources = Sources.getHarvested()
+    // const isLocal = (id: any) => {
+    //   return harvestedSources.includes(id)
+    // }
+    // const maxIndexSeenLocal =
+    //   (Object.values(currentStatus)
+    //     .filter((status: any) => isLocal(status.id))
+    //     .reduce((amt: any, status: any) => {
+    //       amt = amt + status.count
+    //       return amt
+    //     }, 0) as number) + this.currentIndexForSourceGroup.local
+    // const maxIndexPossibleLocal = Object.values(currentStatus)
+    //   .filter((status: any) => isLocal(status.id))
+    //   .reduce((amt: number, status: any) => {
+    //     amt = amt + status.hits
+    //     return amt
+    //   }, 0) as number
+    // if (maxIndexSeenLocal <= maxIndexPossibleLocal) {
+    //   return true
+    // }
 
-    return Object.values(currentStatus)
-      .filter((status) => !isLocal(status.id))
-      .some((status) => {
-        const maxIndexPossible = status.hits
-        const count = status.count
-        const maxIndexSeen = count + this.currentIndexForSourceGroup[status.id]
-        return maxIndexSeen <= maxIndexPossible
-      })
+    // return Object.values(currentStatus)
+    //   .filter((status: any) => !isLocal(status.id))
+    //   .some((status: any) => {
+    //     const maxIndexPossible = status.hits
+    //     const count = status.count
+    //     const maxIndexSeen = count + this.currentIndexForSourceGroup[status.id]
+    //     return maxIndexSeen <= maxIndexPossible
+    //   })
   },
   getNextServerPage() {
     this.setNextIndexForSourceGroupToNextPage(this.getSelectedSources())
+    this.startSearch()
+  },
+  getHasFirstServerPage() {
+    // so technically always "true" but what we really mean is, are we not on page 1 already
+    return this.hasPreviousServerPage()
+  },
+  getFirstServerPage() {
+    this.startSearchFromFirstPage()
+  },
+  getHasLastServerPage() {
+    // so technically always "true" but what we really mean is, are we not on last page already
+    return this.hasNextServerPage()
+  },
+  getLastServerPage() {
+    this.nextIndexForSourceGroup = getConstrainedFinalPageForSourceGroup({
+      queryStatus: this.get('result')?.get('lazyResults')?.status,
+      isLocal: (id) => {
+        return Sources.getHarvested().includes(id)
+      },
+      count: this.get('count'),
+    })
+    console.log(this.nextIndexForSourceGroup)
     this.startSearch()
   },
   resetCurrentIndexForSourceGroup() {
@@ -552,7 +656,7 @@ Query.Model = Backbone.AssociatedModel.extend({
    */
   setNextIndexForSourceGroupToPrevPage() {
     if (this.pastIndexesForSourceGroup.length > 0) {
-      this.nextIndexForSourceGroup = this.pastIndexesForSourceGroup.pop()
+      this.nextIndexForSourceGroup = this.pastIndexesForSourceGroup.pop() || {}
     } else {
       console.error('this should not happen')
     }
@@ -560,57 +664,21 @@ Query.Model = Backbone.AssociatedModel.extend({
   /**
    * Update the next index to be the next page
    */
-  setNextIndexForSourceGroupToNextPage(sources) {
+  setNextIndexForSourceGroupToNextPage(sources: string[]) {
     this.pastIndexesForSourceGroup.push(this.nextIndexForSourceGroup)
-    this.nextIndexForSourceGroup = this._calculateNextIndexForSourceGroupNextPage(
-      sources
-    )
-  },
-  /**
-   * Get what the next index should be for going forward
-   */
-  _calculateNextIndexForSourceGroupNextPage(sources) {
-    const harvestedSources = Sources.getHarvested()
-    const isLocal = (id) => {
-      return harvestedSources.includes(id)
-    }
-    const federatedSources = sources.filter((id) => {
-      return !isLocal(id)
-    })
-    const currentStatus = this.get('result')
-      ? this.get('result').get('lazyResults').status
-      : {}
-
-    const maxLocalStart = Math.max(
-      1,
-      Object.values(currentStatus)
-        .filter((status) => isLocal(status.id))
-        .filter((status) => status.hits !== undefined)
-        .reduce((blob, status) => {
-          return blob + status.hits
-        }, 1)
-    )
-    return Object.values(currentStatus).reduce(
-      (blob, status) => {
-        if (isLocal(status.id)) {
-          blob['local'] = Math.min(maxLocalStart, blob['local'] + status.count)
-        } else {
-          blob[status.id] = Math.min(
-            status.hits !== undefined ? status.hits + 1 : 1,
-            blob[status.id] + status.count
-          )
-        }
-        return blob
+    this.nextIndexForSourceGroup = getNextPageForSourceGroup({
+      sources,
+      currentIndexForSourceGroup: this.currentIndexForSourceGroup,
+      count: this.get('count'),
+      isLocal: (id) => {
+        return Sources.getHarvested().includes(id)
       },
-      {
-        local: 1,
-        ...federatedSources.reduce((blob, id) => {
-          blob[id] = 1
-          return blob
-        }, {}),
-        ...this.currentIndexForSourceGroup,
-      }
-    )
+    })
   },
-})
-module.exports = Query
+  getCurrentStartAndEndForSourceGroup() {
+    return getCurrentStartAndEndForSourceGroup({
+      currentIndexForSourceGroup: this.currentIndexForSourceGroup,
+      queryStatus: this.get('result')?.get('lazyResults')?.status,
+    })
+  },
+} as QueryType)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/permanent-search-sort.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/permanent-search-sort.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import SortSelections from './sort-selections'
 import { useBackbone } from '../../component/selection-checkbox/useBackbone.hook'
+import { QueryType } from '../../js/model/Query'
 
 type Props = {
-  model: Backbone.Model
+  model: QueryType
 }
 
 /**

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/user.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/user.tsx
@@ -23,7 +23,7 @@ import {
   useActingRole,
 } from '../../component/singletons/TypedUser'
 import PersonIcon from '@material-ui/icons/Person'
-import { SvgIconProps } from '@material-ui/core'
+import { SvgIconProps } from '@material-ui/core/SvgIcon'
 const user = require('../../component/singletons/user-instance.js')
 
 export type AvailableRoleType = {

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -3252,6 +3252,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.isequalwith@4.4.7":
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequalwith/-/lodash.isequalwith-4.4.7.tgz#b776265bd92873173261ac6d5d6c7d554f68f1c4"
+  integrity sha512-GdI984QbZw+LGAd3jcFIIhaMwhlVasTMIT3nmE1rOcACjyzp9J9VjTENVkl9aJLOiPZt6RYSJFVEEsRHKbdh3w==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.165"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
@@ -13107,6 +13114,11 @@ lodash.isequal@^4.0.0, lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
+lodash.isequalwith@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
+  integrity sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ==
+
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
@@ -19805,10 +19817,10 @@ ts-pnp@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
 
-tslib@2.2.0, tslib@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
@@ -19818,6 +19830,11 @@ tslib@^1.10.0, tslib@^1.9.0:
 tslib@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+
+tslib@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@~1.10.0:
   version "1.10.0"


### PR DESCRIPTION
-  Enables usage of our base search for doing advanced paging (next page, last page, better index tracking versus x of y possible - now we can say something like 10-15 if we'd like).
- Updates async tasks to allow generic save / create tasks
- Adds unit tests around paging to prevent future regressions.
- Updates Query model to be typescript so we can have better type checking around it.
- Updates Query to allow custom page sizes (previously we always used the user pref), so even passing a count was simply ignored in the end.
