### PR TITLE
Unescape the Source ID for multi-exports

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -105,7 +105,11 @@ class ResultsExport extends React.Component<Props, State> {
   }
 
   getResultSources() {
-    return new Set(this.props.results.map((result: Result) => result.source))
+    return new Set(
+      this.props.results
+        .map((result: Result) => result.source)
+        .map((source: string) => decodeURIComponent(source))
+    )
   }
 
   getSelectedExportFormatId() {


### PR DESCRIPTION
The source id needs to be unescaped for multi-exports because the backend does not expect them to be escaped.

To test, create a source with a space in its identifier. Ingest some records for that source. Search for those records and select two or more. Then using the intereactions menu, export as CSV. Confirm that the export contains the expected results.