### PR TITLE
Change user facing terminology from enhanced to advanced for user role

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/user.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/user/user.tsx
@@ -42,7 +42,7 @@ export const RoleDisplay = () => {
   const enhancedRoles = useEnhancedRoles()
 
   if (actingRole === 'enhanced' && enhancedRoles.length > 0) {
-    return <>Enhanced</>
+    return <>Advanced</>
   }
   return null
 }
@@ -60,7 +60,7 @@ const RolesToggle = () => {
       <div className="font-normal text-lg">Role</div>
       <FormControlLabel
         className="pb-4"
-        label={<Typography variant="body2">Enhanced</Typography>}
+        label={<Typography variant="body2">Advanced</Typography>}
         control={
           <Switch
             color="primary"
@@ -74,7 +74,7 @@ const RolesToggle = () => {
         }
       />
       <div className={`${actingRole === 'user' ? 'opacity-50' : ''}`}>
-        <div className="pb-1 font-normal italic">My Enhanced Roles</div>
+        <div className="pb-1 font-normal italic">My Advanced Roles</div>
         {enhancedRoles.map((role) => {
           return <div className="text-sm">{role}</div>
         })}


### PR DESCRIPTION
Changes the user facing terminology of enhanced roles to advanced roles.  

https://user-images.githubusercontent.com/8962302/221995736-1543b81c-5d49-44e0-8a40-f9505ba7b072.mov

Testing:
1. Add one or more default enhanced roles in user.tsx, line 32. Something like:
   `enhancedRoles: ['Testing'],`
2. Verify that in the user slideout and in the nav bar, the terminology now says "Advanced" instead of "Enhanced".