### PR TITLE
Add 'featured attributes' configuration

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -201,6 +201,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private List<String> attributeSuggestionList = Collections.emptyList();
 
+  private List<String> featuredAttributes = Collections.emptyList();
+
   private Map<String, String> attributeDescriptions = Collections.emptyMap();
 
   private List<String> listTemplates = Collections.emptyList();
@@ -437,6 +439,10 @@ public class ConfigurationApplication implements SparkApplication {
     this.attributeSuggestionList = list;
   }
 
+  public void setFeaturedAttributes(List<String> featuredAttributes) {
+    this.featuredAttributes = featuredAttributes;
+  }
+
   public void setListTemplates(List<String> listTemplates) {
     this.listTemplates = listTemplates;
   }
@@ -603,6 +609,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("useHyphensInUuid", uuidGenerator.useHyphens());
     config.put("i18n", i18n);
     config.put("attributeSuggestionList", attributeSuggestionList);
+    config.put("featuredAttributes", featuredAttributes);
     config.put("defaultSources", defaultSources);
     config.put("defaultTableColumns", defaultTableColumns);
     config.put("helpUrl", helpUrl);

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -117,6 +117,10 @@ Implementation details
                 update-strategy="container-managed"/>
 
         <cm:managed-properties
+                persistent-id="org.codice.ddf.catalog.ui.attribute.featuredAttributes"
+                update-strategy="container-managed"/>
+
+        <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.ui.attribute.descriptions"
                 update-strategy="container-managed"/>
 

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
@@ -44,16 +44,33 @@ Note: Attributes must also be listed under the Facet Attribute Whitelist for thi
             />
     </OCD>
 
+    <OCD name="Catalog UI Search Featured Attributes" id="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
+        <AD id="featuredAttributes"
+            name="Featured Attributes"
+            description="The attributes that will be placed at the top of the drop-down list displayed when choosing an
+            attribute in the advanced search menu. Useful when there are commonly-used attributes you would like to
+            feature to make searching easier for users. The attributes will be displayed in the order in which they are
+            set here. The remaining attributes will be displayed below these in alphabetical order."
+            type="String"
+            cardinality="10000"
+            required="false"
+        />
+    </OCD>
+
     <Designate pid="org.codice.ddf.catalog.ui.attribute.suggestionList">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.suggestionList"/>
     </Designate>
-    
+
     <Designate pid="org.codice.ddf.catalog.ui.attribute.hidden">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.hidden"/>
     </Designate>
 
     <Designate pid="org.codice.ddf.catalog.ui.attribute.descriptions">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.descriptions"/>
+    </Designate>
+
+    <Designate pid="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
+        <Object ocdref="org.codice.ddf.catalog.ui.attribute.featuredAttributes"/>
     </Designate>
 
 </metatype:MetaData>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
@@ -75,6 +75,7 @@ const properties = {
     'form.title': 'title',
   },
   attributeAliases: {},
+  featuredAttributes: [],
   filters: {
     METADATA_CONTENT_TYPE: 'metadata-content-type',
     SOURCE_ID: 'source-id',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -14,19 +14,36 @@
  **/
 import metacardDefinitions from '../../component/singletons/metacard-definitions'
 import properties from '../../js/properties'
-export const getFilteredAttributeList = () => {
+type Attribute = {
+  label: string
+  value: string
+  description: string | undefined
+}
+type StringNumberMap = { [key: string]: number }
+export const getFilteredAttributeList = (): Attribute[] => {
+  const featuredSorts: StringNumberMap = properties.featuredAttributes.reduce((sorts: StringNumberMap, attr: string, index: number) => {
+    // don't want 0 in the map so we can do truth checks on the map's values
+    sorts[attr] = index + 1
+    return sorts
+  }, {})
   return metacardDefinitions.sortedMetacardTypes
-    .filter(({ id }: any) => !properties.isHidden(id))
-    .filter(({ id }: any) => !metacardDefinitions.isHiddenType(id))
-    .map(({ alias, id }: any) => ({
-      label: alias || id,
-      value: id,
-      description: ((properties as any).attributeDescriptions || {})[id],
-    })) as {
-    label: string
-    value: string
-    description: string | undefined
-  }[]
+    .reduce((filteredAttributes: Attribute[], attribute: { alias: string, id: string }) => {
+      if (!properties.isHidden(attribute.id) && !metacardDefinitions.isHiddenType(attribute.id)) {
+        filteredAttributes.push({
+          label: attribute.alias || attribute.id,
+          value: attribute.id,
+          description: (properties.attributeDescriptions || {})[attribute.id],
+        })
+      }
+      return filteredAttributes
+    }, [])
+    .sort((a: Attribute, b: Attribute) => {
+      const aSort = featuredSorts[a.value] || Number.MAX_SAFE_INTEGER
+      const bSort = featuredSorts[b.value] || Number.MAX_SAFE_INTEGER
+      // for non-featured attributes, we can return 0 instead of the comparison of the attributes
+      // since the original list was sorted
+      return aSort - bSort
+    })
 }
 export const getAttributeType = (attribute: string): string => {
   const type = metacardDefinitions.metacardTypes[attribute].type

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
@@ -92,6 +92,7 @@ export default {
   hiddenAttributes: ['^sorts$', '^cql$', '^polling$', '^cached$'],
   timeout: 300000,
   attributeAliases: {},
+  featuredAttributes: [],
   enums: {},
   queryFeedbackEnabled: false,
   editorAttributes: [],


### PR DESCRIPTION
Admins can now set a list of 'featured attributes', which will be placed at the top of the drop-down list displayed when choosing an attribute in the advanced search menu.