### PR TITLE
Use download action provider (if it exists) for UI download

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -144,7 +144,7 @@ const dynamicActionClasses = 'h-full'
 const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
   const triggerDownload = (e: any) => {
     e.stopPropagation()
-    window.open(lazyResult.plain.metacard.properties['resource-download-url'])
+    window.open(lazyResult.getDownloadUrl())
   }
   const metacardInteractionMenuState = useMenuState()
   return (
@@ -222,7 +222,7 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
         ) : null}
       </Grid>
       <Grid item className={dynamicActionClasses}>
-        {lazyResult.isDownloadable() ? (
+        {lazyResult.getDownloadUrl() ? (
           <Button
             component="div"
             data-id="download-button"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -333,7 +333,7 @@ export class LazyQueryResult {
   getDownloadUrl(): string {
     const downloadAction = this.plain.actions.find(
       (action) =>
-        action.id === 'catalog.data.metacard.resource.deployed-download'
+        action.id === 'catalog.data.metacard.resource.alternate-download'
     )
 
     return downloadAction

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -330,8 +330,15 @@ export class LazyQueryResult {
     })
     this.syncWithPlain()
   }
-  isDownloadable(): boolean {
-    return this.plain.metacard.properties['resource-download-url'] !== undefined
+  getDownloadUrl(): string {
+    const downloadAction = this.plain.actions.find(
+      (action) =>
+        action.id === 'catalog.data.metacard.resource.deployed-download'
+    )
+
+    return downloadAction
+      ? downloadAction.url
+      : this.plain.metacard.properties['resource-download-url']
   }
   getPreview(): string {
     return this.plain.metacard.properties['ext.extracted.text']

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/download-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/download-interaction.tsx
@@ -20,14 +20,13 @@ import { hot } from 'react-hot-loader'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
 
 const openValidUrl = (result: LazyQueryResult) => {
-  const downloadUrl = result.plain.metacard.properties['resource-download-url']
+  const downloadUrl = result.getDownloadUrl()
   downloadUrl && window.open(downloadUrl)
 }
 
-const isDownloadable = (model: LazyQueryResult[]): boolean =>
-  model.some(
-    (result) => result.plain.metacard.properties['resource-download-url']
-  )
+const isDownloadable = (model: LazyQueryResult[]): boolean => {
+  return model.some((result) => result.getDownloadUrl())
+}
 
 const handleDownload = (model: LazyQueryResult[]) => {
   model.forEach(openValidUrl)


### PR DESCRIPTION
#### What does this PR do, and why?
Updates the download functionality to use the download action url if it exists on the result. If the download action does not exist on the result, fallback to the existing download functionality (use the resource-download-url).