### PR TITLE
Add 'featured attributes' configuration

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -201,7 +201,7 @@ public class ConfigurationApplication implements SparkApplication {
 
   private List<String> attributeSuggestionList = Collections.emptyList();
 
-  private List<String> featuredAttributes = Collections.emptyList();
+  private List<String> commonAttributes = Collections.emptyList();
 
   private Map<String, String> attributeDescriptions = Collections.emptyMap();
 
@@ -439,8 +439,8 @@ public class ConfigurationApplication implements SparkApplication {
     this.attributeSuggestionList = list;
   }
 
-  public void setFeaturedAttributes(List<String> featuredAttributes) {
-    this.featuredAttributes = featuredAttributes;
+  public void setCommonAttributes(List<String> commonAttributes) {
+    this.commonAttributes = commonAttributes;
   }
 
   public void setListTemplates(List<String> listTemplates) {
@@ -609,7 +609,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("useHyphensInUuid", uuidGenerator.useHyphens());
     config.put("i18n", i18n);
     config.put("attributeSuggestionList", attributeSuggestionList);
-    config.put("featuredAttributes", featuredAttributes);
+    config.put("commonAttributes", commonAttributes);
     config.put("defaultSources", defaultSources);
     config.put("defaultTableColumns", defaultTableColumns);
     config.put("helpUrl", helpUrl);

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -201,6 +201,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private List<String> attributeSuggestionList = Collections.emptyList();
 
+  private List<String> featuredAttributes = Collections.emptyList();
+
   private Map<String, String> attributeDescriptions = Collections.emptyMap();
 
   private List<String> listTemplates = Collections.emptyList();
@@ -437,6 +439,10 @@ public class ConfigurationApplication implements SparkApplication {
     this.attributeSuggestionList = list;
   }
 
+  public void setFeaturedAttributes(List<String> featuredAttributes) {
+    this.featuredAttributes = featuredAttributes;
+  }
+
   public void setListTemplates(List<String> listTemplates) {
     this.listTemplates = listTemplates;
   }
@@ -603,6 +609,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("useHyphensInUuid", uuidGenerator.useHyphens());
     config.put("i18n", i18n);
     config.put("attributeSuggestionList", attributeSuggestionList);
+    config.put("featuredAttributes", featuredAttributes);
     config.put("defaultSources", defaultSources);
     config.put("defaultTableColumns", defaultTableColumns);
     config.put("helpUrl", helpUrl);

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -117,6 +117,10 @@ Implementation details
                 update-strategy="container-managed"/>
 
         <cm:managed-properties
+                persistent-id="org.codice.ddf.catalog.ui.attribute.featuredAttributes"
+                update-strategy="container-managed"/>
+
+        <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.ui.attribute.descriptions"
                 update-strategy="container-managed"/>
 

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -117,7 +117,7 @@ Implementation details
                 update-strategy="container-managed"/>
 
         <cm:managed-properties
-                persistent-id="org.codice.ddf.catalog.ui.attribute.featuredAttributes"
+                persistent-id="org.codice.ddf.catalog.ui.attribute.commonAttributes"
                 update-strategy="container-managed"/>
 
         <cm:managed-properties

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
@@ -48,9 +48,11 @@ Note: Attributes must also be listed under the Facet Attribute Whitelist for thi
         <AD id="featuredAttributes"
             name="Featured Attributes"
             description="The attributes that will be placed at the top of the drop-down list displayed when choosing an
-            attribute in the advanced search menu. Useful when there are commonly-used attributes you would like to
-            feature to make searching easier for users. The attributes will be displayed in the order in which they are
-            set here. The remaining attributes will be displayed below these in alphabetical order."
+            attribute in the advanced search menu. Setting this will cause the attributes in this menu to be grouped.
+            The first group is 'Common Attributes' and consists solely of the attributes set here, in the specified
+            order. The second group is 'All Attributes' and contains every searchable attribute in alphabetical order,
+            including the ones specified here. Use this setting when there are commonly-used attributes you would like
+            to feature to make searching easier for users."
             type="String"
             cardinality="10000"
             required="false"

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
@@ -44,9 +44,9 @@ Note: Attributes must also be listed under the Facet Attribute Whitelist for thi
             />
     </OCD>
 
-    <OCD name="Catalog UI Search Featured Attributes" id="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
-        <AD id="featuredAttributes"
-            name="Featured Attributes"
+    <OCD name="Catalog UI Search Common Attributes" id="org.codice.ddf.catalog.ui.attribute.commonAttributes">
+        <AD id="commonAttributes"
+            name="Common Attributes"
             description="The attributes that will be placed at the top of the drop-down list displayed when choosing an
             attribute in the advanced search menu. Setting this will cause the attributes in this menu to be grouped.
             The first group is 'Common Attributes' and consists solely of the attributes set here, in the specified
@@ -71,8 +71,8 @@ Note: Attributes must also be listed under the Facet Attribute Whitelist for thi
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.descriptions"/>
     </Designate>
 
-    <Designate pid="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
-        <Object ocdref="org.codice.ddf.catalog.ui.attribute.featuredAttributes"/>
+    <Designate pid="org.codice.ddf.catalog.ui.attribute.commonAttributes">
+        <Object ocdref="org.codice.ddf.catalog.ui.attribute.commonAttributes"/>
     </Designate>
 
 </metatype:MetaData>

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.attribute.xml
@@ -44,16 +44,33 @@ Note: Attributes must also be listed under the Facet Attribute Whitelist for thi
             />
     </OCD>
 
+    <OCD name="Catalog UI Search Featured Attributes" id="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
+        <AD id="featuredAttributes"
+            name="Featured Attributes"
+            description="The attributes that will be placed at the top of the drop-down list displayed when choosing an
+            attribute in the advanced search menu. Useful when there are commonly-used attributes you would like to
+            feature to make searching easier for users. The attributes will be displayed in the order in which they are
+            set here. The remaining attributes will be displayed below these in alphabetical order."
+            type="String"
+            cardinality="10000"
+            required="false"
+        />
+    </OCD>
+
     <Designate pid="org.codice.ddf.catalog.ui.attribute.suggestionList">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.suggestionList"/>
     </Designate>
-    
+
     <Designate pid="org.codice.ddf.catalog.ui.attribute.hidden">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.hidden"/>
     </Designate>
 
     <Designate pid="org.codice.ddf.catalog.ui.attribute.descriptions">
         <Object ocdref="org.codice.ddf.catalog.ui.attribute.descriptions"/>
+    </Designate>
+
+    <Designate pid="org.codice.ddf.catalog.ui.attribute.featuredAttributes">
+        <Object ocdref="org.codice.ddf.catalog.ui.attribute.featuredAttributes"/>
     </Designate>
 
 </metatype:MetaData>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
@@ -75,6 +75,7 @@ const properties = {
     'form.title': 'title',
   },
   attributeAliases: {},
+  featuredAttributes: [],
   filters: {
     METADATA_CONTENT_TYPE: 'metadata-content-type',
     SOURCE_ID: 'source-id',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/properties.ts
@@ -75,7 +75,7 @@ const properties = {
     'form.title': 'title',
   },
   attributeAliases: {},
-  featuredAttributes: [],
+  commonAttributes: [],
   filters: {
     METADATA_CONTENT_TYPE: 'metadata-content-type',
     SOURCE_ID: 'source-id',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
@@ -17,7 +17,7 @@ import * as React from 'react'
 
 import FilterComparator from './filter-comparator'
 import FilterInput from './filter-input'
-import { getFilteredAttributeList } from './filterHelper'
+import { Attribute, getGroupedFilteredAttributes } from './filterHelper'
 import Grid from '@material-ui/core/Grid'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 
@@ -32,24 +32,22 @@ type Props = {
 }
 
 export const FilterContext = React.createContext({
-  limitedAttributeList: undefined as
-    | undefined
-    | {
-        label: string
-        value: string
-        description: string | undefined
-      }[],
+  limitedAttributeList: undefined as undefined | Attribute[],
 })
 const Filter = ({ filter, setFilter }: Props) => {
   const { limitedAttributeList } = React.useContext(FilterContext)
+  let attributeList = limitedAttributeList
+  let groups = 1
+  if (!attributeList) {
+    const groupedFilteredAttributes = getGroupedFilteredAttributes()
+    attributeList = groupedFilteredAttributes.attributes
+    groups = groupedFilteredAttributes.groups.length
+  }
   const { property } = filter
-  const attributeList =
-    limitedAttributeList !== undefined
-      ? limitedAttributeList
-      : getFilteredAttributeList()
   const currentSelectedAttribute = attributeList.find(
     (attrInfo) => attrInfo.value === property
   )
+  const groupBy = groups > 1 ? (option: Attribute) => option.group : undefined
   return (
     <Grid container direction="column" alignItems="center" className="w-full">
       <Grid item className="w-full pb-2">
@@ -58,6 +56,7 @@ const Filter = ({ filter, setFilter }: Props) => {
           fullWidth
           size="small"
           options={attributeList}
+          groupBy={groupBy}
           getOptionLabel={(option) => option.label}
           getOptionSelected={(option, value) => option.value === value.value}
           onChange={(_e, newValue) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
@@ -47,7 +47,7 @@ const Filter = ({ filter, setFilter }: Props) => {
   const currentSelectedAttribute = attributeList.find(
     (attrInfo) => attrInfo.value === property
   )
-  const groupBy = groups > 1 ? (option: Attribute) => option.group : undefined
+  const groupBy = groups > 1 ? (option: Attribute) => option.group! : undefined
   return (
     <Grid container direction="column" alignItems="center" className="w-full">
       <Grid item className="w-full pb-2">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -45,9 +45,9 @@ export const getGroupedFilteredAttributes = (): {
     },
     {}
   )
-  const validFeaturedAttributes = (properties.featuredAttributes as string[]).reduce(
-    (attributes: Attribute[], featuredId: string) => {
-      const attribute = allAttributes[featuredId]
+  const validCommonAttributes = (properties.commonAttributes as string[]).reduce(
+    (attributes: Attribute[], id: string) => {
+      const attribute = allAttributes[id]
       if (attribute) {
         attributes.push(toAttribute(attribute, 'Common Attributes'))
       }
@@ -55,11 +55,11 @@ export const getGroupedFilteredAttributes = (): {
     },
     []
   )
-  const groupedFilteredAttributes = validFeaturedAttributes.concat(
+  const groupedFilteredAttributes = validCommonAttributes.concat(
     getFilteredAttributeList('All Attributes')
   )
   const groups =
-    validFeaturedAttributes.length > 0
+    validCommonAttributes.length > 0
       ? ['Common Attributes', 'All Attributes']
       : []
   return {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -31,7 +31,10 @@ const toAttribute = (
     group,
   }
 }
-export const getGroupedFilteredAttributes = (): { groups: string[], attributes: Attribute[] } => {
+export const getGroupedFilteredAttributes = (): {
+  groups: string[]
+  attributes: Attribute[]
+} => {
   const allAttributes = metacardDefinitions.sortedMetacardTypes.reduce(
     (
       attributes: { [key: string]: { id: string; alias: string } },
@@ -55,7 +58,10 @@ export const getGroupedFilteredAttributes = (): { groups: string[], attributes: 
   const groupedFilteredAttributes = validFeaturedAttributes.concat(
     getFilteredAttributeList('All Attributes')
   )
-  const groups = validFeaturedAttributes.length > 0 ? ['Common Attributes', 'All Attributes'] : []
+  const groups =
+    validFeaturedAttributes.length > 0
+      ? ['Common Attributes', 'All Attributes']
+      : []
   return {
     groups,
     attributes: groupedFilteredAttributes,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
@@ -92,7 +92,7 @@ export default {
   hiddenAttributes: ['^sorts$', '^cql$', '^polling$', '^cached$'],
   timeout: 300000,
   attributeAliases: {},
-  featuredAttributes: [],
+  commonAttributes: [],
   enums: {},
   queryFeedbackEnabled: false,
   editorAttributes: [],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.ts
@@ -92,6 +92,7 @@ export default {
   hiddenAttributes: ['^sorts$', '^cql$', '^polling$', '^cached$'],
   timeout: 300000,
   attributeAliases: {},
+  featuredAttributes: [],
   enums: {},
   queryFeedbackEnabled: false,
   editorAttributes: [],


### PR DESCRIPTION
https://user-images.githubusercontent.com/4495447/219789713-92318450-3459-430a-b99f-4bfbf225684c.mp4

<br>
Configure the 'featured attributes' in the Admin UI. In the autocomplete drop-down of the advanced search menu, these attributes will be displayed in their own group at the top, in the order you specified in the configuration, and with the heading 'Common Attributes'. The group below has the heading 'All Attributes' and is the complete, alphabetically sorted list of attributes, including the 'featured attributes'.

<br>
<br>
If no featured attributes are configured, then there will be no groups or headers in the drop-down and the list will be displayed as it usually is.