### PR TITLE
Get sort from user preferences for table-export

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -82,8 +82,11 @@ function getColumnOrder(): string[] {
 function getHiddenFields(): string[] {
   return user.get('user').get('preferences').get('columnHide')
 }
-function getSorts() {
-  return user.get('user').get('preferences').get('resultSort')
+function getSorts(selectionInterface: any) {
+  return (
+    user.get('user').get('preferences').get('resultSort') ||
+    selectionInterface.getCurrentQuery().get('sorts')
+  )
 }
 function getSearches(
   exportSize: string,
@@ -195,7 +198,7 @@ export const getDownloadBody = (downloadInfo: DownloadInfo) => {
     queryRef: query,
   })
   const srcs = getSrcs(selectionInterface)
-  const sorts = getSorts()
+  const sorts = getSorts(selectionInterface)
   const phonetics = query.get('phonetics')
   const spellcheck = query.get('spellcheck')
   const args = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -33,6 +33,7 @@ import { AddSnack } from '../snack/snack.provider'
 import properties from '../../js/properties'
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'cont... Remove this comment to see the full error message
 import contentDisposition from 'content-disposition'
+
 type ExportResponse = {
   displayName: string
   id: string
@@ -80,6 +81,9 @@ function getColumnOrder(): string[] {
 }
 function getHiddenFields(): string[] {
   return user.get('user').get('preferences').get('columnHide')
+}
+function getSorts() {
+  return user.get('user').get('preferences').get('resultSort')
 }
 function getSearches(
   exportSize: string,
@@ -130,9 +134,6 @@ function getExportCount({
   return exportSize === 'all'
     ? getHits(Object.values(result.get('lazyResults').status))
     : Object.keys(result.get('lazyResults').results).length
-}
-function getSorts(selectionInterface: any) {
-  return selectionInterface.getCurrentQuery().get('sorts')
 }
 export const getWarning = (exportCountInfo: ExportCountInfo): string => {
   const exportCount = getExportCount(exportCountInfo)
@@ -194,7 +195,7 @@ export const getDownloadBody = (downloadInfo: DownloadInfo) => {
     queryRef: query,
   })
   const srcs = getSrcs(selectionInterface)
-  const sorts = getSorts(selectionInterface)
+  const sorts = getSorts()
   const phonetics = query.get('phonetics')
   const spellcheck = query.get('spellcheck')
   const args = {


### PR DESCRIPTION
![Untitled copy](https://user-images.githubusercontent.com/14789712/223608347-7687db2e-d2b6-40cf-82d9-1289e943cd26.jpg)
TESTING:
Upload multiple products, and run a * search. Click export > select CSV. Confirm that the export file contains the expected results and they they are in the same order as in the Results pane. Try a few different sorting configurations.