### PR TITLE
Fix async task save to use update instead of create

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -559,7 +559,7 @@ class SaveTask extends AsyncTask {
       const payload = {
         id: '1',
         jsonrpc: '2.0',
-        method: 'ddf.catalog/create',
+        method: 'ddf.catalog/update',
         params: {
           metacards: [
             {


### PR DESCRIPTION
Fix the async save to use update instead of create. Using update causes the correct plugin action to be taken in the backend catalog
