### PR TITLE
Move "delete" from tabs to metacard interactions

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -121,6 +121,9 @@ export const TypedUserInstance = {
   canWrite: (result: LazyQueryResult): boolean => {
     return userInstance.canWrite(result.plain.metacard.properties)
   },
+  isAdmin: (result: LazyQueryResult): boolean => {
+    return userInstance.canShare(result.plain.metacard.properties)
+  },
   getResultCount: (): number => {
     return userInstance.get('user').get('preferences').get('resultCount')
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.tsx
@@ -14,7 +14,6 @@
  **/
 import React from 'react'
 import { MetacardOverwrite } from '../../metacard-overwrite/metacard-overwrite.view'
-import MetacardArchive from '../../../react-component/metacard-archive'
 import MetacardActions from '../../../react-component/metacard-actions'
 import MetacardQuality from '../../../react-component/metacard-quality'
 import MetacardHistory from '../../../react-component/metacard-history'
@@ -37,7 +36,6 @@ export const TabNames = {
   History: 'History',
   Quality: 'Quality',
   Actions: 'Actions',
-  Delete: 'Delete',
   Overwrite: 'Overwrite',
 }
 
@@ -49,9 +47,6 @@ const Tabs = {
   History: MetacardHistory,
   Quality: MetacardQuality,
   Actions: MetacardActions,
-  Delete: ({ result }) => {
-    return <MetacardArchive results={[result]} />
-  },
   Overwrite: ({ result }) => {
     return <MetacardOverwrite lazyResult={result} />
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
@@ -126,7 +126,6 @@ const usePossibleMetacardTabs = ({ result }: { result: LazyQueryResult }) => {
         delete copyOfMetacardTabs[TabNames.History]
         delete copyOfMetacardTabs[TabNames.Actions]
         delete copyOfMetacardTabs[TabNames.Overwrite]
-        delete copyOfMetacardTabs[TabNames.Delete]
       }
       if (result.isDeleted()) {
         delete copyOfMetacardTabs[TabNames.History]
@@ -136,7 +135,6 @@ const usePossibleMetacardTabs = ({ result }: { result: LazyQueryResult }) => {
       if (result.isRemote()) {
         delete copyOfMetacardTabs[TabNames.History]
         delete copyOfMetacardTabs[TabNames.Overwrite]
-        delete copyOfMetacardTabs[TabNames.Delete]
         delete copyOfMetacardTabs[TabNames.Quality]
       }
       if (!result.hasPreview()) {
@@ -146,7 +144,6 @@ const usePossibleMetacardTabs = ({ result }: { result: LazyQueryResult }) => {
         delete copyOfMetacardTabs[TabNames.Preview]
       }
       if (!TypedUserInstance.canWrite(result)) {
-        delete copyOfMetacardTabs[TabNames.Delete]
         delete copyOfMetacardTabs[TabNames.Overwrite]
       }
       setPossibleMetacardTabs(copyOfMetacardTabs)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/lazy-metacard-interactions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/lazy-metacard-interactions.tsx
@@ -24,7 +24,11 @@ type Props = {
 }
 
 const LazyMetacardInteractions = ({ lazyResults, onClose }: Props) => {
-  return <MetacardInteractions model={lazyResults} onClose={onClose} />
+  return (
+    <div className="py-3">
+      <MetacardInteractions model={lazyResults} onClose={onClose} />
+    </div>
+  )
 }
 
 export default hot(module)(LazyMetacardInteractions)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-archive/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-archive/container.tsx
@@ -34,6 +34,7 @@ class MetacardArchive extends React.Component<Props, State> {
     const isDeleted = collection.some((result) => {
       return result.isDeleted()
     })
+
     this.state = {
       collection,
       isDeleted,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/archive-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/archive-interaction.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import MetacardArchive from '../metacard-archive'
+import { MetacardInteractionProps } from '.'
+import { MetacardInteraction } from './metacard-interactions'
+import { hot } from 'react-hot-loader'
+import { useDialog } from '../../component/dialog'
+import { Divider } from './metacard-interactions'
+import { TypedUserInstance } from '../../component/singletons/TypedUser'
+
+export const ArchiveAction = (props: MetacardInteractionProps) => {
+  if (!props.model || props.model.length <= 0) {
+    return null
+  }
+
+  const isDeleteAction = props.model.some((result) => {
+    return !result.isDeleted()
+  })
+
+  const canPerformOnAll = props.model.every((result) => {
+    return (
+      TypedUserInstance.isAdmin(result) &&
+      !result.isRemote() &&
+      result.isDeleted() !== isDeleteAction
+    )
+  })
+
+  if (!canPerformOnAll) {
+    return null
+  }
+
+  const dialogContext = useDialog()
+  return (
+    <>
+      <Divider />
+      <MetacardInteraction
+        onClick={() => {
+          props.onClose()
+          if (props.model) {
+            dialogContext.setProps({
+              children: <MetacardArchive results={props.model} />,
+              open: true,
+            })
+          }
+        }}
+        icon={isDeleteAction ? 'fa fa-trash' : 'fa fa-undo'}
+        text={isDeleteAction ? 'Delete' : 'Restore'}
+        help={
+          isDeleteAction ? 'Move item(s) to trash' : 'Move item(s) from trash'
+        }
+      />
+    </>
+  )
+}
+
+export default hot(module)(ArchiveAction)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
@@ -18,6 +18,7 @@ import { MetacardInteractionProps } from '.'
 import { hot } from 'react-hot-loader'
 import Button from '@material-ui/core/Button'
 import { Link } from '../../component/link/link'
+import { Divider } from './metacard-interactions'
 
 const ExpandMetacard = (props: MetacardInteractionProps) => {
   const isRouted = router && router.toJSON().name === 'openMetacard'
@@ -33,16 +34,19 @@ const ExpandMetacard = (props: MetacardInteractionProps) => {
       : `/metacards/${id}`
 
   return (
-    <Button
-      fullWidth
-      component={Link}
-      to={to}
-      variant="text"
-      color="primary"
-      target="_blank"
-    >
-      Open Metacard View
-    </Button>
+    <>
+      <Button
+        fullWidth
+        component={Link}
+        to={to}
+        variant="text"
+        color="primary"
+        target="_blank"
+      >
+        Open Metacard View
+      </Button>
+      <Divider />
+    </>
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/progress-button/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/progress-button/index.tsx
@@ -12,16 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-import ExpandMetacard from '../../react-component/metacard-interactions/expand-interaction'
-import DownloadProduct from '../../react-component/metacard-interactions/download-interaction'
-import ExportActions from '../../react-component/metacard-interactions/export-interaction'
-import ArchiveAction from '../../react-component/metacard-interactions/archive-interaction'
-
-const DefaultItems = [
-  ExpandMetacard,
-  DownloadProduct,
-  ExportActions,
-  ArchiveAction,
-]
-
-export default DefaultItems
+export { default } from './progress-button'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/progress-button/progress-button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/progress-button/progress-button.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import LinearProgress, {
+  LinearProgressProps,
+} from '@material-ui/core/LinearProgress'
+import Button, { ButtonProps } from '@material-ui/core/Button'
+import CircularProgress, {
+  CircularProgressProps,
+} from '@material-ui/core/CircularProgress'
+
+type Props = {
+  children: React.ReactNode
+  style?: React.CSSProperties
+  disabled?: boolean
+  loading?: boolean
+  variant?: ButtonProps['variant']
+  color?: ButtonProps['color']
+  size?: ButtonProps['size']
+  progressVariant?: 'circular' | 'linear'
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
+  buttonProps?: ButtonProps
+  linearProgressProps?: LinearProgressProps
+  circularProgressProps?: CircularProgressProps
+  className?: string
+  dataId?: string
+}
+
+const ProgressButton = (props: Props) => {
+  const {
+    children,
+    style,
+    disabled,
+    loading,
+    variant,
+    color,
+    size,
+    progressVariant,
+    onClick,
+    buttonProps,
+    linearProgressProps,
+    circularProgressProps,
+    className,
+    dataId,
+  } = props
+
+  const Loading = () => {
+    return progressVariant === 'circular' ? (
+      <CircularProgress
+        size={24}
+        className="absolute"
+        {...circularProgressProps}
+      />
+    ) : (
+      <LinearProgress
+        className="absolute w-full h-full opacity-25"
+        {...linearProgressProps}
+      />
+    )
+  }
+
+  return (
+    <Button
+      data-id={dataId}
+      style={style}
+      variant={variant || 'contained'}
+      color={color || 'primary'}
+      size={size}
+      className={`relative ${className}`}
+      disabled={loading || disabled}
+      onClick={onClick}
+      {...buttonProps}
+    >
+      {children}
+      {loading && <Loading />}
+    </Button>
+  )
+}
+
+export default ProgressButton


### PR DESCRIPTION

https://user-images.githubusercontent.com/14789712/220998453-f8d75570-f225-4ba4-82e3-054c01e0113d.mov

Delete/Restore interaction is available when all of the selected products are in the same state (all deleted or all active), are all local, and the user has write permission for all of them.

There is some weird behavior when trying to restore a metacard right after it has been deleted without rerunning the search, but that was happening before (it didnt display that there was an error, but the metacard never restored).

<img width="209" alt="Screenshot 2023-02-23 at 2 30 05 AM" src="https://user-images.githubusercontent.com/14789712/220870125-52fe60fa-2d7e-4669-85c8-38f1766c4712.png">

Testing
1. Upload several products
2. Delete a few (verify single and multi selected works)
3. Run a search on deleted metacard
4. Restore a few (verify single and multi selected works)
5. Run a search on a harvested/federated source and see delete action is not available
6. Login as another user and see that delete action is not available
