### PR TITLE
Turn on debouncing for lazy query results

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResults.tsx
@@ -19,7 +19,7 @@ import { QuerySortType } from './types'
 import { Status } from './status'
 import { TransformSortsComposedFunctionType } from '../TypedQuery'
 import _ from 'underscore'
-const debounceTime = 50
+const debounceTime = 250
 
 import Backbone from 'backbone'
 
@@ -283,6 +283,7 @@ export class LazyQueryResults {
     sources = [],
     transformSorts,
   }: ConstructorProps = {}) {
+    this._turnOnDebouncing()
     this.reset({ results, sorts, sources, transformSorts })
 
     this.backboneModel = new Backbone.Model({


### PR DESCRIPTION
 - Sets the time to 250ms for now.  This allows us to handle larger sets of results without having to change much of the code around subscriptions / selecting.
 - Note that this is specifically debouncing notifying those who subscribe to the events in lazy query results.