### PR TITLE
Adds zoom in / zoom out controls that work across each map

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -72,6 +72,9 @@ export const MuiOutlinedInputBorderClasses =
   'MuiOutlinedInput-root MuiOutlinedInput-multiline MuiOutlinedInput-inputMarginDense MuiOutlinedInput-notchedOutline border'
 
 const GlobalStyles = createGlobalStyle<ThemeInterface>`
+      .ol-overlaycontainer-stopevent {
+        display: none;
+      }
       a {
         color: inherit !important;
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
@@ -1049,6 +1049,12 @@ export default function CesiumMap(
     getMap() {
       return map
     },
+    zoomIn() {
+      map.scene.camera.zoomIn(map.scene.camera.defaultZoomAmount * 10)
+    },
+    zoomOut() {
+      map.scene.camera.zoomOut(map.scene.camera.defaultZoomAmount * 10)
+    },
     destroy() {
       ;(wreqr as any).vent.off('map:requestRender', requestRenderHandler)
       map.destroy()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
@@ -497,24 +497,26 @@ export const MapViewReact = (props: MapViewReactType) => {
           <>
             <Paper
               elevation={Elevations.overlays}
-              className="py-2 z-10 absolute right-0 bottom-0 mr-4 mb-4"
+              className="p-2 z-10 absolute right-0 bottom-0 mr-4 mb-4"
             >
               <div>
                 <Button
+                  size="small"
                   onClick={() => {
                     map.zoomIn()
                   }}
                 >
-                  <PlusIcon />
+                  <PlusIcon className="  h-5 w-5" />
                 </Button>
               </div>
               <div>
                 <Button
+                  size="small"
                   onClick={() => {
                     map.zoomOut()
                   }}
                 >
-                  <MinusIcon />
+                  <MinusIcon className="  h-5 w-5" />
                 </Button>
               </div>
             </Paper>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
@@ -31,6 +31,12 @@ import { SHAPE_ID_PREFIX } from './drawing-and-display'
 import useSnack from '../../hooks/useSnack'
 import { zoomToHome } from './home'
 import featureDetection from '../../singletons/feature-detection'
+import Paper from '@material-ui/core/Paper'
+import { Elevations } from '../../theme/theme'
+import Button from '@material-ui/core/Button'
+import PlusIcon from '@material-ui/icons/Add'
+import MinusIcon from '@material-ui/icons/Remove'
+
 const useMapCode = (props: MapViewReactType) => {
   const [mapCode, setMapCode] = React.useState<any>(null)
   React.useEffect(() => {
@@ -486,6 +492,33 @@ export const MapViewReact = (props: MapViewReactType) => {
               setIsClustering(!isClustering)
             }}
           />
+        ) : null}
+        {map ? (
+          <>
+            <Paper
+              elevation={Elevations.overlays}
+              className="py-2 z-10 absolute right-0 bottom-0 mr-4 mb-4"
+            >
+              <div>
+                <Button
+                  onClick={() => {
+                    map.zoomIn()
+                  }}
+                >
+                  <PlusIcon />
+                </Button>
+              </div>
+              <div>
+                <Button
+                  onClick={() => {
+                    map.zoomOut()
+                  }}
+                >
+                  <MinusIcon />
+                </Button>
+              </div>
+            </Paper>
+          </>
         ) : null}
       </div>
       <div

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -250,13 +250,13 @@ export default function (
     },
     doPanZoom(coords: any) {
       const that = this
-      that.zoomOut({ duration: 1000 }, () => {
+      that.panZoomOut({ duration: 1000 }, () => {
         setTimeout(() => {
           that.zoomToExtent(coords, { duration: 2000 })
         }, 0)
       })
     },
-    zoomOut(_opts: any, next: any) {
+    panZoomOut(_opts: any, next: any) {
       next()
     },
     panToResults(results: any) {
@@ -917,6 +917,16 @@ export default function (
     },
     getMap() {
       return map
+    },
+    zoomIn() {
+      const view = map.getView()
+      const zoom = view.getZoom()
+      view.setZoom(zoom + 1)
+    },
+    zoomOut() {
+      const view = map.getView()
+      const zoom = view.getZoom()
+      view.setZoom(zoom - 1)
     },
     destroy() {
       unlistenToResize()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/Environment.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/Environment.tsx
@@ -13,7 +13,7 @@
  *
  **/
 // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name '__ENV__'.
-console.log(__ENV__) // moving this here as it's useful to see at least once
+console.info(__ENV__) // moving this here as it's useful to see at least once
 export const Environment = {
   isTest() {
     // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name '__ENV__'.

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layers.tsx
@@ -179,10 +179,6 @@ export class CesiumLayers extends Subscribable<''> {
       prev: this.layerOrder,
       cur: newLayerOrder,
     })
-    // const name = this.collection.models
-    //   .find(model => model.id === layer)
-    //   .get('name')
-    //console.log(method + ' ' + name + ' ' + count) // useful for debugging!
     _.times(
       count,
       () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.methods.tsx
@@ -109,7 +109,7 @@ export const getMaxIndexForSourceGroup = ({
   isLocal: (id: string) => boolean
 }): IndexForSourceGroupType => {
   if (Object.keys(queryStatus).length === 0) {
-    console.log(
+    console.warn(
       'Invalid invocation:  queryStatus is required to determine max index for a query'
     )
     return {}


### PR DESCRIPTION
![Screen Shot 2023-02-07 at 3 11 21 PM](https://user-images.githubusercontent.com/11984853/217378509-aa0e9c45-1bc9-4060-b502-c0aa569c3d67.png)

Not much to this one, but we recently updated our css and hid the native openlayers zoom in / out buttons.  This brings them back, but at the base map component level so they exist on cesium now as well.