### PR TITLE
Construct cql from lazyQueryResults during export re-query

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/index.tsx
@@ -17,6 +17,4 @@ export {
   Props,
   getWarning,
   getDownloadBody,
-  getStartIndex,
-  getSrcCount,
 } from './table-export'


### PR DESCRIPTION
This specifically fixes the issue of running a search against multiple WFS sources and the export not matching the on-screen results. We now use lazyQueryResults to construct the cql for the export's re-query.
```
  let queryCount = exportCount
  let cql = DEFAULT_USER_QUERY_OPTIONS.transformFilterTree({
    originalFilterTree: query.get('filterTree'),
    queryRef: query,
  })
  if (downloadInfo.exportSize !== 'all') {
    queryCount = pageSize
    cql = getResultSetCql(results)
  }
```
This is the only "new" chunk of code. Since we have the specific IDs for exporting the current page, we no longer need "paging" info when running the search, and therefore, the "searches" attribute is going to be the same format for any type of export. Was able to remove getSearches, getStartIndex, and getSrcCount.

**Testing Notes:**
For the following searches sort on title=Z-A, then perform each type of export (custom, current page, all). Verify export matches the on screen results for `custom` and `current page`. Export `all` will not match the UI, but the export should be in the correct sort order.
-Search multiple WFS sources
-Search single WFS sources
-Search multiple non-WFS sources
-Search single non-WFS sources
I found it helpful to configure `export limit` to 100 in the admin ui and set the user's search page size preference to 10. 