### PR TITLE
Update to change how we handle possible infinite loops with preference saving

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -235,13 +235,10 @@ const Theme = Backbone.Model.extend({
     if (this.parents[0].isGuestUser()) {
       window.localStorage.setItem('preferences', JSON.stringify(currentPrefs))
     } else {
+      this.lastSaved = Common.duplicate(currentPrefs)
       this.save(currentPrefs, {
         drop: true,
-        wait: true,
         customErrorHandling: true,
-        success: () => {
-          this.lastSaved = Common.duplicate(currentPrefs)
-        },
         error: () => {
           ;(wreqr as any).vent.trigger('snack', {
             message:


### PR DESCRIPTION
 - Previously we tried the wait method, but that changes some things downstream causing slight issues.
 - The new method will instead update lastSaved as soon as the request is sent, so further duplicate saves get stopped.