### PR TITLE
Update timeout logic to not depend on return text of endpoint

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.ts
@@ -111,11 +111,9 @@ const sessionTimeoutModel = new (Backbone.Model.extend({
     }
     fetch(invalidateUrl + window.location.href, {
       redirect: 'manual',
+    }).finally(() => {
+      window.location.reload()
     })
-      .then((response) => response.text())
-      .then((text) => {
-        window.location.replace(text)
-      })
   },
   renew() {
     this.hidePrompt()


### PR DESCRIPTION
 - Reloading the page on the current url has the same desired effect and is not prone to issues.