### PR TITLE
Fix coordinate copying on map

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -111,7 +111,6 @@
     "backbone.wreqr": "1.4.0",
     "bootstrap": "3.4.0",
     "cesium": "1.44",
-    "clipboard": "1.7.1",
     "content-disposition": "0.5.3",
     "d3": "5.16.0",
     "density-clustering": "1.3.0",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/copy-coordinates/copy-coordinates.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/copy-coordinates/copy-coordinates.tsx
@@ -20,8 +20,6 @@ import Popover from '@material-ui/core/Popover'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import useSnack from '../../component/hooks/useSnack'
 import { AddSnack } from '../../component/snack/snack.provider'
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'clip... Remove this comment to see the full error message
-import Clipboard from 'clipboard'
 
 type Props = {
   coordinateValues: {
@@ -43,29 +41,25 @@ const generateClipboardHandler = ({
   closeParent: () => void
   addSnack: AddSnack
 }) => {
-  return (e: React.MouseEvent) => {
-    const clipboardInstance = new Clipboard(e.target, {
-      text: () => {
-        return text
-      },
-    })
-    clipboardInstance.on('success', (e: any) => {
-      addSnack('Copied to clipboard: ' + e.text, {
+  return async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      addSnack(`Copied to clipboard: ${text}`, {
         alertProps: {
           severity: 'success',
         },
       })
-    })
-    clipboardInstance.on('error', (e: any) => {
-      addSnack('Press Ctrl+C to copy: ' + e.text, {
+    } catch (e) {
+      addSnack(`Unable to copy ${text} to clipboard.`, {
         alertProps: {
-          severity: 'info',
+          severity: 'error',
         },
+        // Longer timeout to give the user a chance to copy the coordinates from the snack.
+        timeout: 10000,
       })
-    })
-    clipboardInstance.onClick(e)
-    clipboardInstance.destroy()
-    closeParent()
+    } finally {
+      closeParent()
+    }
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -7825,14 +7825,6 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
 
-clipboard@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 clipboard@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"


### PR DESCRIPTION
The clipboard library we were using worked by inserting a textarea with the desired text, then selecting it and calling execCommand('copy'). Some time ago, the copy-coordinates component was updated to use a modal, which prevented the fake textarea element from being focused normally. There are ways to work around this, but we elected to switch to the Clipboard API instead, to ensure more consistent behavior across browsers.

### Testing Instructions
Copy all the supported coordinate formats on both the 2D and 3D maps, in at least Chrome and Firefox.