### PR TITLE
 add column adjusting to result table

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -216,7 +216,8 @@ const RowComponent = ({
                         style={{
                           width: `${headerColWidth[index]}`,
                           minWidth: '200px',
-                          height: '100%'
+                          height: '100%',
+                          // borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`
                         }}
                       >
                         {property === 'thumbnail' && thumbnail ? (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -83,7 +83,7 @@ const RowComponent = ({
   measure,
   index,
   results,
-  headerColWidth
+  headerColWidth,
 }: ResultItemFullProps) => {
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
   const [shownAttributes, setShownAttributes] = React.useState(
@@ -121,8 +121,7 @@ const RowComponent = ({
       <div
         className="bg-inherit flex items-strech flex-no-wrap"
         style={{
-          width: shownAttributes.length * 200 + 'px'
-
+          width: shownAttributes.length * 200 + 'px',
         }}
       >
         <div
@@ -171,13 +170,7 @@ const RowComponent = ({
             className="outline-none rounded-none select-text p-0 text-left break-words h-full children-h-full"
           >
             <div className="w-full h-full">
-              <Grid
-                container
-                direction="row"
-                className="h-full"
-                wrap="nowrap"
-                
-              >
+              <Grid container direction="row" className="h-full" wrap="nowrap">
                 {shownAttributes.map((property) => {
                   let value = lazyResult.plain.metacard.properties[
                     property
@@ -202,8 +195,7 @@ const RowComponent = ({
                     }
                   }
                   return (
-                    <div key={property} 
-                  >
+                    <div key={property}>
                       <CellComponent
                         key={property}
                         data-property={`${property}`}
@@ -213,7 +205,7 @@ const RowComponent = ({
                         data-value={`${value}`}
                         style={{
                           width: `${headerColWidth.get(property)}`,
-                          minWidth: '200px'
+                          minWidth: '200px',
                         }}
                       >
                         {property === 'thumbnail' && thumbnail ? (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -178,7 +178,7 @@ const RowComponent = ({
                 wrap="nowrap"
                 
               >
-                {shownAttributes.map((property, index) => {
+                {shownAttributes.map((property) => {
                   let value = lazyResult.plain.metacard.properties[
                     property
                   ] as any
@@ -202,7 +202,7 @@ const RowComponent = ({
                     }
                   }
                   return (
-                    <div key={index} 
+                    <div key={property} 
                   >
                       <CellComponent
                         key={property}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -37,7 +37,7 @@ type ResultItemFullProps = {
   measure: () => void
   index: number
   results: LazyQueryResult[]
-  headerWidth: Array<string>
+  headerColWidth: Array<string>
 }
 export function clearSelection() {
   if (window.getSelection) {
@@ -83,7 +83,7 @@ const RowComponent = ({
   measure,
   index,
   results,
-  headerWidth
+  headerColWidth
 }: ResultItemFullProps) => {
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
   const [shownAttributes, setShownAttributes] = React.useState(
@@ -122,8 +122,9 @@ const RowComponent = ({
         className="bg-inherit flex items-strech flex-no-wrap"
         style={{
           width: shownAttributes.length * 200 + 'px',
-          display: 'grid',
-          gridTemplateColumns: 'repeat(12, 1fr)'
+          // display: 'grid',
+          // gridTemplateColumns: 'repeat(12, 1fr)'
+
         }}
       >
         <div
@@ -213,7 +214,7 @@ const RowComponent = ({
                         } h-full`}
                         data-value={`${value}`}
                         style={{
-                          width: `${headerWidth[index]}`,
+                          width: `${headerColWidth[index]}`,
                           minWidth: '200px',
                           height: '100%'
                         }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -37,7 +37,7 @@ type ResultItemFullProps = {
   measure: () => void
   index: number
   results: LazyQueryResult[]
-  headerColWidth: Array<string>
+  headerColWidth: Map<string, string>
 }
 export function clearSelection() {
   if (window.getSelection) {
@@ -121,9 +121,7 @@ const RowComponent = ({
       <div
         className="bg-inherit flex items-strech flex-no-wrap"
         style={{
-          width: shownAttributes.length * 200 + 'px',
-          // display: 'grid',
-          // gridTemplateColumns: 'repeat(12, 1fr)'
+          width: shownAttributes.length * 200 + 'px'
 
         }}
       >
@@ -214,10 +212,8 @@ const RowComponent = ({
                         } h-full`}
                         data-value={`${value}`}
                         style={{
-                          width: `${headerColWidth[index]}`,
-                          minWidth: '200px',
-                          height: '100%',
-                          // borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`
+                          width: `${headerColWidth.get(property)}`,
+                          minWidth: '200px'
                         }}
                       >
                         {property === 'thumbnail' && thumbnail ? (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -37,8 +37,6 @@ type ResultItemFullProps = {
   measure: () => void
   index: number
   results: LazyQueryResult[]
-  activeIndexMain: any
-  mouseDownMain: Function
   headerWidth: Array<string>
 }
 export function clearSelection() {
@@ -85,8 +83,6 @@ const RowComponent = ({
   measure,
   index,
   results,
-  activeIndexMain,
-  mouseDownMain,
   headerWidth
 }: ResultItemFullProps) => {
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
@@ -97,69 +93,6 @@ const RowComponent = ({
   const { listenTo } = useBackbone()
   const convertToFormat = useCoordinateFormat()
   useRerenderOnBackboneSync({ lazyResult })
-
-  const [activeIndex, setActiveIndex] = React.useState(activeIndexMain)
-  const minCellWidth = 200
-  const [cellWidth, setWidth] = React.useState('200px')
-  
-  const createHeaders = () => {
-    return shownAttributes.map((item) => ({
-      property: item,
-      ref: React.useRef<HTMLDivElement>(null)
-    }))
-  }
-
-  const columns = createHeaders()
-
-  // const mouseDown = (index:any) => {
-  //   setActiveIndex(index);
-  // }
-
-  // const mouseMove = React.useCallback((e) => {
-
-  //   columns.map((col, i) => {
-  //     if (i === activeIndex) {
-  //       if (col.ref.current){
-  //         const width = e.clientX - col.ref.current?.getBoundingClientRect().x
-  //         if (width > minCellWidth){
-  //           col.ref.current.style.width = `${width}px`
-  //           // console.log(width +" "+ i)
-  //           console.log("WIDTH: " + col.ref.current.style.width)
-  //           console.log("HEIGHT: " + col.ref.current.style.height)
-  //           // setWidth(`${headerWidth}px`)
-
-  //         }
-  //       }   
-  //     }
-  
-  //   });
-  //   console.log(headerWidth)
-  
-  // }, [activeIndex, columns])
-
-  // const removeListeners = React.useCallback(() => {
-  //   window.removeEventListener('mousemove', mouseMove)
-  //   window.removeEventListener('mouseup', removeListeners)
-  // }, [mouseMove])
-  
-  // const mouseUp = React.useCallback(() => {
-  //   setActiveIndex(null)
-  //   removeListeners()
-  //   console.log("MOUSE UP")
-  //   // columns[activeIndex].ref.current?.style
-  // }, [setActiveIndex, removeListeners])
-
-  // React.useEffect(() => {
-  //   if (activeIndex !== null) {
-  //     window.addEventListener('mousemove', mouseMove)
-  //     // window.addEventListener('mouseup', mouseUp)
-  //     console.log("ROW")
-  //   }
-  
-  //   return () => {
-  //     removeListeners()
-  //   }
-  // }, [activeIndex, mouseMove, removeListeners])  
 
   React.useEffect(() => {
     listenTo(
@@ -246,7 +179,7 @@ const RowComponent = ({
                 wrap="nowrap"
                 
               >
-                {columns.map(({property, ref}, index) => {
+                {shownAttributes.map((property, index) => {
                   let value = lazyResult.plain.metacard.properties[
                     property
                   ] as any
@@ -270,7 +203,7 @@ const RowComponent = ({
                     }
                   }
                   return (
-                    <div key={index} ref={ref} 
+                    <div key={index} 
                   >
                       <CellComponent
                         key={property}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -270,7 +270,7 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
 }
 export const SelectionBackground = ({
   lazyResult,
-  style,
+  // style,
 }: {
   lazyResult: LazyQueryResult
   style?: React.CSSProperties
@@ -281,7 +281,7 @@ export const SelectionBackground = ({
       className="absolute left-0 top-0 z-0 w-full h-full Mui-bg-secondary"
       style={{
         opacity: isSelected ? 0.05 : 0,
-        ...style,
+        // ...style,
       }}
     />
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -270,8 +270,8 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
 }
 export const SelectionBackground = ({
   lazyResult,
-  // style,
-}: {
+}: // style,
+{
   lazyResult: LazyQueryResult
   style?: React.CSSProperties
 }) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -270,7 +270,6 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
 }
 export const SelectionBackground = ({
   lazyResult,
-  // style,
 }: {
   lazyResult: LazyQueryResult
   style?: React.CSSProperties
@@ -281,7 +280,6 @@ export const SelectionBackground = ({
       className="absolute left-0 top-0 z-0 w-full h-full Mui-bg-secondary"
       style={{
         opacity: isSelected ? 0.05 : 0,
-        // ...style,
       }}
     />
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -35,6 +35,9 @@ export type Header = {
 
 type HeaderProps = {
   lazyResults: LazyQueryResults
+  columns: Array<any>
+  mouseDownMain: Function
+  attributes: any
 }
 
 type Sort = {
@@ -159,82 +162,82 @@ export const HeaderCheckbox = ({
   )
 }
 
-export const Header = ({ lazyResults }: HeaderProps) => {
+export const Header = ({ lazyResults, columns, mouseDownMain,attributes }: HeaderProps) => {
   const handleSortClick = _.debounce(updateSort, 500, true)
-  const [shownAttributes, setShownAttributes] = React.useState(
-    TypedUserInstance.getResultsAttributesShownTable()
-  )
-  const [activeIndex, setActiveIndex] = React.useState(null);
-  const minCellWidth = 200
+  // const [shownAttributes, setShownAttributes] = React.useState(
+  //   TypedUserInstance.getResultsAttributesShownTable()
+  // )
+  // const { listenTo } = useBackbone()
+
+  // const [activeIndex, setActiveIndex] = React.useState(activeIndexMain)
+  // const minCellWidth = 200
   
-  const createHeaders = () => {
-    return shownAttributes.map((item) => ({
-      attr: item,
-      ref: React.useRef<HTMLDivElement>(null)
-    }))
-  }
+  // const createHeaders = () => {
+  //   return shownAttributes.map((item) => ({
+  //     attr: item,
+  //     ref: React.useRef<HTMLDivElement>(null)
+  //   }))
+  // }
 
-  const columns = createHeaders()
+  // const columns = createHeaders()
 
-  const mouseDown = (index:any) => {
-    setActiveIndex(index);
-  }
+  // const mouseDown = (index:any) => {
+  //   setActiveIndex(index);
+  // }
 
-  const { listenTo } = useBackbone()
+  // const mouseMove = React.useCallback((e) => {
 
-  const mouseMove = React.useCallback((e) => {
-
-    columns.map((col, i) => {
-      if (i === activeIndex) {
-        if (col.ref.current){
-          const width = e.clientX - col.ref.current?.getBoundingClientRect().x
-          if (width > minCellWidth){
-            col.ref.current.style.width = `${width}px`
-          }
-        }   
-      }
+  //   columns.map((col, i) => {
+  //     if (i === activeIndex) {
+  //       if (col.ref.current){
+  //         const width = e.clientX - col.ref.current?.getBoundingClientRect().x
+  //         if (width > minCellWidth){
+  //           col.ref.current.style.width = `${width}px`
+  //         }
+  //       }   
+  //     }
   
-    });
+  //   });
   
-  }, [activeIndex, columns])
+  // }, [activeIndex, columns])
 
-  const removeListeners = React.useCallback(() => {
-    window.removeEventListener('mousemove', mouseMove)
-    window.removeEventListener('mouseup', removeListeners)
-  }, [mouseMove])
+  // const removeListeners = React.useCallback(() => {
+  //   window.removeEventListener('mousemove', mouseMove)
+  //   window.removeEventListener('mouseup', removeListeners)
+  // }, [mouseMove])
   
-  const mouseUp = React.useCallback(() => {
-    setActiveIndex(null)
-    removeListeners()
-  }, [setActiveIndex, removeListeners])
+  // const mouseUp = React.useCallback(() => {
+  //   setActiveIndex(null)
+  //   removeListeners()
+  // }, [setActiveIndex, removeListeners])
 
-  React.useEffect(() => {
-    if (activeIndex !== null) {
-      window.addEventListener('mousemove', mouseMove)
-      window.addEventListener('mouseup', mouseUp)
-    }
+  // React.useEffect(() => {
+  //   if (activeIndex !== null) {
+  //     window.addEventListener('mousemove', mouseMove)
+  //     window.addEventListener('mouseup', mouseUp)
+  //   }
   
-    return () => {
-      removeListeners()
-    }
-  }, [activeIndex, mouseMove, mouseUp, removeListeners])
+  //   return () => {
+  //     removeListeners()
+  //   }
+  // }, [activeIndex, mouseMove, mouseUp, removeListeners])
 
-  React.useEffect(() => {
-    listenTo(
-      user.get('user').get('preferences'),
-      'change:results-attributesShownTable',
-      () => {
-        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-      }
-    )
-  }, [])
+  // React.useEffect(() => {
+  //   listenTo(
+  //     user.get('user').get('preferences'),
+  //     'change:results-attributesShownTable',
+  //     () => {
+  //       setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
+  //     }
+  //   )
+  // }, [])
   return (
     <React.Fragment>
       <div
         data-id="table-container"
         className="bg-inherit whitespace-no-wrap flex items-strech flex-no-wrap"
         style={{
-          width: shownAttributes.length * 200 + 'px',
+          width: attributes.length * 200 + 'px',
           display: 'grid',
           gridTemplateColumns: 'repeat(12, 1fr)'
         }}
@@ -255,13 +258,17 @@ export const Header = ({ lazyResults }: HeaderProps) => {
               sortable ? 'is-sortable' : ''
             } Mui-border-divider border border-t-0 border-l-0 border-b-0`}
             style={{cursor: 'col-resize', display: 'flex'}}
-            onMouseDown={() => mouseDown(index)}
+            onMouseDown={() => {
+              // mouseDown(index)
+              mouseDownMain(index)
+            }}
             >
                 <CellComponent
                   data-propertyid={`${attr}`}
                   data-propertytext={`${label ? `${label}` : `${attr}`}`}
                   style={{
-                    minWidth: '200px',
+                    width: '100%',
+                    minWidth: '200px'
                   }}
                 >                    
                     <Button
@@ -279,7 +286,7 @@ export const Header = ({ lazyResults }: HeaderProps) => {
                         </span>
                         <span
                           className={getSortDirectionClass(attr)}
-                          style={{ paddingLeft: '3px' }}
+                          style={{ paddingLeft: '3px'}}
                         />
                       </div>
                     </Button>            

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -184,6 +184,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
     setActiveIndex(index);
   }
 
+
   const mouseMove = React.useCallback((e) => {
     const columnsWidth = [...headerColWidth]
     columns.map((col, i) => {
@@ -203,6 +204,13 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
     setHeaderColWidth(columnsWidth)
   
   }, [activeIndex, columns])
+
+  const resetColumnWidth = (index:number) => {
+    const columnsWidth = [...headerColWidth]
+    columnsWidth[index] = '200px'
+    setHeaderColWidth(columnsWidth)
+    
+  }
 
   const removeListeners = React.useCallback(() => {
     window.removeEventListener('mousemove', mouseMove)
@@ -270,7 +278,9 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                   style={{
                     width: '100%',
                     minWidth: '200px',
-                    display: 'flex'
+                    display: 'flex',
+                    padding: 0,
+                    borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`
                   }}
                 >                    
                     <Button
@@ -292,10 +302,16 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                         />
                       </div>
                     </Button>
-                    <div style={{width: '10px', cursor: 'col-resize', 
-                      borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`, 
+                    <div style={{width: '10px', cursor: 'col-resize'
                       }}
                       className='hover:border-solid'
+                      onDoubleClick={() => {
+                        resetColumnWidth(index)
+                        if(ref.current){
+                          ref.current.style.width = '200px'
+                        }
+                        
+                      }}
                       onMouseDown={() => {
                         mouseDown(index)
                         }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -26,6 +26,7 @@ import IndeterminateCheckBoxIcon from '@material-ui/icons/IndeterminateCheckBox'
 import { TypedUserInstance } from '../../singletons/TypedUser'
 import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
 import { TypedMetacardDefs } from '../../tabs/metacard/metacardDefinitions'
+import debounce from 'lodash.debounce'
 export type Header = {
   hidden: boolean
   id: string
@@ -182,8 +183,8 @@ export const Header = ({
     setActiveIndex(index)
   }
 
-  const mouseMove = React.useCallback(
-    (e) => {
+  const mouseMove = 
+    (e:any) => {
       const columnsWidth = new Map<string, string>([...headerColWidth])
 
       if (headerColWidth.size === 0) {
@@ -206,9 +207,11 @@ export const Header = ({
         }
       })
       setHeaderColWidth(columnsWidth)
-    },
-    [activeIndex, shownAttributes]
-  )
+    }
+   
+  const debounceMouseMove = React.useCallback(
+    debounce(mouseMove, 100)
+  ,[activeIndex, shownAttributes])
 
   const resetColumnWidth = (col: string) => {
     const columnsWidth = new Map<string, string>([...headerColWidth])
@@ -217,9 +220,9 @@ export const Header = ({
   }
 
   const removeListeners = React.useCallback(() => {
-    window.removeEventListener('mousemove', mouseMove)
+    window.removeEventListener('mousemove', debounceMouseMove)
     window.removeEventListener('mouseup', removeListeners)
-  }, [mouseMove])
+  }, [debounceMouseMove])
 
   const mouseUp = React.useCallback(() => {
     setActiveIndex(null)
@@ -228,14 +231,15 @@ export const Header = ({
 
   React.useEffect(() => {
     if (activeIndex !== null) {
-      window.addEventListener('mousemove', mouseMove)
+      window.addEventListener('mousemove', debounceMouseMove)
       window.addEventListener('mouseup', mouseUp)
     }
 
     return () => {
       removeListeners()
+      debounceMouseMove.cancel()
     }
-  }, [activeIndex, mouseMove, mouseUp, removeListeners])
+  }, [activeIndex, debounceMouseMove, mouseUp, removeListeners])
 
   React.useEffect(() => {
     listenTo(

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -171,39 +171,34 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
   const [activeIndex, setActiveIndex] = React.useState(null)
   const minCellWidth = 200
   
-  const createHeaders = () => {
-    return shownAttributes.map((item) => ({
-      attr: item,
-      ref: React.useRef<HTMLDivElement>(null)
-    }))
-  }
-
-  const columns = createHeaders()
+  const columnRefs = React.useRef(shownAttributes.map(() =>  React.createRef<HTMLDivElement>()))
 
   const mouseDown = (index:any) => {
     setActiveIndex(index);
   }
 
-
   const mouseMove = React.useCallback((e) => {
     const columnsWidth = [...headerColWidth]
-    columns.map((col, i) => {
-      let width = col.ref.current?.offsetWidth
+    shownAttributes.map((col, i) => {
+      let width = columnRefs.current[i].current?.offsetWidth
       if (i === activeIndex) {
-        if (col.ref.current){
-          width = e.clientX - col.ref.current?.getBoundingClientRect().x
-          if (width > minCellWidth){
-            col.ref.current.style.width = `${width}px`
+        const currRef = columnRefs.current[i].current
+        const offset = currRef?.getBoundingClientRect().x
+        if(offset){
+          width = e.clientX - offset
+          if (width > minCellWidth && currRef){
+            currRef.style.width = `${width}px`
             columnsWidth[i] = `${width}px`
           }
-        }   
+        }
+      
       }
       columnsWidth[i] = width + 'px'
       
     });
     setHeaderColWidth(columnsWidth)
   
-  }, [activeIndex, columns])
+  }, [activeIndex, shownAttributes])
 
   const resetColumnWidth = (index:number) => {
     const columnsWidth = [...headerColWidth]
@@ -239,6 +234,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
       'change:results-attributesShownTable',
       () => {
         setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
+        columnRefs.current = TypedUserInstance.getResultsAttributesShownTable().map(() => React.createRef<HTMLDivElement>())
       }
     )
   }, [])
@@ -261,13 +257,13 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
             <HeaderCheckbox lazyResults={lazyResults} />
           </CellComponent>
         </div>
-        {columns.map(({attr, ref}, index) => {
+        {shownAttributes.map((attr, index) => {
           const label = TypedMetacardDefs.getAlias({ attr })
           const sortable = true
           return (
-            <div key={index} ref={ref}
+            <div key={index} 
             style={{display: 'flex'}}
-            
+            ref={columnRefs.current[index]}
             >
                 <CellComponent
                 className={`${
@@ -280,7 +276,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                     minWidth: '200px',
                     display: 'flex',
                     padding: 0,
-                    borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`
+                    // borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`
                   }}
                 >                    
                     <Button
@@ -307,8 +303,9 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                       className='hover:border-solid'
                       onDoubleClick={() => {
                         resetColumnWidth(index)
-                        if(ref.current){
-                          ref.current.style.width = '200px'
+                        const currRef = columnRefs.current[index].current
+                        if(currRef){
+                          currRef.style.width = '200px'
                         }
                         
                       }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -161,7 +161,11 @@ export const HeaderCheckbox = ({
   )
 }
 
-export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: HeaderProps) => {
+export const Header = ({
+  lazyResults,
+  setHeaderColWidth,
+  headerColWidth,
+}: HeaderProps) => {
   const handleSortClick = _.debounce(updateSort, 500, true)
   const [shownAttributes, setShownAttributes] = React.useState(
     TypedUserInstance.getResultsAttributesShownTable()
@@ -169,41 +173,44 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
   const { listenTo } = useBackbone()
 
   const [activeIndex, setActiveIndex] = React.useState(null)
-  
-  const columnRefs = React.useRef(shownAttributes.map(() => React.createRef<HTMLDivElement>()))
 
+  const columnRefs = React.useRef(
+    shownAttributes.map(() => React.createRef<HTMLDivElement>())
+  )
 
-  const mouseDown = (index:any) => {
-    setActiveIndex(index);
+  const mouseDown = (index: any) => {
+    setActiveIndex(index)
   }
 
-  const mouseMove = React.useCallback((e) => {
+  const mouseMove = React.useCallback(
+    (e) => {
+      const columnsWidth = new Map<string, string>([...headerColWidth])
 
-    const columnsWidth = new Map<string, string>([...headerColWidth])
+      if (headerColWidth.size === 0) {
+        shownAttributes.map((col) => {
+          columnsWidth.set(col, '200px')
+        })
+      }
 
-    if(headerColWidth.size === 0){
-      shownAttributes.map((col) => {
-        columnsWidth.set(col, '200px')
-      })
-    }
-   
-    shownAttributes.map((col, i) => {
-      if (i === activeIndex) {
-        const currRef = columnRefs.current[i].current
-        const offset = currRef?.getBoundingClientRect().x
-        if(offset){
-          const width = e.clientX - offset
-          if (currRef){
-            currRef.style.width = `${width}px`
-            columnsWidth.set(col, `${width}px`)
+      shownAttributes.map((col, i) => {
+        if (i === activeIndex) {
+          const currRef = columnRefs.current[i].current
+          const offset = currRef?.getBoundingClientRect().x
+          if (offset) {
+            const width = e.clientX - offset
+            if (currRef) {
+              currRef.style.width = `${width}px`
+              columnsWidth.set(col, `${width}px`)
+            }
           }
-        }  
-      }  
-    });
-    setHeaderColWidth(columnsWidth)
-  }, [activeIndex, shownAttributes])
+        }
+      })
+      setHeaderColWidth(columnsWidth)
+    },
+    [activeIndex, shownAttributes]
+  )
 
-  const resetColumnWidth = (col:string) => {
+  const resetColumnWidth = (col: string) => {
     const columnsWidth = new Map<string, string>([...headerColWidth])
     columnsWidth.set(col, '200px')
     setHeaderColWidth(columnsWidth)
@@ -213,7 +220,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
     window.removeEventListener('mousemove', mouseMove)
     window.removeEventListener('mouseup', removeListeners)
   }, [mouseMove])
-  
+
   const mouseUp = React.useCallback(() => {
     setActiveIndex(null)
     removeListeners()
@@ -224,7 +231,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
       window.addEventListener('mousemove', mouseMove)
       window.addEventListener('mouseup', mouseUp)
     }
-  
+
     return () => {
       removeListeners()
     }
@@ -236,7 +243,9 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
       'change:results-attributesShownTable',
       () => {
         setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-        columnRefs.current = TypedUserInstance.getResultsAttributesShownTable().map(() => React.createRef<HTMLDivElement>())
+        columnRefs.current = TypedUserInstance.getResultsAttributesShownTable().map(
+          () => React.createRef<HTMLDivElement>()
+        )
       }
     )
   }, [])
@@ -248,7 +257,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
         style={{
           width: shownAttributes.length * 200 + 'px',
           display: 'grid',
-          gridTemplateColumns: `repeat(${shownAttributes.length + 2}, 1fr)`
+          gridTemplateColumns: `repeat(${shownAttributes.length + 2}, 1fr)`,
         }}
       >
         <div className="sticky left-0 w-auto z-10 bg-inherit Mui-border-divider border border-t-0 border-l-0 border-b-0">
@@ -263,58 +272,62 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
           const label = TypedMetacardDefs.getAlias({ attr })
           const sortable = true
           return (
-            <div key={attr} 
-            style={{display: 'flex', width: `${headerColWidth.get(attr)}`, minWidth: '200px'}}
-            ref={columnRefs.current[index]}
+            <div
+              key={attr}
+              style={{
+                display: 'flex',
+                width: `${headerColWidth.get(attr)}`,
+                minWidth: '200px',
+              }}
+              ref={columnRefs.current[index]}
             >
-                <CellComponent
+              <CellComponent
                 className={`${
                   sortable ? 'is-sortable' : ''
                 } Mui-border-divider border border-t-0 border-l-0 border-b-0`}
-                  data-propertyid={`${attr}`}
-                  data-propertytext={`${label ? `${label}` : `${attr}`}`}
-                  style={{
-                    width: '100%',
-                    minWidth: '200px',
-                    display: 'flex',
-                    padding: 0
-                  }}
-                >                   
-                    <Button
-                      disabled={!sortable}
-                      className="w-full outline-none is-bold h-full"
-                      onClick={() => handleSortClick(attr)}
-                      style={{ width: '100%', marginRight: '5px'}}
+                data-propertyid={`${attr}`}
+                data-propertytext={`${label ? `${label}` : `${attr}`}`}
+                style={{
+                  width: '100%',
+                  minWidth: '200px',
+                  display: 'flex',
+                  padding: 0,
+                }}
+              >
+                <Button
+                  disabled={!sortable}
+                  className="w-full outline-none is-bold h-full"
+                  onClick={() => handleSortClick(attr)}
+                  style={{ width: '100%', marginRight: '5px' }}
+                >
+                  <div className="w-full text-left">
+                    <span
+                      className="column-text is-bold"
+                      title={`${label ? `${label}` : `${attr}`}`}
                     >
-                      <div className="w-full text-left">
-                        <span
-                          className="column-text is-bold"
-                          title={`${label ? `${label}` : `${attr}`}`}
-                        >
-                          {`${label ? `${label}` : `${attr}`}`}
-                        </span>
-                        <span
-                          className={getSortDirectionClass(attr)}
-                          style={{ paddingLeft: '3px'}}
-                        />
-                      </div>
-                    </Button>
-                    <div style={{width: '10px', cursor: 'col-resize'
-                      }}
-                      className='hover:border-solid'
-                      onDoubleClick={() => {
-                        resetColumnWidth(attr)
-                        const currRef = columnRefs.current[index].current
-                        if(currRef){
-                          currRef.style.width = '200px'
-                        } 
-                      }}
-                      onMouseDown={() => {
-                        mouseDown(index)
-                        }}
-                     >
-                    </div>            
-                </CellComponent>
+                      {`${label ? `${label}` : `${attr}`}`}
+                    </span>
+                    <span
+                      className={getSortDirectionClass(attr)}
+                      style={{ paddingLeft: '3px' }}
+                    />
+                  </div>
+                </Button>
+                <div
+                  style={{ width: '10px', cursor: 'col-resize' }}
+                  className="hover:border-solid"
+                  onDoubleClick={() => {
+                    resetColumnWidth(attr)
+                    const currRef = columnRefs.current[index].current
+                    if (currRef) {
+                      currRef.style.width = '200px'
+                    }
+                  }}
+                  onMouseDown={() => {
+                    mouseDown(index)
+                  }}
+                ></div>
+              </CellComponent>
             </div>
           )
         })}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -187,18 +187,18 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
   const mouseMove = React.useCallback((e) => {
     const columnsWidth = [...headerColWidth]
     columns.map((col, i) => {
-      const width = col.ref.current?.offsetWidth
+      let width = col.ref.current?.offsetWidth
       if (i === activeIndex) {
         if (col.ref.current){
-          const width = e.clientX - col.ref.current?.getBoundingClientRect().x
+          width = e.clientX - col.ref.current?.getBoundingClientRect().x
           if (width > minCellWidth){
             col.ref.current.style.width = `${width}px`
             columnsWidth[i] = `${width}px`
-            setHeaderColWidth(columnsWidth)
           }
         }   
       }
       columnsWidth[i] = width + 'px'
+      
     });
     setHeaderColWidth(columnsWidth)
   
@@ -259,9 +259,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
           return (
             <div key={index} ref={ref}
             style={{display: 'flex'}}
-            onMouseDown={() => {
-              mouseDown(index)
-            }}
+            
             >
                 <CellComponent
                 className={`${
@@ -272,14 +270,14 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                   style={{
                     width: '100%',
                     minWidth: '200px',
-                    cursor: 'col-resize',
+                    display: 'flex'
                   }}
                 >                    
                     <Button
                       disabled={!sortable}
                       className="w-full outline-none is-bold h-full"
                       onClick={() => handleSortClick(attr)}
-                      style={{ width: '100%'}}
+                      style={{ width: '100%', marginRight: '5px'}}
                     >
                       <div className="w-full text-left">
                         <span
@@ -293,7 +291,16 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
                           style={{ paddingLeft: '3px'}}
                         />
                       </div>
-                    </Button>            
+                    </Button>
+                    <div style={{width: '10px', cursor: 'col-resize', 
+                      borderRightWidth: `${index===activeIndex ? 'thick' : '1px'}`, 
+                      }}
+                      className='hover:border-solid'
+                      onMouseDown={() => {
+                        mouseDown(index)
+                        }}
+                     >
+                    </div>            
                 </CellComponent>
             </div>
           )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -35,7 +35,8 @@ export type Header = {
 
 type HeaderProps = {
   lazyResults: LazyQueryResults
-  headerWidth: Function
+  setHeaderColWidth: Function
+  headerColWidth: Array<string>
 }
 
 type Sort = {
@@ -160,7 +161,7 @@ export const HeaderCheckbox = ({
   )
 }
 
-export const Header = ({ lazyResults, headerWidth }: HeaderProps) => {
+export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: HeaderProps) => {
   const handleSortClick = _.debounce(updateSort, 500, true)
   const [shownAttributes, setShownAttributes] = React.useState(
     TypedUserInstance.getResultsAttributesShownTable()
@@ -184,21 +185,22 @@ export const Header = ({ lazyResults, headerWidth }: HeaderProps) => {
   }
 
   const mouseMove = React.useCallback((e) => {
-    const columnsWidth : string[] = [] 
+    const columnsWidth = [...headerColWidth]
     columns.map((col, i) => {
-      const width = col.ref.current?.clientWidth
+      const width = col.ref.current?.offsetWidth
       if (i === activeIndex) {
         if (col.ref.current){
           const width = e.clientX - col.ref.current?.getBoundingClientRect().x
           if (width > minCellWidth){
             col.ref.current.style.width = `${width}px`
             columnsWidth[i] = `${width}px`
+            setHeaderColWidth(columnsWidth)
           }
         }   
       }
       columnsWidth[i] = width + 'px'
     });
-    headerWidth(columnsWidth)
+    setHeaderColWidth(columnsWidth)
   
   }, [activeIndex, columns])
 
@@ -255,20 +257,22 @@ export const Header = ({ lazyResults, headerWidth }: HeaderProps) => {
           const label = TypedMetacardDefs.getAlias({ attr })
           const sortable = true
           return (
-            <div key={index} ref={ref} className={`${
-              sortable ? 'is-sortable' : ''
-            } Mui-border-divider border border-t-0 border-l-0 border-b-0`}
-            style={{cursor: 'col-resize', display: 'flex'}}
+            <div key={index} ref={ref}
+            style={{display: 'flex'}}
             onMouseDown={() => {
               mouseDown(index)
             }}
             >
                 <CellComponent
+                className={`${
+                  sortable ? 'is-sortable' : ''
+                } Mui-border-divider border border-t-0 border-l-0 border-b-0`}
                   data-propertyid={`${attr}`}
                   data-propertytext={`${label ? `${label}` : `${attr}`}`}
                   style={{
                     width: '100%',
-                    minWidth: '200px'
+                    minWidth: '200px',
+                    cursor: 'col-resize',
                   }}
                 >                    
                     <Button

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -188,19 +188,16 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
     }
    
     shownAttributes.map((col, i) => {
-      let width = columnRefs.current[i].current?.offsetWidth
       if (i === activeIndex) {
         const currRef = columnRefs.current[i].current
         const offset = currRef?.getBoundingClientRect().x
         if(offset){
-          width = e.clientX - offset
+          const width = e.clientX - offset
           if (currRef){
             currRef.style.width = `${width}px`
             columnsWidth.set(col, `${width}px`)
           }
-      
-        }
-        columnsWidth.set(col, `${width}px`)
+        }  
       }  
     });
     setHeaderColWidth(columnsWidth)
@@ -266,7 +263,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
           const label = TypedMetacardDefs.getAlias({ attr })
           const sortable = true
           return (
-            <div key={index} 
+            <div key={attr} 
             style={{display: 'flex', width: `${headerColWidth.get(attr)}`, minWidth: '200px'}}
             ref={columnRefs.current[index]}
             >

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -35,8 +35,6 @@ export type Header = {
 
 type HeaderProps = {
   lazyResults: LazyQueryResults
-  mouseDownMain: Function
-  activeIndexMain: any
   headerWidth: Function
 }
 
@@ -162,14 +160,14 @@ export const HeaderCheckbox = ({
   )
 }
 
-export const Header = ({ lazyResults, mouseDownMain,activeIndexMain, headerWidth }: HeaderProps) => {
+export const Header = ({ lazyResults, headerWidth }: HeaderProps) => {
   const handleSortClick = _.debounce(updateSort, 500, true)
   const [shownAttributes, setShownAttributes] = React.useState(
     TypedUserInstance.getResultsAttributesShownTable()
   )
   const { listenTo } = useBackbone()
 
-  const [activeIndex, setActiveIndex] = React.useState(activeIndexMain)
+  const [activeIndex, setActiveIndex] = React.useState(null)
   const minCellWidth = 200
   
   const createHeaders = () => {
@@ -195,13 +193,10 @@ export const Header = ({ lazyResults, mouseDownMain,activeIndexMain, headerWidth
           if (width > minCellWidth){
             col.ref.current.style.width = `${width}px`
             columnsWidth[i] = `${width}px`
-            // headerWidth(width + 'px')
           }
         }   
       }
-      
       columnsWidth[i] = width + 'px'
-      console.log(columnsWidth)
     });
     headerWidth(columnsWidth)
   
@@ -266,7 +261,6 @@ export const Header = ({ lazyResults, mouseDownMain,activeIndexMain, headerWidth
             style={{cursor: 'col-resize', display: 'flex'}}
             onMouseDown={() => {
               mouseDown(index)
-              mouseDownMain(index)
             }}
             >
                 <CellComponent

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -35,9 +35,9 @@ export type Header = {
 
 type HeaderProps = {
   lazyResults: LazyQueryResults
-  columns: Array<any>
   mouseDownMain: Function
-  attributes: any
+  activeIndexMain: any
+  headerWidth: Function
 }
 
 type Sort = {
@@ -162,82 +162,88 @@ export const HeaderCheckbox = ({
   )
 }
 
-export const Header = ({ lazyResults, columns, mouseDownMain,attributes }: HeaderProps) => {
+export const Header = ({ lazyResults, mouseDownMain,activeIndexMain, headerWidth }: HeaderProps) => {
   const handleSortClick = _.debounce(updateSort, 500, true)
-  // const [shownAttributes, setShownAttributes] = React.useState(
-  //   TypedUserInstance.getResultsAttributesShownTable()
-  // )
-  // const { listenTo } = useBackbone()
+  const [shownAttributes, setShownAttributes] = React.useState(
+    TypedUserInstance.getResultsAttributesShownTable()
+  )
+  const { listenTo } = useBackbone()
 
-  // const [activeIndex, setActiveIndex] = React.useState(activeIndexMain)
-  // const minCellWidth = 200
+  const [activeIndex, setActiveIndex] = React.useState(activeIndexMain)
+  const minCellWidth = 200
   
-  // const createHeaders = () => {
-  //   return shownAttributes.map((item) => ({
-  //     attr: item,
-  //     ref: React.useRef<HTMLDivElement>(null)
-  //   }))
-  // }
+  const createHeaders = () => {
+    return shownAttributes.map((item) => ({
+      attr: item,
+      ref: React.useRef<HTMLDivElement>(null)
+    }))
+  }
 
-  // const columns = createHeaders()
+  const columns = createHeaders()
 
-  // const mouseDown = (index:any) => {
-  //   setActiveIndex(index);
-  // }
+  const mouseDown = (index:any) => {
+    setActiveIndex(index);
+  }
 
-  // const mouseMove = React.useCallback((e) => {
-
-  //   columns.map((col, i) => {
-  //     if (i === activeIndex) {
-  //       if (col.ref.current){
-  //         const width = e.clientX - col.ref.current?.getBoundingClientRect().x
-  //         if (width > minCellWidth){
-  //           col.ref.current.style.width = `${width}px`
-  //         }
-  //       }   
-  //     }
+  const mouseMove = React.useCallback((e) => {
+    const columnsWidth : string[] = [] 
+    columns.map((col, i) => {
+      const width = col.ref.current?.clientWidth
+      if (i === activeIndex) {
+        if (col.ref.current){
+          const width = e.clientX - col.ref.current?.getBoundingClientRect().x
+          if (width > minCellWidth){
+            col.ref.current.style.width = `${width}px`
+            columnsWidth[i] = `${width}px`
+            // headerWidth(width + 'px')
+          }
+        }   
+      }
+      
+      columnsWidth[i] = width + 'px'
+      console.log(columnsWidth)
+    });
+    headerWidth(columnsWidth)
   
-  //   });
-  
-  // }, [activeIndex, columns])
+  }, [activeIndex, columns])
 
-  // const removeListeners = React.useCallback(() => {
-  //   window.removeEventListener('mousemove', mouseMove)
-  //   window.removeEventListener('mouseup', removeListeners)
-  // }, [mouseMove])
+  const removeListeners = React.useCallback(() => {
+    window.removeEventListener('mousemove', mouseMove)
+    window.removeEventListener('mouseup', removeListeners)
+  }, [mouseMove])
   
-  // const mouseUp = React.useCallback(() => {
-  //   setActiveIndex(null)
-  //   removeListeners()
-  // }, [setActiveIndex, removeListeners])
+  const mouseUp = React.useCallback(() => {
+    setActiveIndex(null)
+    removeListeners()
+  }, [setActiveIndex, removeListeners])
 
-  // React.useEffect(() => {
-  //   if (activeIndex !== null) {
-  //     window.addEventListener('mousemove', mouseMove)
-  //     window.addEventListener('mouseup', mouseUp)
-  //   }
+  React.useEffect(() => {
+    if (activeIndex !== null) {
+      window.addEventListener('mousemove', mouseMove)
+      window.addEventListener('mouseup', mouseUp)
+    }
   
-  //   return () => {
-  //     removeListeners()
-  //   }
-  // }, [activeIndex, mouseMove, mouseUp, removeListeners])
+    return () => {
+      removeListeners()
+    }
+  }, [activeIndex, mouseMove, mouseUp, removeListeners])
 
-  // React.useEffect(() => {
-  //   listenTo(
-  //     user.get('user').get('preferences'),
-  //     'change:results-attributesShownTable',
-  //     () => {
-  //       setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-  //     }
-  //   )
-  // }, [])
+  React.useEffect(() => {
+    listenTo(
+      user.get('user').get('preferences'),
+      'change:results-attributesShownTable',
+      () => {
+        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
+      }
+    )
+  }, [])
   return (
     <React.Fragment>
       <div
         data-id="table-container"
         className="bg-inherit whitespace-no-wrap flex items-strech flex-no-wrap"
         style={{
-          width: attributes.length * 200 + 'px',
+          width: shownAttributes.length * 200 + 'px',
           display: 'grid',
           gridTemplateColumns: 'repeat(12, 1fr)'
         }}
@@ -259,7 +265,7 @@ export const Header = ({ lazyResults, columns, mouseDownMain,attributes }: Heade
             } Mui-border-divider border border-t-0 border-l-0 border-b-0`}
             style={{cursor: 'col-resize', display: 'flex'}}
             onMouseDown={() => {
-              // mouseDown(index)
+              mouseDown(index)
               mouseDownMain(index)
             }}
             >

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -169,15 +169,12 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
   const { listenTo } = useBackbone()
 
   const [activeIndex, setActiveIndex] = React.useState(null)
-  const minCellWidth = 200
   
   const columnRefs = React.useRef(shownAttributes.map(() => React.createRef<HTMLDivElement>()))
 
 
-
   const mouseDown = (index:any) => {
     setActiveIndex(index);
-    // console.log(attr)
   }
 
   const mouseMove = React.useCallback((e) => {
@@ -197,7 +194,7 @@ export const Header = ({ lazyResults, setHeaderColWidth, headerColWidth }: Heade
         const offset = currRef?.getBoundingClientRect().x
         if(offset){
           width = e.clientX - offset
-          if (width > minCellWidth && currRef){
+          if (currRef){
             currRef.style.width = `${width}px`
             columnsWidth.set(col, `${width}px`)
           }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -116,17 +116,12 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
     }
   }, [])
 
-  // const [activeIndex, setActiveIndex] = React.useState(null)
   const columnsWidth : string[] = []
-  const [headerWidth, setHeaderWidth] = React.useState(columnsWidth)
-
-  // const mouseDown = (index:any) => {
-  //   setActiveIndex(index);
-  // }
+  const [headerColWidth, setHeaderColWidth] = React.useState(columnsWidth)
   
   const setWidth = (width:Array<string>) => {
-    setHeaderWidth(width)
-    console.log("WIDTH: " + width)
+    setHeaderColWidth(width)
+    // console.log(width)
   }
   
   return (
@@ -210,7 +205,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                   className="w-auto overflow-auto scrollbars-hide bg-inherit"
                   ref={headerRef}
                 >
-                  <Header lazyResults={lazyResults}   headerWidth={setWidth}/>
+                  <Header lazyResults={lazyResults}   setHeaderColWidth={setWidth} headerColWidth={headerColWidth}/>
                 </div>
               </Grid>
               <Grid item>
@@ -237,7 +232,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                           measure={measure}
                           index={index}
                           results={results}
-                          headerWidth={headerWidth}
+                          headerColWidth={headerColWidth}
                         />
                       </div>
                     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -116,7 +116,8 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
     }
   }, [])
 
-  const columnsWidth = new Map<string, string>()
+  const prefs = user.get('user').get('preferences')
+  const columnsWidth = new Map<string, string>(prefs.get('columnWidths'))
   const [headerColWidth, setHeaderColWidth] = React.useState(columnsWidth)
 
   const setWidth = (width: Map<string, string>) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -107,10 +107,10 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
    * This is solely to keep the illusion of responsiveness when switching from table mode to list mode (or dropping a new result visual in)
    */
   const [isMounted, setIsMounted] = React.useState(false)
-  const [shownAttributes, setShownAttributes] = React.useState(
-    TypedUserInstance.getResultsAttributesShownTable()
-  )
-  const { listenTo } = useBackbone()
+  // const [shownAttributes, setShownAttributes] = React.useState(
+  //   TypedUserInstance.getResultsAttributesShownTable()
+  // )
+  // const { listenTo } = useBackbone()
 
   React.useEffect(() => {
     const mountedTimeout = setTimeout(() => {
@@ -125,67 +125,74 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
   //   TypedUserInstance.getResultsAttributesShownTable()
   // )
   const [activeIndex, setActiveIndex] = React.useState(null)
-  const minCellWidth = 200
-  
-  const createHeaders = () => {
-    return shownAttributes.map((item) => ({
-      attr: item,
-      ref: React.useRef<HTMLDivElement>(null)
-    }))
-  }
+  const columnsWidth : string[] = []
+  const [headerWidth, setHeaderWidth] = React.useState(columnsWidth)
 
-  const columns = createHeaders()
+  // const minCellWidth = 200
+  
+  // const createHeaders = () => {
+  //   return shownAttributes.map((item) => ({
+  //     attr: item,
+  //     ref: React.useRef<HTMLDivElement>(null)
+  //   }))
+  // }
+
+  // const columns = createHeaders()
 
   const mouseDown = (index:any) => {
     setActiveIndex(index);
   }
 
-  const mouseMove = React.useCallback((e) => {
+  const setWidth = (width:Array<string>) => {
+    setHeaderWidth(width)
+    console.log("WIDTH: " + width)
+  }
+  // const mouseMove = React.useCallback((e) => {
 
-    columns.map((col, i) => {
-      if (i === activeIndex) {
-        if (col.ref.current){
-          const width = e.clientX - col.ref.current?.getBoundingClientRect().x
-          if (width > minCellWidth){
-            col.ref.current.style.width = `${width}px`
-          }
-        }   
-      }
+  //   columns.map((col, i) => {
+  //     if (i === activeIndex) {
+  //       if (col.ref.current){
+  //         const width = e.clientX - col.ref.current?.getBoundingClientRect().x
+  //         if (width > minCellWidth){
+  //           col.ref.current.style.width = `${width}px`
+  //         }
+  //       }   
+  //     }
   
-    });
+  //   });
   
-  }, [activeIndex, columns, minCellWidth])
+  // }, [activeIndex, columns, minCellWidth])
 
-  const removeListeners = React.useCallback(() => {
-    window.removeEventListener('mousemove', mouseMove)
-    window.removeEventListener('mouseup', removeListeners)
-  }, [mouseMove])
+  // const removeListeners = React.useCallback(() => {
+  //   window.removeEventListener('mousemove', mouseMove)
+  //   window.removeEventListener('mouseup', removeListeners)
+  // }, [mouseMove])
   
-  const mouseUp = React.useCallback(() => {
-    setActiveIndex(null)
-    removeListeners()
-  }, [setActiveIndex, removeListeners])
+  // const mouseUp = React.useCallback(() => {
+  //   setActiveIndex(null)
+  //   removeListeners()
+  // }, [setActiveIndex, removeListeners])
 
-  React.useEffect(() => {
-    if (activeIndex !== null) {
-      window.addEventListener('mousemove', mouseMove)
-      window.addEventListener('mouseup', mouseUp)
-    }
+  // React.useEffect(() => {
+  //   if (activeIndex !== null) {
+  //     window.addEventListener('mousemove', mouseMove)
+  //     window.addEventListener('mouseup', mouseUp)
+  //   }
   
-    return () => {
-      removeListeners()
-    }
-  }, [activeIndex, mouseMove, mouseUp, removeListeners])
+  //   return () => {
+  //     removeListeners()
+  //   }
+  // }, [activeIndex, mouseMove, mouseUp, removeListeners])
 
-  React.useEffect(() => {
-    listenTo(
-      user.get('user').get('preferences'),
-      'change:results-attributesShownTable',
-      () => {
-        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-      }
-    )
-  }, [])
+  // React.useEffect(() => {
+  //   listenTo(
+  //     user.get('user').get('preferences'),
+  //     'change:results-attributesShownTable',
+  //     () => {
+  //       setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
+  //     }
+  //   )
+  // }, [])
 
   return (
     <Grid
@@ -268,7 +275,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                   className="w-auto overflow-auto scrollbars-hide bg-inherit"
                   ref={headerRef}
                 >
-                  <Header lazyResults={lazyResults} columns={columns} mouseDownMain={mouseDown} attributes={shownAttributes}/>
+                  <Header lazyResults={lazyResults}  mouseDownMain={mouseDown} activeIndexMain={activeIndex} headerWidth={setWidth}/>
                 </div>
               </Grid>
               <Grid item>
@@ -297,6 +304,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                           results={results}
                           activeIndexMain={activeIndex}
                           mouseDownMain={mouseDown}
+                          headerWidth={headerWidth}
                         />
                       </div>
                     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -118,11 +118,11 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
 
   const columnsWidth = new Map<string, string>()
   const [headerColWidth, setHeaderColWidth] = React.useState(columnsWidth)
-  
-  const setWidth = (width:Map<string, string>) => {
+
+  const setWidth = (width: Map<string, string>) => {
     setHeaderColWidth(width)
   }
-  
+
   return (
     <Grid
       container
@@ -204,7 +204,11 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                   className="w-auto overflow-auto scrollbars-hide bg-inherit"
                   ref={headerRef}
                 >
-                  <Header lazyResults={lazyResults}   setHeaderColWidth={setWidth} headerColWidth={headerColWidth}/>
+                  <Header
+                    lazyResults={lazyResults}
+                    setHeaderColWidth={setWidth}
+                    headerColWidth={headerColWidth}
+                  />
                 </div>
               </Grid>
               <Grid item>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -116,12 +116,11 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
     }
   }, [])
 
-  const columnsWidth : string[] = []
+  const columnsWidth = new Map<string, string>()
   const [headerColWidth, setHeaderColWidth] = React.useState(columnsWidth)
   
-  const setWidth = (width:Array<string>) => {
+  const setWidth = (width:Map<string, string>) => {
     setHeaderColWidth(width)
-    // console.log(width)
   }
   
   return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -35,6 +35,7 @@ import TransferList from '../../tabs/metacard/transfer-list'
 import { useDialog } from '../../dialog'
 import { TypedUserInstance } from '../../singletons/TypedUser'
 import useTimePrefs from '../../fields/useTimePrefs'
+import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
 type Props = {
   selectionInterface: any
   mode: any
@@ -106,6 +107,11 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
    * This is solely to keep the illusion of responsiveness when switching from table mode to list mode (or dropping a new result visual in)
    */
   const [isMounted, setIsMounted] = React.useState(false)
+  const [shownAttributes, setShownAttributes] = React.useState(
+    TypedUserInstance.getResultsAttributesShownTable()
+  )
+  const { listenTo } = useBackbone()
+
   React.useEffect(() => {
     const mountedTimeout = setTimeout(() => {
       setIsMounted(true)
@@ -114,6 +120,73 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
       clearTimeout(mountedTimeout)
     }
   }, [])
+
+  // const shownAttributes = React.useState(
+  //   TypedUserInstance.getResultsAttributesShownTable()
+  // )
+  const [activeIndex, setActiveIndex] = React.useState(null)
+  const minCellWidth = 200
+  
+  const createHeaders = () => {
+    return shownAttributes.map((item) => ({
+      attr: item,
+      ref: React.useRef<HTMLDivElement>(null)
+    }))
+  }
+
+  const columns = createHeaders()
+
+  const mouseDown = (index:any) => {
+    setActiveIndex(index);
+  }
+
+  const mouseMove = React.useCallback((e) => {
+
+    columns.map((col, i) => {
+      if (i === activeIndex) {
+        if (col.ref.current){
+          const width = e.clientX - col.ref.current?.getBoundingClientRect().x
+          if (width > minCellWidth){
+            col.ref.current.style.width = `${width}px`
+          }
+        }   
+      }
+  
+    });
+  
+  }, [activeIndex, columns, minCellWidth])
+
+  const removeListeners = React.useCallback(() => {
+    window.removeEventListener('mousemove', mouseMove)
+    window.removeEventListener('mouseup', removeListeners)
+  }, [mouseMove])
+  
+  const mouseUp = React.useCallback(() => {
+    setActiveIndex(null)
+    removeListeners()
+  }, [setActiveIndex, removeListeners])
+
+  React.useEffect(() => {
+    if (activeIndex !== null) {
+      window.addEventListener('mousemove', mouseMove)
+      window.addEventListener('mouseup', mouseUp)
+    }
+  
+    return () => {
+      removeListeners()
+    }
+  }, [activeIndex, mouseMove, mouseUp, removeListeners])
+
+  React.useEffect(() => {
+    listenTo(
+      user.get('user').get('preferences'),
+      'change:results-attributesShownTable',
+      () => {
+        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
+      }
+    )
+  }, [])
+
   return (
     <Grid
       container
@@ -195,7 +268,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                   className="w-auto overflow-auto scrollbars-hide bg-inherit"
                   ref={headerRef}
                 >
-                  <Header lazyResults={lazyResults} />
+                  <Header lazyResults={lazyResults} columns={columns} mouseDownMain={mouseDown} attributes={shownAttributes}/>
                 </div>
               </Grid>
               <Grid item>
@@ -222,6 +295,8 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                           measure={measure}
                           index={index}
                           results={results}
+                          activeIndexMain={activeIndex}
+                          mouseDownMain={mouseDown}
                         />
                       </div>
                     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -35,7 +35,6 @@ import TransferList from '../../tabs/metacard/transfer-list'
 import { useDialog } from '../../dialog'
 import { TypedUserInstance } from '../../singletons/TypedUser'
 import useTimePrefs from '../../fields/useTimePrefs'
-import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
 type Props = {
   selectionInterface: any
   mode: any
@@ -107,10 +106,6 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
    * This is solely to keep the illusion of responsiveness when switching from table mode to list mode (or dropping a new result visual in)
    */
   const [isMounted, setIsMounted] = React.useState(false)
-  // const [shownAttributes, setShownAttributes] = React.useState(
-  //   TypedUserInstance.getResultsAttributesShownTable()
-  // )
-  // const { listenTo } = useBackbone()
 
   React.useEffect(() => {
     const mountedTimeout = setTimeout(() => {
@@ -121,79 +116,19 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
     }
   }, [])
 
-  // const shownAttributes = React.useState(
-  //   TypedUserInstance.getResultsAttributesShownTable()
-  // )
-  const [activeIndex, setActiveIndex] = React.useState(null)
+  // const [activeIndex, setActiveIndex] = React.useState(null)
   const columnsWidth : string[] = []
   const [headerWidth, setHeaderWidth] = React.useState(columnsWidth)
 
-  // const minCellWidth = 200
-  
-  // const createHeaders = () => {
-  //   return shownAttributes.map((item) => ({
-  //     attr: item,
-  //     ref: React.useRef<HTMLDivElement>(null)
-  //   }))
+  // const mouseDown = (index:any) => {
+  //   setActiveIndex(index);
   // }
-
-  // const columns = createHeaders()
-
-  const mouseDown = (index:any) => {
-    setActiveIndex(index);
-  }
-
+  
   const setWidth = (width:Array<string>) => {
     setHeaderWidth(width)
     console.log("WIDTH: " + width)
   }
-  // const mouseMove = React.useCallback((e) => {
-
-  //   columns.map((col, i) => {
-  //     if (i === activeIndex) {
-  //       if (col.ref.current){
-  //         const width = e.clientX - col.ref.current?.getBoundingClientRect().x
-  //         if (width > minCellWidth){
-  //           col.ref.current.style.width = `${width}px`
-  //         }
-  //       }   
-  //     }
   
-  //   });
-  
-  // }, [activeIndex, columns, minCellWidth])
-
-  // const removeListeners = React.useCallback(() => {
-  //   window.removeEventListener('mousemove', mouseMove)
-  //   window.removeEventListener('mouseup', removeListeners)
-  // }, [mouseMove])
-  
-  // const mouseUp = React.useCallback(() => {
-  //   setActiveIndex(null)
-  //   removeListeners()
-  // }, [setActiveIndex, removeListeners])
-
-  // React.useEffect(() => {
-  //   if (activeIndex !== null) {
-  //     window.addEventListener('mousemove', mouseMove)
-  //     window.addEventListener('mouseup', mouseUp)
-  //   }
-  
-  //   return () => {
-  //     removeListeners()
-  //   }
-  // }, [activeIndex, mouseMove, mouseUp, removeListeners])
-
-  // React.useEffect(() => {
-  //   listenTo(
-  //     user.get('user').get('preferences'),
-  //     'change:results-attributesShownTable',
-  //     () => {
-  //       setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-  //     }
-  //   )
-  // }, [])
-
   return (
     <Grid
       container
@@ -275,7 +210,7 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                   className="w-auto overflow-auto scrollbars-hide bg-inherit"
                   ref={headerRef}
                 >
-                  <Header lazyResults={lazyResults}  mouseDownMain={mouseDown} activeIndexMain={activeIndex} headerWidth={setWidth}/>
+                  <Header lazyResults={lazyResults}   headerWidth={setWidth}/>
                 </div>
               </Grid>
               <Grid item>
@@ -302,8 +237,6 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                           measure={measure}
                           index={index}
                           results={results}
-                          activeIndexMain={activeIndex}
-                          mouseDownMain={mouseDown}
                           headerWidth={headerWidth}
                         />
                       </div>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -136,6 +136,7 @@ const Theme = Backbone.Model.extend({
       visualization: '3dmap',
       columnHide: [],
       columnOrder: ['title', 'created', 'modified', 'thumbnail'],
+      columnWidths: [],
       hasSelectedColumns: false,
       uploads: [],
       oauth: [],


### PR DESCRIPTION
**What does this PR do, and why?**

Currently Table View on Results pane have fixed column width. Added functionality to drag column border to adjust its width. Double clicking on column border will reset its width.

**How should this be tested?**

1. Hover over a column border and drag the column to change its width.
2. Double click on the adjusted column border to reset its width.

**PR Definition of Done**

- Table view columns adjustable in Results pane without braking any current functionalities
- Minimum 2 reviewer approval 
- All comments resolved
- Hero build with results
- Passing CI or full local build

**Relevant links:**
[ISR-10834](https://jira.nciteglobal.com.au/jira/browse/ISR-10834)

**Demo:**

https://user-images.githubusercontent.com/125233437/224907156-2108df94-8ae5-4e0e-b7b7-3d10a85571ac.mp4


