### PR TITLE
Pass the user selected sort parameters to multi-select exports

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
@@ -28,6 +28,9 @@ export const ExportActions = (props: MetacardInteractionProps) => {
   if (!props.model || props.model.length <= 0) {
     return null
   }
+  if (!props.model[0].parent || !props.model[0].parent.persistantSorts) {
+    return null
+  }
   return (
     <>
       <exportDialogState.MuiDialogComponents.Dialog
@@ -47,7 +50,10 @@ export const ExportActions = (props: MetacardInteractionProps) => {
           </div>
         </exportDialogState.MuiDialogComponents.DialogTitle>
         <Divider></Divider>
-        <ResultsExport results={getExportResults(props.model)} />
+        <ResultsExport
+          results={getExportResults(props.model)}
+          sorts={props.model[0].parent.persistantSorts}
+        />
       </exportDialogState.MuiDialogComponents.Dialog>
       <MetacardInteraction
         onClick={() => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
@@ -28,7 +28,7 @@ export const ExportActions = (props: MetacardInteractionProps) => {
   if (!props.model || props.model.length <= 0) {
     return null
   }
-  if (!props.model[0].parent || !props.model[0].parent.persistantSorts) {
+  if (!props.model[0].parent) {
     return null
   }
   return (
@@ -52,7 +52,7 @@ export const ExportActions = (props: MetacardInteractionProps) => {
         <Divider></Divider>
         <ResultsExport
           results={getExportResults(props.model)}
-          sorts={props.model[0].parent.persistantSorts}
+          lazyQueryResults={props.model[0].parent}
         />
       </exportDialogState.MuiDialogComponents.Dialog>
       <MetacardInteraction

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -20,6 +20,7 @@ import { exportResult, exportResultSet } from '../utils/export'
 import { getResultSetCql } from '../utils/cql'
 import saveFile from '../utils/save-file'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
+import { QuerySortType } from '../../js/model/LazyQueryResult/types'
 
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'cont... Remove this comment to see the full error message
 import contentDisposition from 'content-disposition'
@@ -37,6 +38,7 @@ type Result = {
 
 type Props = {
   results: Result[]
+  sorts: QuerySortType[]
   isZipped?: boolean
 } & WithBackboneProps
 
@@ -159,7 +161,7 @@ class ResultsExport extends React.Component<Props, State> {
       response = await exportResultSet(uriEncodedTransformerId, {
         searches,
         count,
-        sorts: [],
+        sorts: this.props.sorts,
       })
     } else {
       const result = this.props.results[0]

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -20,7 +20,7 @@ import { exportResult, exportResultSet } from '../utils/export'
 import { getResultSetCql } from '../utils/cql'
 import saveFile from '../utils/save-file'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
-import { QuerySortType } from '../../js/model/LazyQueryResult/types'
+import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResults'
 
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'cont... Remove this comment to see the full error message
 import contentDisposition from 'content-disposition'
@@ -38,7 +38,7 @@ type Result = {
 
 type Props = {
   results: Result[]
-  sorts: QuerySortType[]
+  lazyQueryResults: LazyQueryResults
   isZipped?: boolean
 } & WithBackboneProps
 
@@ -161,7 +161,9 @@ class ResultsExport extends React.Component<Props, State> {
       response = await exportResultSet(uriEncodedTransformerId, {
         searches,
         count,
-        sorts: this.props.sorts,
+        sorts: this.props.lazyQueryResults?.transformSorts({
+          originalSorts: this.props.lazyQueryResults?.persistantSorts,
+        }),
       })
     } else {
       const result = this.props.results[0]


### PR DESCRIPTION
This change addresses an underlying issue where DDF uses an invalid default sort for WFS sources. It also addresses a complaint that the order of exported results does not match the order of the results displayed in the UI.

TESTING:

Setup a federated WFS source. Select multiple results and export as CSV. Confirm that the export file contains the expected results and they they are in the same order as in the Results pane. Try a few different sorting configurations.