### PR TITLE
Fix issue with inspector "export as" dialog closing immediately

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.tsx
@@ -36,7 +36,7 @@ const SelectedResults = ({ selectionInterface }: any) => {
     selectionInterface,
   })
   const selectedResultsArray = Object.values(selectedResults)
-  const { MuiButtonProps, MuiPopoverProps } = useMenuState()
+  const { MuiButtonProps, MuiPopoverProps, handleClose } = useMenuState()
 
   return (
     <>
@@ -60,11 +60,11 @@ const SelectedResults = ({ selectionInterface }: any) => {
           <MoreIcon />
         </div>
       </Button>
-      <Popover {...MuiPopoverProps}>
+      <Popover {...MuiPopoverProps} keepMounted={true}>
         <Paper>
           <LazyMetacardInteractions
             lazyResults={selectedResultsArray}
-            onClose={() => {}}
+            onClose={handleClose}
           />
         </Paper>
       </Popover>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
@@ -83,7 +83,7 @@ export const TitleView = ({ lazyResult }: TitleViewType) => {
       <Button {...menuState.MuiButtonProps}>
         <MoreVertIcon />
       </Button>
-      <Popover {...menuState.MuiPopoverProps}>
+      <Popover {...menuState.MuiPopoverProps} keepMounted={true}>
         <Paper elevation={Elevations.overlays}>
           <LazyMetacardInteractions
             lazyResults={[lazyResult]}


### PR DESCRIPTION
 - We rely on keepMounted, since the dialog is contained within the popover component.
 - Updated result selector which uses the same component to be similar, since it worked instead by not closing the popover when the dialog opened.