### PR TITLE
Add time precision preference

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
@@ -14,6 +14,7 @@ import { TimePrecision } from '@blueprintjs/datetime'
 const data = {
   date1: {
     originalISO: '2021-01-15T06:53:54.316Z',
+    utcISOMinutes: '2021-01-15T06:53:00.000Z',
     userFormatISO: {
       millisecond: '2021-01-15T03:23:54.316-03:30',
       second: '2021-01-15T03:23:54-03:30',
@@ -40,12 +41,14 @@ describe('verify date around field works', () => {
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   afterEach(() => {
+    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
+    // Has to be unmounted before we set any preferences so we don't trigger any onChange
+    // callbacks again.
+    wrapper.unmount()
     user
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
-    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
-    wrapper.unmount()
   })
   const verifyDateRender = (
     format: string,
@@ -109,4 +112,25 @@ describe('verify date around field works', () => {
     'should render with 12hr format and minute precision',
     verifyDateRender('12', 'minute', data.date1.userFormat12.minute)
   )
+  it('calls onChange with updated value when precision changes', () => {
+    wrapper = mount(
+      <DateAroundField
+        value={{
+          date: data.date1.userFormatISO.millisecond,
+          buffer: {
+            amount: '1',
+            unit: 'd',
+          },
+          direction: 'both',
+        }}
+        onChange={(updatedValue) => {
+          expect(updatedValue.date).to.equal(data.date1.utcISOMinutes)
+        }}
+      />
+    )
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['minute'])
+  })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+Enzyme.configure({ adapter: new Adapter() })
+
+import { DateAroundField } from './date-around'
+import { expect } from 'chai'
+
+import user from '../singletons/user-instance'
+import Common from '../../js/Common'
+import { TimePrecision } from '@blueprintjs/datetime'
+
+// rely on static data when possible, but in these we can use the DateHelpers (a must for shifted date timezone testing)
+const data = {
+  date1: {
+    originalISO: '2021-01-15T06:53:54.316Z',
+    userFormatISO: {
+      millisecond: '2021-01-15T03:23:54.316-03:30',
+      second: '2021-01-15T03:23:54-03:30',
+      minute: '2021-01-15T03:23-03:30',
+    },
+    userFormat24: {
+      millisecond: '15 Jan 2021 03:23:54.316 -03:30',
+      second: '15 Jan 2021 03:23:54 -03:30',
+      minute: '15 Jan 2021 03:23 -03:30',
+    },
+    userFormat12: {
+      millisecond: '15 Jan 2021 03:23:54.316 am -03:30',
+      second: '15 Jan 2021 03:23:54 am -03:30',
+      minute: '15 Jan 2021 03:23 am -03:30',
+    },
+  },
+}
+let wrapper: Enzyme.ReactWrapper
+describe('verify date around field works', () => {
+  beforeEach(() => {
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
+  })
+  afterEach(() => {
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
+    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
+    wrapper.unmount()
+  })
+  const verifyDateRender = (
+    format: string,
+    precision: TimePrecision,
+    expected: string
+  ) => {
+    return () => {
+      user
+        .get('user')
+        .get('preferences')
+        .set('dateTimeFormat', Common.getDateTimeFormats()[format][precision])
+      wrapper = mount(
+        <DateAroundField
+          value={{
+            date: data.date1.originalISO,
+            buffer: {
+              amount: '1',
+              unit: 'd',
+            },
+            direction: 'both',
+          }}
+          onChange={() => {}}
+        />
+      )
+      expect(wrapper.render().find('input').val()).to.equal(expected)
+    }
+  }
+  it(
+    'should render with ISO format and millisecond precision',
+    verifyDateRender('ISO', 'millisecond', data.date1.userFormatISO.millisecond)
+  )
+  it(
+    'should render with ISO format and second precision',
+    verifyDateRender('ISO', 'second', data.date1.userFormatISO.second)
+  )
+  it(
+    'should render with ISO format and minute precision',
+    verifyDateRender('ISO', 'minute', data.date1.userFormatISO.minute)
+  )
+  it(
+    'should render with 24hr format and millisecond precision',
+    verifyDateRender('24', 'millisecond', data.date1.userFormat24.millisecond)
+  )
+  it(
+    'should render with 24hr format and second precision',
+    verifyDateRender('24', 'second', data.date1.userFormat24.second)
+  )
+  it(
+    'should render with 24hr format and minute precision',
+    verifyDateRender('24', 'minute', data.date1.userFormat24.minute)
+  )
+  it(
+    'should render with 12hr format and millisecond precision',
+    verifyDateRender('12', 'millisecond', data.date1.userFormat12.millisecond)
+  )
+  it(
+    'should render with 12hr format and second precision',
+    verifyDateRender('12', 'second', data.date1.userFormat12.second)
+  )
+  it(
+    'should render with 12hr format and minute precision',
+    verifyDateRender('12', 'minute', data.date1.userFormat12.minute)
+  )
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -49,15 +49,7 @@ const validateDate = ({ value, onChange }: DateAroundProps) => {
     !value.direction ||
     DateHelpers.Blueprint.commonProps.parseDate(value.date) === null
   ) {
-    // TODO create helper method for this
-    const newDate = new Date()
-    switch (DateHelpers.General.getTimePrecision()) {
-      case 'minute':
-        newDate.setUTCSeconds(0)
-      // Intentional fall-through
-      case 'second':
-        newDate.setUTCMilliseconds(0)
-    }
+    const newDate = DateHelpers.General.withPrecision(new Date())
     onChange({ ...defaultValue(), date: newDate.toISOString() })
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -83,7 +83,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           parseDate={DateHelpers.Blueprint.commonProps.parseDate}
           placeholder={'M/D/YYYY'}
           shortcuts
-          timePrecision="millisecond"
+          timePrecision={DateHelpers.General.getTimePrecision()}
           inputProps={{
             ...EnterKeySubmitProps,
           }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
@@ -15,8 +15,8 @@
 import { expect } from 'chai'
 import { DateHelpers, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import user from '../singletons/user-instance'
-// TODO do I need to set a format for this?
-// TODO tests for precision
+import Common from '../../js/Common'
+
 user.get('user').get('preferences').set('timeZone', 'America/St_Johns')
 const date = new Date()
 describe('verify that transforming to and from timezone is accurate (no loss)', () => {
@@ -33,5 +33,30 @@ describe('verify that transforming to and from timezone is accurate (no loss)', 
     expect(date.toISOString(), 'Unexpected difference').to.equal(
       unshiftedDate.toISOString()
     )
+  })
+})
+describe('untimeshifting respects the time precision', () => {
+  it('milliseconds are 0 when time precision is seconds', () => {
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['second'])
+    const unshiftedDate =
+      DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(
+        new Date('2023-04-23T22:39:46.117Z')
+      )
+    expect(unshiftedDate.getUTCMilliseconds()).to.equal(0)
+  })
+  it('seconds and milliseconds are 0 when time precision is minutes', () => {
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['minute'])
+    const unshiftedDate =
+      DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(
+        new Date('2023-04-23T22:39:46.117Z')
+      )
+    expect(unshiftedDate.getUTCMilliseconds()).to.equal(0)
+    expect(unshiftedDate.getUTCSeconds()).to.equal(0)
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
@@ -13,16 +13,18 @@
  *
  **/
 import { expect } from 'chai'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import user from '../singletons/user-instance'
+// TODO do I need to set a format for this?
+// TODO tests for precision
 user.get('user').get('preferences').set('timeZone', 'America/St_Johns')
 const date = new Date()
 describe('verify that transforming to and from timezone is accurate (no loss)', () => {
   it(`shifts and unshifts without losing information ${date.toISOString()}`, () => {
-    const timeShiftedDated =
-      DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(date.toISOString())
+    const timeShiftedDate =
+      DateHelpers.Blueprint.converters.TimeshiftForDatePicker(date.toISOString(), ISO_8601_FORMAT_ZONED)
     const unshiftedDate =
-      DateHelpers.Blueprint.converters.TimeshiftedDateToISO(timeShiftedDated)
-    expect(date.toISOString(), 'Unexpected difference').to.equal(unshiftedDate)
+      DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(timeShiftedDate)
+    expect(date.toISOString(), 'Unexpected difference').to.equal(unshiftedDate.toISOString())
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.spec.tsx
@@ -22,9 +22,16 @@ const date = new Date()
 describe('verify that transforming to and from timezone is accurate (no loss)', () => {
   it(`shifts and unshifts without losing information ${date.toISOString()}`, () => {
     const timeShiftedDate =
-      DateHelpers.Blueprint.converters.TimeshiftForDatePicker(date.toISOString(), ISO_8601_FORMAT_ZONED)
+      DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+        date.toISOString(),
+        ISO_8601_FORMAT_ZONED
+      )
     const unshiftedDate =
-      DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(timeShiftedDate)
-    expect(date.toISOString(), 'Unexpected difference').to.equal(unshiftedDate.toISOString())
+      DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(
+        timeShiftedDate
+      )
+    expect(date.toISOString(), 'Unexpected difference').to.equal(
+      unshiftedDate.toISOString()
+    )
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -1,7 +1,6 @@
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { IDateInputProps } from '@blueprintjs/datetime'
 import { IDateRangeInputProps } from '@blueprintjs/datetime'
-import { TimePrecision } from '@blueprintjs/datetime'
 import user from '../singletons/user-instance'
 import moment from 'moment-timezone'
 import {
@@ -9,6 +8,7 @@ import {
   isDayInRange,
 } from '@blueprintjs/datetime/lib/esm/common/dateUtils'
 import { getDefaultMaxDate } from '@blueprintjs/datetime/lib/esm/datePickerCore'
+import Common from '../../js/Common'
 
 export const ISO_8601_FORMAT_ZONED = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 
@@ -29,10 +29,9 @@ export const DateHelpers = {
       return user.get('user').get('preferences').get('timeZone') as string
     },
     getTimePrecision: () => {
-      return user
-        .get('user')
-        .get('preferences')
-        .get('timePrecision') as TimePrecision
+      return Common.getDateTimeFormatsReverseMap()[
+        DateHelpers.General.getDateFormat()
+      ].precision
     },
   },
   Blueprint: {
@@ -45,7 +44,7 @@ export const DateHelpers = {
        * TLDR: this function is only called when the user manually types in a date
        */
       parseDate: (input?: string) => {
-        console.log('parseDate', input)
+        //console.log('parseDate', input)
         try {
           return DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
             input || '',
@@ -59,7 +58,7 @@ export const DateHelpers = {
        * Basically undoes the value shift to make sure the date is displayed in user's chosen timezone
        */
       formatDate: (date: Date) => {
-        console.log('formatDate', date)
+        //console.log('formatDate', date)
         try {
           const unshiftedDate =
             DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(date)
@@ -93,7 +92,7 @@ export const DateHelpers = {
         }) as IDateInputProps['onChange']
       },
       generateValue: (value: string, minDate?: Date, maxDate?: Date) => {
-        console.log('generateValue', value)
+        //console.log('generateValue', value)
         return DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
           value,
           ISO_8601_FORMAT_ZONED,
@@ -105,6 +104,7 @@ export const DateHelpers = {
     DateRangeProps: {
       generateOnChange: (onChange: (value: ValueTypes['during']) => void) => {
         return (([start, end]) => {
+          console.log('onChange', start, end)
           if (onChange) {
             onChange({
               start: start
@@ -157,14 +157,14 @@ export const DateHelpers = {
       ): Date => {
         try {
           const unshiftedDate = moment(value, format)
-          console.log(
+          /*console.log(
             'before timeshifting date',
             value,
             unshiftedDate,
             unshiftedDate.toDate()
-          )
+          )*/
           if (!unshiftedDate.isValid()) {
-            console.log('INVALID DATE FOR DATE PICKER')
+            //console.log('INVALID DATE FOR DATE PICKER')
             return DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
               moment.utc().toISOString(),
               ISO_8601_FORMAT_ZONED
@@ -183,12 +183,12 @@ export const DateHelpers = {
             .utcOffset()
           const totalOffset = utcOffsetMinutesLocal + utcOffsetMinutesTimezone
           const shiftedDate = unshiftedDate.add(totalOffset, 'minutes')
-          console.log(
+          /*console.log(
             'after timeshifting date',
             value,
             shiftedDate,
             shiftedDate.toDate()
-          )
+          )*/
           if (
             shiftedDate.isValid() &&
             DateHelpers.Blueprint.commonProps.isValid(
@@ -221,7 +221,7 @@ export const DateHelpers = {
       UntimeshiftFromDatePicker: (value: Date) => {
         try {
           const shiftedDate = moment(value)
-          console.log('before untimeshifting date', value, shiftedDate)
+          //console.log('before untimeshifting date', value, shiftedDate)
           switch (DateHelpers.General.getTimePrecision()) {
             case 'minute':
               shiftedDate.seconds(0)
@@ -235,7 +235,7 @@ export const DateHelpers = {
             .utcOffset()
           const totalOffset = utcOffsetMinutesLocal + utcOffsetMinutesTimezone
           const temp = shiftedDate.subtract(totalOffset, 'minutes').toDate()
-          console.log('after untimeshifting date', value, temp)
+          //console.log('after untimeshifting date', value, temp)
           return temp
         } catch (err) {
           console.error(err)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -1,6 +1,7 @@
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { IDateInputProps } from '@blueprintjs/datetime'
 import { IDateRangeInputProps } from '@blueprintjs/datetime'
+import { TimePrecision } from '@blueprintjs/datetime'
 import user from '../singletons/user-instance'
 import moment from 'moment-timezone'
 import {
@@ -24,6 +25,12 @@ export const DateHelpers = {
     },
     getTimeZone: () => {
       return user.get('user').get('preferences').get('timeZone') as string
+    },
+    getTimePrecision: () => {
+      return user
+        .get('user')
+        .get('preferences')
+        .get('timePrecision') as TimePrecision
     },
   },
   Blueprint: {
@@ -134,8 +141,13 @@ export const DateHelpers = {
         try {
           const originalDate = new Date(value)
           let momentShiftedDate = moment.utc(originalDate.toUTCString())
-          // we lose milliseconds with utc, so add them back in here
-          momentShiftedDate.add(originalDate.getMilliseconds(), 'milliseconds')
+          if (DateHelpers.General.getTimePrecision() === 'millisecond') {
+            // we lose milliseconds with utc, so add them back in here
+            momentShiftedDate.add(
+              originalDate.getMilliseconds(),
+              'milliseconds'
+            )
+          }
           const utcOffsetMinutesLocal = new Date().getTimezoneOffset()
           const utcOffsetMinutesTimezone = moment
             .tz(value, DateHelpers.General.getTimeZone()) // pass in the value, otherwise it won't account for daylight savings time!
@@ -173,8 +185,10 @@ export const DateHelpers = {
       TimeshiftedDateToISO: (value: Date) => {
         try {
           let momentShiftedDate = moment.utc(value.toUTCString())
-          // we lose milliseconds with utc, so add them back in here
-          momentShiftedDate.add(value.getMilliseconds(), 'milliseconds')
+          if (DateHelpers.General.getTimePrecision() === 'millisecond') {
+            // we lose milliseconds with utc, so add them back in here
+            momentShiftedDate.add(value.getMilliseconds(), 'milliseconds')
+          }
           const utcOffsetMinutesLocal = new Date().getTimezoneOffset()
           const utcOffsetMinutesTimezone = moment
             .tz(value, DateHelpers.General.getTimeZone()) // pass in the value, otherwise it won't account for daylight savings time!

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -99,14 +99,13 @@ export const DateHelpers = {
           }
         }) as IDateInputProps['onChange']
       },
-      generateValue: (value: string, minDate?: Date, maxDate?: Date) => {
-        return DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+      generateValue: (value: string, minDate?: Date, maxDate?: Date) =>
+        DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
           value,
           ISO_8601_FORMAT_ZONED,
           minDate,
           maxDate
-        )
-      },
+        ),
     },
     DateRangeProps: {
       generateOnChange: (onChange: (value: ValueTypes['during']) => void) => {
@@ -153,7 +152,7 @@ export const DateHelpers = {
        * chosen timezone, we have to shift the date ourselves.  So what we do is pretend the value is utc, then calculate the offset of the computer's local timezone and the timezone the user wants to create a total offset.  This is because the datepicker internally
        * uses date, so we have to pretend we're in local time.  We then take that utc date and add the totaloffset, then tell the datepicker that is our value.  As a result, when the datepicker internally uses Date it will shift back to the correct timezone.
        *
-       * TLDR: Use this on a date string formatted by the user's preference going INTO the blueprint datepicker (the value prop).  Use the sibling function TimeshiftedDateToFormattedDate to reverse this.
+       * TLDR: Use this on a date string formatted in the manner specified by the provided format going INTO the blueprint datepicker (the value prop).  Use the sibling function UntimeshiftFromDatePicker to reverse this.
        */
       TimeshiftForDatePicker: (
         value: string,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -9,7 +9,7 @@ import moment from 'moment'
 
 import user from '../singletons/user-instance'
 import { ValueTypes } from '../filter-builder/filter.structure'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import Common from '../../js/Common'
 
 const UncontrolledDateRangeField = ({
@@ -208,11 +208,13 @@ describe('verify date field works', () => {
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
       [
-        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-          data.date5.originalISO
+        DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+          data.date5.originalISO,
+          ISO_8601_FORMAT_ZONED
         ),
-        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-          data.date5.originalISO
+        DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+          data.date5.originalISO,
+          ISO_8601_FORMAT_ZONED
         ),
       ],
       true
@@ -234,11 +236,13 @@ describe('verify date field works', () => {
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
       [
-        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-          data.date1.originalISO
+        DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+          data.date1.originalISO,
+          ISO_8601_FORMAT_ZONED
         ),
-        DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-          data.date1.originalISO
+        DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+          data.date1.originalISO,
+          ISO_8601_FORMAT_ZONED
         ),
       ],
       true

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -35,6 +35,7 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-15T06:53:54.316Z',
     originalDate: new Date('2021-01-15T06:53:54.316Z'),
+    utcISOMinutes: '2021-01-15T06:53:00.000Z',
     userFormatISO: {
       millisecond: '2021-01-15T03:23:54.316-03:30',
       second: '2021-01-15T03:23:54-03:30',
@@ -65,6 +66,7 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-14T06:53:54.316Z',
     originalDate: new Date('2021-01-14T06:53:54.316Z'),
+    utcISOMinutes: '2021-01-14T06:53:00.000Z',
     userFormatISO: {
       millisecond: '2021-01-14T03:23:54.316-03:30',
       second: '2021-01-14T03:23:54-03:30',
@@ -102,12 +104,14 @@ describe('verify date range field works', () => {
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   afterEach(() => {
+    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
+    // Has to be unmounted before we set any preferences so we don't trigger any onChange
+    // callbacks again.
+    wrapper.unmount()
     user
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
-    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
-    wrapper.unmount()
   })
   it(`should not allow overlapping dates`, () => {
     user
@@ -352,5 +356,23 @@ describe('verify date range field works', () => {
     input.simulate('change', {
       target: { value: data.date3.maxFuture },
     })
+  })
+  it('calls onChange with updated value when precision changes', () => {
+    wrapper = mount(
+      <DateRangeField
+        value={{
+          start: data.date4.originalISO,
+          end: data.date1.originalISO,
+        }}
+        onChange={(updatedValue) => {
+          expect(updatedValue.start).to.equal(data.date4.utcISOMinutes)
+          expect(updatedValue.end).to.equal(data.date1.utcISOMinutes)
+        }}
+      />
+    )
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['minute'])
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -73,19 +73,19 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   afterEach(() => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   it(`should not allow overlapping dates`, () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
     const wrapper = mount(
       <DateRangeField
         value={{
@@ -106,7 +106,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
     const wrapper = mount(
       <DateRangeField
         value={{
@@ -127,7 +127,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['12'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['12']['millisecond'])
 
     const wrapper = mount(
       <DateRangeField
@@ -149,7 +149,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['24'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
 
     const wrapper = mount(
       <DateRangeField
@@ -172,7 +172,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['24'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
 
     const wrapper = mount(
       <UncontrolledDateRangeField
@@ -266,18 +266,21 @@ describe('verify date field works', () => {
     })
   })
   it(`should allow dates up to max future`, () => {
+    const initValue = {
+      start: new Date().toISOString(),
+      end: new Date().toISOString(),
+    }
+    console.log('initValue', initValue)
     const wrapper = mount(
       <DateRangeField
-        value={{
-          start: new Date().toISOString(),
-          end: new Date().toISOString(),
-        }}
+        value={initValue}
         onChange={(updatedValue) => {
-          expect(updatedValue.start).to.equal(data.date3.maxFuture)
+          console.log('TEST onChange', updatedValue)
+          expect(updatedValue.end).to.equal(data.date3.maxFuture)
         }}
       />
     )
-    const input = wrapper.find('input').first()
+    const input = wrapper.find('input').last()
     input.simulate('change', {
       target: { value: data.date3.maxFuture },
     })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -11,6 +11,7 @@ import user from '../singletons/user-instance'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { DateHelpers, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import Common from '../../js/Common'
+import { TimePrecision } from '@blueprintjs/datetime'
 
 const UncontrolledDateRangeField = ({
   startingValue,
@@ -34,9 +35,21 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-15T06:53:54.316Z',
     originalDate: new Date('2021-01-15T06:53:54.316Z'),
-    userFormatISO: '2021-01-15T03:23:54.316-03:30',
-    userFormat24: '15 Jan 2021 03:23:54.316 -03:30',
-    userFormat12: '15 Jan 2021 03:23:54.316 am -03:30',
+    userFormatISO: {
+      millisecond: '2021-01-15T03:23:54.316-03:30',
+      second: '2021-01-15T03:23:54-03:30',
+      minute: '2021-01-15T03:23-03:30',
+    },
+    userFormat24: {
+      millisecond: '15 Jan 2021 03:23:54.316 -03:30',
+      second: '15 Jan 2021 03:23:54 -03:30',
+      minute: '15 Jan 2021 03:23 -03:30',
+    },
+    userFormat12: {
+      millisecond: '15 Jan 2021 03:23:54.316 am -03:30',
+      second: '15 Jan 2021 03:23:54 am -03:30',
+      minute: '15 Jan 2021 03:23 am -03:30',
+    },
   },
   date2: {
     timezone: 'America/St_Johns',
@@ -52,9 +65,21 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-14T06:53:54.316Z',
     originalDate: new Date('2021-01-14T06:53:54.316Z'),
-    userFormatISO: '2021-01-14T03:23:54.316-03:30',
-    userFormat24: '14 Jan 2021 03:23:54.316 -03:30',
-    userFormat12: '14 Jan 2021 03:23:54.316 am -03:30',
+    userFormatISO: {
+      millisecond: '2021-01-14T03:23:54.316-03:30',
+      second: '2021-01-14T03:23:54-03:30',
+      minute: '2021-01-14T03:23-03:30',
+    },
+    userFormat24: {
+      millisecond: '14 Jan 2021 03:23:54.316 -03:30',
+      second: '14 Jan 2021 03:23:54 -03:30',
+      minute: '14 Jan 2021 03:23 -03:30',
+    },
+    userFormat12: {
+      millisecond: '14 Jan 2021 03:23:54.316 am -03:30',
+      second: '14 Jan 2021 03:23:54 am -03:30',
+      minute: '14 Jan 2021 03:23 am -03:30',
+    },
   },
   // this is useful for testing daylist savings (date 1 is pre, this is post)
   date5: {
@@ -62,7 +87,8 @@ const data = {
     originalISO: '2021-04-15T05:53:54.316Z', // use the converter to find the appropriate shifted date
   },
 }
-describe('verify date field works', () => {
+let wrapper: Enzyme.ReactWrapper
+describe('verify date range field works', () => {
   before(() => {
     user.get('user').get('preferences').set('timeZone', data.date1.timezone)
   })
@@ -80,13 +106,15 @@ describe('verify date field works', () => {
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
+    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
+    wrapper.unmount()
   })
   it(`should not allow overlapping dates`, () => {
     user
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
-    const wrapper = mount(
+    wrapper = mount(
       <DateRangeField
         value={{
           start: data.date1.originalISO,
@@ -96,77 +124,119 @@ describe('verify date field works', () => {
       />
     )
     expect(wrapper.render().find('input').first().val()).to.equal(
-      data.date1.userFormatISO
+      data.date1.userFormatISO.millisecond
     )
     expect(wrapper.render().find('input').last().val()).to.equal(
       'Overlapping dates'
     )
   })
-  it(`should allow non-overlapping dates`, () => {
-    user
-      .get('user')
-      .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
-    const wrapper = mount(
-      <DateRangeField
-        value={{
-          start: data.date4.originalISO,
-          end: data.date1.originalISO,
-        }}
-        onChange={() => {}}
-      />
+  const verifyDateRender = (
+    format: string,
+    precision: TimePrecision,
+    expectedStart: string,
+    expectedEnd: string
+  ) => {
+    return () => {
+      user
+        .get('user')
+        .get('preferences')
+        .set('dateTimeFormat', Common.getDateTimeFormats()[format][precision])
+      wrapper = mount(
+        <DateRangeField
+          value={{
+            start: data.date4.originalISO,
+            end: data.date1.originalISO,
+          }}
+          onChange={() => {}}
+        />
+      )
+      expect(wrapper.render().find('input').first().val()).to.equal(
+        expectedStart
+      )
+      expect(wrapper.render().find('input').last().val()).to.equal(expectedEnd)
+    }
+  }
+  it(
+    'should render with ISO format and millisecond precision',
+    verifyDateRender(
+      'ISO',
+      'millisecond',
+      data.date4.userFormatISO.millisecond,
+      data.date1.userFormatISO.millisecond
     )
-    expect(wrapper.render().find('input').first().val()).to.equal(
-      data.date4.userFormatISO
+  )
+  it(
+    'should render with ISO format and second precision',
+    verifyDateRender(
+      'ISO',
+      'second',
+      data.date4.userFormatISO.second,
+      data.date1.userFormatISO.second
     )
-    expect(wrapper.render().find('input').last().val()).to.equal(
-      data.date1.userFormatISO
+  )
+  it(
+    'should render with ISO format and minute precision',
+    verifyDateRender(
+      'ISO',
+      'minute',
+      data.date4.userFormatISO.minute,
+      data.date1.userFormatISO.minute
     )
-  })
-  it(`should render with user's pref format of 12hr standard`, () => {
-    user
-      .get('user')
-      .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['12']['millisecond'])
-
-    const wrapper = mount(
-      <DateRangeField
-        value={{
-          start: data.date4.originalISO,
-          end: data.date1.originalISO,
-        }}
-        onChange={() => {}}
-      />
+  )
+  it(
+    'should render with 24hr format and millisecond precision',
+    verifyDateRender(
+      '24',
+      'millisecond',
+      data.date4.userFormat24.millisecond,
+      data.date1.userFormat24.millisecond
     )
-    expect(wrapper.render().find('input').first().val()).to.equal(
-      data.date4.userFormat12
+  )
+  it(
+    'should render with 24hr format and second precision',
+    verifyDateRender(
+      '24',
+      'second',
+      data.date4.userFormat24.second,
+      data.date1.userFormat24.second
     )
-    expect(wrapper.render().find('input').last().val()).to.equal(
-      data.date1.userFormat12
+  )
+  it(
+    'should render with 24hr format and minute precision',
+    verifyDateRender(
+      '24',
+      'minute',
+      data.date4.userFormat24.minute,
+      data.date1.userFormat24.minute
     )
-  })
-  it(`should render with user's pref format of 24hr standard`, () => {
-    user
-      .get('user')
-      .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
-
-    const wrapper = mount(
-      <DateRangeField
-        value={{
-          start: data.date4.originalISO,
-          end: data.date1.originalISO,
-        }}
-        onChange={() => {}}
-      />
+  )
+  it(
+    'should render with 12hr format and millisecond precision',
+    verifyDateRender(
+      '12',
+      'millisecond',
+      data.date4.userFormat12.millisecond,
+      data.date1.userFormat12.millisecond
     )
-    expect(wrapper.render().find('input').first().val()).to.equal(
-      data.date4.userFormat24
+  )
+  it(
+    'should render with 12hr format and second precision',
+    verifyDateRender(
+      '12',
+      'second',
+      data.date4.userFormat12.second,
+      data.date1.userFormat12.second
     )
-    expect(wrapper.render().find('input').last().val()).to.equal(
-      data.date1.userFormat24
+  )
+  it(
+    'should render with 12hr format and minute precision',
+    verifyDateRender(
+      '12',
+      'minute',
+      data.date4.userFormat12.minute,
+      data.date1.userFormat12.minute
     )
-  })
+  )
   it(`should parse with user's pref timezone`, () => {
     // gist is user enters a time in a diff time from their pref, on blur we adjust it to their preference
     user
@@ -174,7 +244,7 @@ describe('verify date field works', () => {
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
 
-    const wrapper = mount(
+    wrapper = mount(
       <UncontrolledDateRangeField
         startingValue={{
           start: data.date2.userSuppliedInput,
@@ -193,7 +263,7 @@ describe('verify date field works', () => {
     expect(input.last().render().val()).to.equal(data.date2.parsedOutput)
   })
   it(`should generate appropriately shifted ISO strings on change (DST)`, () => {
-    const wrapper = mount(
+    wrapper = mount(
       <DateRangeField
         value={{
           start: new Date().toISOString(),
@@ -221,7 +291,7 @@ describe('verify date field works', () => {
     )
   })
   it(`should generate appropriately shifted ISO strings on change`, () => {
-    const wrapper = mount(
+    wrapper = mount(
       <DateRangeField
         value={{
           start: new Date().toISOString(),
@@ -249,7 +319,7 @@ describe('verify date field works', () => {
     )
   })
   it(`should not allow dates beyond max future`, () => {
-    const wrapper = mount(
+    wrapper = mount(
       <DateRangeField
         value={{
           start: new Date().toISOString(),
@@ -270,17 +340,15 @@ describe('verify date field works', () => {
       start: new Date().toISOString(),
       end: new Date().toISOString(),
     }
-    console.log('initValue', initValue)
-    const wrapper = mount(
+    wrapper = mount(
       <DateRangeField
         value={initValue}
         onChange={(updatedValue) => {
-          console.log('TEST onChange', updatedValue)
-          expect(updatedValue.end).to.equal(data.date3.maxFuture)
+          expect(updatedValue.start).to.equal(data.date3.maxFuture)
         }}
       />
     )
-    const input = wrapper.find('input').last()
+    const input = wrapper.find('input').first()
     input.simulate('change', {
       target: { value: data.date3.maxFuture },
     })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -41,8 +41,7 @@ const validateDates = (
     value.end === undefined
   ) {
     const end = new Date()
-    const start = new Date(end)
-    start.setDate(start.getDate() - 1) // start and end can't be equal or the backend will throw a fit
+    const start = new Date(end.valueOf() - 86_400_000) // start and end can't be equal or the backend will throw a fit
     switch (DateHelpers.General.getTimePrecision()) {
       case 'minute':
         start.setUTCSeconds(0)
@@ -69,6 +68,7 @@ export const DateRangeField = ({
   const valueRef = React.useRef(value)
 
   useTimePrefs(() => {
+    console.log('useTimePrefs callback', valueRef.current)
     const shiftedDates = DateHelpers.Blueprint.DateRangeProps.generateValue(
       valueRef.current
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -114,6 +114,7 @@ export const DateRangeField = ({
       parseDate={DateHelpers.Blueprint.commonProps.parseDate}
       shortcuts
       timePrecision={DateHelpers.General.getTimePrecision()}
+      placeholder={DateHelpers.General.getDateFormat()}
       {...(value
         ? {
             value: DateHelpers.Blueprint.DateRangeProps.generateValue(value),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -79,7 +79,7 @@ export const DateRangeField = ({
       onChange={DateHelpers.Blueprint.DateRangeProps.generateOnChange(onChange)}
       parseDate={DateHelpers.Blueprint.commonProps.parseDate}
       shortcuts
-      timePrecision="millisecond"
+      timePrecision={DateHelpers.General.getTimePrecision()}
       {...(value
         ? {
             value: DateHelpers.Blueprint.DateRangeProps.generateValue(value),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -68,7 +68,6 @@ export const DateRangeField = ({
   const valueRef = React.useRef(value)
 
   useTimePrefs(() => {
-    console.log('useTimePrefs callback', valueRef.current)
     const shiftedDates = DateHelpers.Blueprint.DateRangeProps.generateValue(
       valueRef.current
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -40,17 +40,10 @@ const validateDates = (
     value.start === undefined ||
     value.end === undefined
   ) {
-    const end = new Date()
-    const start = new Date(end.valueOf() - 86_400_000) // start and end can't be equal or the backend will throw a fit
-    switch (DateHelpers.General.getTimePrecision()) {
-      case 'minute':
-        start.setUTCSeconds(0)
-        end.setUTCSeconds(0)
-      // Intentional fall-through
-      case 'second':
-        start.setUTCMilliseconds(0)
-        end.setUTCMilliseconds(0)
-    }
+    const end = DateHelpers.General.withPrecision(new Date())
+    const start = DateHelpers.General.withPrecision(
+      new Date(end.valueOf() - 86_400_000)
+    ) // start and end can't be equal or the backend will throw a fit
     const newValue = {
       start: start.toISOString(),
       end: end.toISOString(),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
@@ -42,6 +42,7 @@ const data = {
     timezone: 'America/St_Johns',
     originalISO: '2021-01-15T06:53:54.316Z',
     originalDate: new Date('2021-01-15T06:53:54.316Z'),
+    utcISOMinutes: '2021-01-15T06:53:00.000Z',
     userFormatISO: {
       millisecond: '2021-01-15T03:23:54.316-03:30',
       second: '2021-01-15T03:23:54-03:30',
@@ -89,12 +90,14 @@ describe('verify date field works', () => {
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   afterEach(() => {
+    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
+    // Has to be unmounted before we set any preferences so we don't trigger any onChange
+    // callbacks again.
+    wrapper.unmount()
     user
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
-    // Must unmount to stop listening to the user prefs model (the useTimePrefs() hook)
-    wrapper.unmount()
   })
   const verifyDateRender = (
     format: string,
@@ -227,5 +230,19 @@ describe('verify date field works', () => {
     input.simulate('change', {
       target: { value: data.date3.maxFuture },
     })
+  })
+  it('calls onChange with updated value when precision changes', () => {
+    wrapper = mount(
+      <DateField
+        value={data.date1.userFormatISO.millisecond}
+        onChange={(updatedValue) => {
+          expect(updatedValue).to.equal(data.date1.utcISOMinutes)
+        }}
+      />
+    )
+    user
+      .get('user')
+      .get('preferences')
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['minute'])
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
@@ -8,7 +8,7 @@ import moment from 'moment'
 import { expect } from 'chai'
 
 import user from '../singletons/user-instance'
-import { DateHelpers } from './date-helpers'
+import { DateHelpers, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import Common from '../../js/Common'
 
 /**
@@ -145,8 +145,9 @@ describe('verify date field works', () => {
     )
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
-      DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-        data.date4.originalISO
+      DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+        data.date4.originalISO,
+        ISO_8601_FORMAT_ZONED
       ),
       true
     )
@@ -162,8 +163,9 @@ describe('verify date field works', () => {
     )
     const dateFieldInstance = wrapper.children().get(0)
     dateFieldInstance.props.onChange(
-      DateHelpers.Blueprint.converters.ISOToTimeshiftedDate(
-        data.date1.originalISO
+      DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+        data.date1.originalISO,
+        ISO_8601_FORMAT_ZONED
       ),
       true
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.spec.tsx
@@ -72,19 +72,19 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   afterEach(() => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
   })
   it(`should render with user's pref format of ISO`, () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['millisecond'])
     const wrapper = mount(
       <DateField value={data.date1.originalISO} onChange={() => {}} />
     )
@@ -96,7 +96,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['12'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['12']['millisecond'])
 
     const wrapper = mount(
       <DateField value={data.date1.originalISO} onChange={() => {}} />
@@ -109,7 +109,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['24'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
 
     const wrapper = mount(
       <DateField value={data.date1.originalISO} onChange={() => {}} />
@@ -123,7 +123,7 @@ describe('verify date field works', () => {
     user
       .get('user')
       .get('preferences')
-      .set('dateTimeFormat', Common.getDateTimeFormats()['24'])
+      .set('dateTimeFormat', Common.getDateTimeFormats()['24']['millisecond'])
 
     const wrapper = mount(
       <UncontrolledDateField startingValue={data.date1.originalISO} />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -16,7 +16,12 @@ import * as React from 'react'
 import { useRef } from 'react'
 import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
 
-import { DateHelpers, DefaultMaxDate, DefaultMinDate, ISO_8601_FORMAT_ZONED } from './date-helpers'
+import {
+  DateHelpers,
+  DefaultMaxDate,
+  DefaultMinDate,
+  ISO_8601_FORMAT_ZONED,
+} from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -16,7 +16,7 @@ import * as React from 'react'
 import { useRef } from 'react'
 import { DateInput, IDateInputProps } from '@blueprintjs/datetime'
 
-import { DateHelpers, DefaultMaxDate, DefaultMinDate } from './date-helpers'
+import { DateHelpers, DefaultMaxDate, DefaultMinDate, ISO_8601_FORMAT_ZONED } from './date-helpers'
 import { MuiOutlinedInputBorderClasses } from '../theme/theme'
 import useTimePrefs from './useTimePrefs'
 
@@ -39,7 +39,7 @@ const validateDate = (
   valueRef: React.MutableRefObject<string>
 ) => {
   //console.log('validating', value, DateHelpers.General.getDateFormat())
-  const date = moment(value, DateHelpers.General.getDateFormat())
+  const date = moment(value, ISO_8601_FORMAT_ZONED)
   if (!date.isValid()) {
     //console.log('INVALID DATE', value, DateHelpers.General.getDateFormat())
     const newDate = new Date()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -38,10 +38,10 @@ const validateDate = (
   { value, onChange }: DateFieldProps,
   valueRef: React.MutableRefObject<string>
 ) => {
-  console.log('validating', value, DateHelpers.General.getDateFormat())
+  //console.log('validating', value, DateHelpers.General.getDateFormat())
   const date = moment(value, DateHelpers.General.getDateFormat())
   if (!date.isValid()) {
-    console.log('INVALID DATE', value, DateHelpers.General.getDateFormat())
+    //console.log('INVALID DATE', value, DateHelpers.General.getDateFormat())
     const newDate = new Date()
     switch (DateHelpers.General.getTimePrecision()) {
       case 'minute':
@@ -50,13 +50,13 @@ const validateDate = (
       case 'second':
         newDate.setUTCMilliseconds(0)
     }
-    onChange(newDate.toISOString())
     valueRef.current = newDate.toISOString()
+    onChange(newDate.toISOString())
   }
 }
 
 export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
-  console.log('DateField', value)
+  //console.log('DateField', value)
 
   const valueRef = useRef(value)
 
@@ -69,7 +69,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
     onChange(unshiftedDate.toISOString())
   })
   React.useEffect(() => {
-    console.log('RUNNING DateField EFFECT')
+    //console.log('RUNNING DateField EFFECT')
     validateDate({ onChange, value }, valueRef)
   }, [])
 
@@ -83,8 +83,8 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         fill
         formatDate={DateHelpers.Blueprint.commonProps.formatDate}
         onChange={DateHelpers.Blueprint.DateProps.generateOnChange((value) => {
-          onChange(value)
           valueRef.current = value
+          onChange(value)
         })}
         parseDate={DateHelpers.Blueprint.commonProps.parseDate}
         placeholder={DateHelpers.General.getDateFormat()}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -57,7 +57,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
         parseDate={DateHelpers.Blueprint.commonProps.parseDate}
         placeholder={'M/D/YYYY'}
         shortcuts
-        timePrecision="millisecond"
+        timePrecision={DateHelpers.General.getTimePrecision()}
         outOfRangeMessage="Out of range"
         timePickerProps={{
           useAmPm: user.getAmPmDisplay(),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -43,26 +43,15 @@ const validateDate = (
   { value, onChange }: DateFieldProps,
   valueRef: React.MutableRefObject<string>
 ) => {
-  //console.log('validating', value, DateHelpers.General.getDateFormat())
   const date = moment(value, ISO_8601_FORMAT_ZONED)
   if (!date.isValid()) {
-    //console.log('INVALID DATE', value, DateHelpers.General.getDateFormat())
-    const newDate = new Date()
-    switch (DateHelpers.General.getTimePrecision()) {
-      case 'minute':
-        newDate.setUTCSeconds(0)
-      // Intentional fall-through
-      case 'second':
-        newDate.setUTCMilliseconds(0)
-    }
+    const newDate = DateHelpers.General.withPrecision(new Date())
     valueRef.current = newDate.toISOString()
     onChange(newDate.toISOString())
   }
 }
 
 export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
-  //console.log('DateField', value)
-
   const valueRef = useRef(value)
 
   useTimePrefs(() => {
@@ -74,7 +63,6 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
     onChange(unshiftedDate.toISOString())
   })
   React.useEffect(() => {
-    //console.log('RUNNING DateField EFFECT')
     validateDate({ onChange, value }, valueRef)
   }, [])
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
@@ -9,7 +9,7 @@ const useTimePrefs = () => {
   useEffect(() => {
     listenTo(
       user.getPreferences(),
-      'change:dateTimeFormat change:timeZone',
+      'change:dateTimeFormat change:timePrecision change:timeZone',
       () => {
         setForceRender(Math.random())
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
@@ -2,18 +2,26 @@ import { useState, useEffect } from 'react'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import user from '../singletons/user-instance'
 
-const useTimePrefs = () => {
-  const { listenTo } = useBackbone()
+const useTimePrefs = (action?: () => void) => {
+  const { listenTo, stopListening } = useBackbone()
   const [, setForceRender] = useState(Math.random())
 
   useEffect(() => {
+    const callback = () => {
+      setForceRender(Math.random())
+      action && action()
+    }
     listenTo(
       user.getPreferences(),
       'change:dateTimeFormat change:timePrecision change:timeZone',
-      () => {
-        setForceRender(Math.random())
-      }
+      callback
     )
+    return () =>
+      stopListening(
+        user.getPreferences(),
+        'change:dateTimeFormat change:timePrecision change:timeZone',
+        callback
+      )
   }, [])
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
@@ -13,13 +13,13 @@ const useTimePrefs = (action?: () => void) => {
     }
     listenTo(
       user.getPreferences(),
-      'change:dateTimeFormat change:timePrecision change:timeZone',
+      'change:dateTimeFormat change:timeZone',
       callback
     )
     return () =>
       stopListening(
         user.getPreferences(),
-        'change:dateTimeFormat change:timePrecision change:timeZone',
+        'change:dateTimeFormat change:timeZone',
         callback
       )
   }, [])

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -679,7 +679,7 @@ const Summary = ({ result: selection }: Props) => {
   React.useEffect(() => {
     listenTo(
       user.get('user').get('preferences'),
-      'change:inspector-summaryShown change:dateTimeFormat change:timePrecision change:timeZone',
+      'change:inspector-summaryShown change:dateTimeFormat change:timeZone',
       () => {
         setSummaryShown([...getSummaryShown()])
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -679,7 +679,7 @@ const Summary = ({ result: selection }: Props) => {
   React.useEffect(() => {
     listenTo(
       user.get('user').get('preferences'),
-      'change:inspector-summaryShown change:dateTimeFormat change:timeZone',
+      'change:inspector-summaryShown change:dateTimeFormat change:timePrecision change:timeZone',
       () => {
         setSummaryShown([...getSummaryShown()])
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/Common.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/Common.tsx
@@ -17,6 +17,7 @@ import $ from 'jquery'
 import moment from 'moment'
 import './requestAnimationFramePolyfill'
 import properties from './properties'
+import { TimePrecision } from '@blueprintjs/datetime'
 const timeZones = {
   UTC: 'Etc/UTC',
   '-12': 'Etc/GMT+12',
@@ -45,10 +46,73 @@ const timeZones = {
   12: 'Etc/GMT-12',
 }
 const dateTimeFormats = {
-  ISO: { datetimefmt: 'YYYY-MM-DD[T]HH:mm:ss.SSSZ', timefmt: 'HH:mm:ssZ' },
-  24: { datetimefmt: 'DD MMM YYYY HH:mm:ss.SSS Z', timefmt: 'HH:mm:ss Z' },
-  12: { datetimefmt: 'DD MMM YYYY hh:mm:ss.SSS a Z', timefmt: 'hh:mm:ss a Z' },
+  ISO: {
+    millisecond: {
+      datetimefmt: 'YYYY-MM-DD[T]HH:mm:ss.SSSZ',
+      timefmt: 'HH:mm:ssZ',
+    },
+    second: { datetimefmt: 'YYYY-MM-DD[T]HH:mm:ssZ', timefmt: 'HH:mm:ssZ' },
+    minute: { datetimefmt: 'YYYY-MM-DD[T]HH:mmZ', timefmt: 'HH:mmZ' },
+  },
+  '24': {
+    millisecond: {
+      datetimefmt: 'DD MMM YYYY HH:mm:ss.SSS Z',
+      timefmt: 'HH:mm:ss Z',
+    },
+    second: {
+      datetimefmt: 'DD MMM YYYY HH:mm:ss Z',
+      timefmt: 'HH:mm:ss Z',
+    },
+    minute: {
+      datetimefmt: 'DD MMM YYYY HH:mm Z',
+      timefmt: 'HH:mm Z',
+    },
+  },
+  '12': {
+    millisecond: {
+      datetimefmt: 'DD MMM YYYY hh:mm:ss.SSS a Z',
+      timefmt: 'hh:mm:ss a Z',
+    },
+    second: {
+      datetimefmt: 'DD MMM YYYY hh:mm:ss a Z',
+      timefmt: 'hh:mm:ss a Z',
+    },
+    minute: {
+      datetimefmt: 'DD MMM YYYY hh:mm a Z',
+      timefmt: 'hh:mm a Z',
+    },
+  },
+} as {
+  [key: string]: {
+    [key in keyof TimePrecision as TimePrecision]: {
+      datetimefmt: string
+      timefmt: string
+    }
+  }
 }
+const dateTimeFormatsReverseMap = Object.entries(dateTimeFormats).reduce(
+  (map, val) => {
+    const format = val[0]
+    for (const [precision, formats] of Object.entries(val[1])) {
+      map[formats.datetimefmt] = {
+        format,
+        precision: precision as TimePrecision,
+      }
+    }
+    return map
+  },
+  {} as { [key: string]: { format: string; precision: TimePrecision } }
+)
+const timeFormatsReverseMap = Object.entries(dateTimeFormats).reduce(
+  (map, val) => {
+    const format = val[0]
+    for (const [precision, formats] of Object.entries(val[1])) {
+      map[formats.timefmt] = { format, precision: precision as TimePrecision }
+    }
+    return map
+  },
+  {} as { [key: string]: { format: string; precision: TimePrecision } }
+)
 export const Common = {
   //randomly generated guid guaranteed to be unique ;)
   undefined: '2686dcb5-7578-4957-974d-aaa9289cd2f0',
@@ -154,10 +218,16 @@ export const Common = {
   },
   //can be deleted once histogram changes are merged
   getHumanReadableDateTime(date: string) {
-    return moment(date).format(dateTimeFormats['24']['datetimefmt'])
+    return moment(date).format(dateTimeFormats['24']['second']['datetimefmt'])
   },
   getDateTimeFormats() {
     return dateTimeFormats
+  },
+  getDateTimeFormatsReverseMap() {
+    return dateTimeFormatsReverseMap
+  },
+  getTimeFormatsReverseMap() {
+    return timeFormatsReverseMap
   },
   getTimeZones() {
     return timeZones

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -143,7 +143,6 @@ const Theme = Backbone.Model.extend({
       fontSize: 16,
       resultCount: (properties as any).resultCount,
       dateTimeFormat: Common.getDateTimeFormats()['ISO']['millisecond'],
-      timePrecision: 'millisecond',
       timeZone: Common.getTimeZones()['UTC'],
       coordinateFormat: 'degrees',
       autoPan: true,
@@ -430,9 +429,6 @@ const Theme = Backbone.Model.extend({
     return this.get('user').get('preferences').get('dateTimeFormat')[
       'datetimefmt'
     ]
-  },
-  getTimePrecision() {
-    return this.get('user').get('preferences').get('timePrecision')
   },
   getTimeZone() {
     return this.get('user').get('preferences').get('timeZone')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -411,7 +411,6 @@ const Theme = Backbone.Model.extend({
   getSummaryShown() {
     return this.get('user').getSummaryShown()
   },
-  // TODO watch for unsupported formats
   getUserReadableDateTime(date: any) {
     return moment
       .tz(date, this.get('user').get('preferences').get('timeZone'))

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -412,6 +412,7 @@ const Theme = Backbone.Model.extend({
   getSummaryShown() {
     return this.get('user').getSummaryShown()
   },
+  // TODO watch for unsupported formats
   getUserReadableDateTime(date: any) {
     return moment
       .tz(date, this.get('user').get('preferences').get('timeZone'))

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -142,7 +142,8 @@ const Theme = Backbone.Model.extend({
       oauth: [],
       fontSize: 16,
       resultCount: (properties as any).resultCount,
-      dateTimeFormat: Common.getDateTimeFormats()['ISO'],
+      dateTimeFormat: Common.getDateTimeFormats()['ISO']['millisecond'],
+      timePrecision: 'millisecond',
       timeZone: Common.getTimeZones()['UTC'],
       coordinateFormat: 'degrees',
       autoPan: true,
@@ -419,15 +420,16 @@ const Theme = Backbone.Model.extend({
       )
   },
   getAmPmDisplay() {
-    return (
-      this.get('user').get('preferences').get('dateTimeFormat')['timefmt'] ===
-      Common.getDateTimeFormats()[12].timefmt
-    )
+    const timefmt = this.get('user').get('preferences').get('dateTimeFormat')['timefmt']
+    return Common.getTimeFormatsReverseMap()[timefmt].format === '12'
   },
   getDateTimeFormat() {
     return this.get('user').get('preferences').get('dateTimeFormat')[
       'datetimefmt'
     ]
+  },
+  getTimePrecision() {
+    return this.get('user').get('preferences').get('timePrecision')
   },
   getTimeZone() {
     return this.get('user').get('preferences').get('timeZone')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -420,7 +420,9 @@ const Theme = Backbone.Model.extend({
       )
   },
   getAmPmDisplay() {
-    const timefmt = this.get('user').get('preferences').get('dateTimeFormat')['timefmt']
+    const timefmt = this.get('user').get('preferences').get('dateTimeFormat')[
+      'timefmt'
+    ]
     return Common.getTimeFormatsReverseMap()[timefmt].format === '12'
   },
   getDateTimeFormat() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
@@ -6,9 +6,11 @@ import withListenTo, { WithBackboneProps } from '../backbone-container'
 
 import TimeSettingsPresentation from './presentation'
 import { TimeZone, TimeFormat } from './types'
+import { TimePrecision } from '@blueprintjs/datetime'
 
 import momentTimezone from 'moment-timezone'
 import user from '../../component/singletons/user-instance'
+import Common from '../../js/Common'
 
 type UserPreferences = {
   get: (key: string) => any
@@ -21,6 +23,7 @@ type State = {
   timeZones: TimeZone[]
   timeZone: string
   timeFormat: string
+  timePrecision: TimePrecision
 }
 
 const getUserPreferences = (): UserPreferences => {
@@ -38,6 +41,8 @@ const savePreferences = (model: {}) => {
 
 const getCurrentDateTimeFormat = () =>
   getUserPreferences().get('dateTimeFormat').datetimefmt
+
+const getCurrentTimePrecision = () => getUserPreferences().get('timePrecision')
 
 const getCurrentTimeZone = () => getUserPreferences().get('timeZone')
 
@@ -80,7 +85,8 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
       currentTime: getCurrentTime(),
       timeZones: generateZoneObjects(),
       timeZone: getCurrentTimeZone(),
-      timeFormat: getCurrentDateTimeFormat(),
+      timeFormat: Common.getDateTimeFormatsReverseMap()[getCurrentDateTimeFormat()].format,
+      timePrecision: getCurrentTimePrecision(),
     }
   }
 
@@ -106,9 +112,17 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
         savePreferences({ timeZone: timeZone.zoneName })
       }}
       handleTimeFormatUpdate={(timeFormat: TimeFormat) => {
-        savePreferences({ dateTimeFormat: timeFormat.value })
+        const dateTimeFormat = Common.getDateTimeFormats()[timeFormat.value][this.state.timePrecision]
+        this.setState({ timeFormat: timeFormat.value })
+        savePreferences({ dateTimeFormat })
       }}
       timeFormat={this.state.timeFormat}
+      handleTimePrecisionUpdate={(timePrecision: TimePrecision) => {
+        this.setState({ timePrecision })
+        const dateTimeFormat = Common.getDateTimeFormats()[this.state.timeFormat][timePrecision]
+        savePreferences({ timePrecision, dateTimeFormat })
+      }}
+      timePrecision={this.state.timePrecision}
     />
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
@@ -11,6 +11,7 @@ import { TimePrecision } from '@blueprintjs/datetime'
 import momentTimezone from 'moment-timezone'
 import user from '../../component/singletons/user-instance'
 import Common from '../../js/Common'
+import { DateHelpers } from '../../component/fields/date-helpers'
 
 type UserPreferences = {
   get: (key: string) => any
@@ -42,7 +43,7 @@ const savePreferences = (model: {}) => {
 const getCurrentDateTimeFormat = () =>
   getUserPreferences().get('dateTimeFormat').datetimefmt
 
-const getCurrentTimePrecision = () => getUserPreferences().get('timePrecision')
+const getCurrentTimePrecision = DateHelpers.General.getTimePrecision
 
 const getCurrentTimeZone = () => getUserPreferences().get('timeZone')
 
@@ -126,7 +127,7 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
         this.setState({ timePrecision })
         const dateTimeFormat =
           Common.getDateTimeFormats()[this.state.timeFormat][timePrecision]
-        savePreferences({ timePrecision, dateTimeFormat })
+        savePreferences({ dateTimeFormat })
       }}
       timePrecision={this.state.timePrecision}
     />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
@@ -115,11 +115,11 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
         savePreferences({ timeZone: timeZone.zoneName })
       }}
       handleTimeFormatUpdate={(timeFormat: TimeFormat) => {
+        this.setState({ timeFormat: timeFormat.value })
         const dateTimeFormat =
           Common.getDateTimeFormats()[timeFormat.value][
             this.state.timePrecision
           ]
-        this.setState({ timeFormat: timeFormat.value })
         savePreferences({ dateTimeFormat })
       }}
       timeFormat={this.state.timeFormat}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/container.tsx
@@ -85,7 +85,9 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
       currentTime: getCurrentTime(),
       timeZones: generateZoneObjects(),
       timeZone: getCurrentTimeZone(),
-      timeFormat: Common.getDateTimeFormatsReverseMap()[getCurrentDateTimeFormat()].format,
+      timeFormat:
+        Common.getDateTimeFormatsReverseMap()[getCurrentDateTimeFormat()]
+          .format,
       timePrecision: getCurrentTimePrecision(),
     }
   }
@@ -112,14 +114,18 @@ class TimeSettingsContainer extends React.Component<WithBackboneProps, State> {
         savePreferences({ timeZone: timeZone.zoneName })
       }}
       handleTimeFormatUpdate={(timeFormat: TimeFormat) => {
-        const dateTimeFormat = Common.getDateTimeFormats()[timeFormat.value][this.state.timePrecision]
+        const dateTimeFormat =
+          Common.getDateTimeFormats()[timeFormat.value][
+            this.state.timePrecision
+          ]
         this.setState({ timeFormat: timeFormat.value })
         savePreferences({ dateTimeFormat })
       }}
       timeFormat={this.state.timeFormat}
       handleTimePrecisionUpdate={(timePrecision: TimePrecision) => {
         this.setState({ timePrecision })
-        const dateTimeFormat = Common.getDateTimeFormats()[this.state.timeFormat][timePrecision]
+        const dateTimeFormat =
+          Common.getDateTimeFormats()[this.state.timeFormat][timePrecision]
         savePreferences({ timePrecision, dateTimeFormat })
       }}
       timePrecision={this.state.timePrecision}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/presentation.tsx
@@ -5,7 +5,9 @@ import styled from 'styled-components'
 
 import TimeZoneSelector from './time-zone-picker'
 import TimeFormatSelector from './time-format-picker'
+import TimePrecisionSelector from './time-precision-picker'
 import { TimeZone, TimeFormat } from './types'
+import { TimePrecision } from '@blueprintjs/datetime'
 
 const Root = styled.div`
   overflow: auto;
@@ -36,8 +38,10 @@ type Props = {
   timeZone: string
   timeFormat: string
   timeZones: TimeZone[]
+  timePrecision: TimePrecision
   handleTimeZoneUpdate: (timeZone: TimeZone) => any
   handleTimeFormatUpdate: (timeFormat: TimeFormat) => any
+  handleTimePrecisionUpdate: (timePrecision: TimePrecision) => any
 }
 
 class TimeSettingsPresentation extends React.Component<Props, {}> {
@@ -52,6 +56,10 @@ class TimeSettingsPresentation extends React.Component<Props, {}> {
         <TimeFormatSelector
           timeFormat={this.props.timeFormat}
           handleTimeFormatUpdate={this.props.handleTimeFormatUpdate}
+        />
+        <TimePrecisionSelector
+          timePrecision={this.props.timePrecision}
+          handleTimePrecisionUpdate={this.props.handleTimePrecisionUpdate}
         />
         <Time>
           <TimeLabel>Current Time</TimeLabel>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-format-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-format-picker.tsx
@@ -3,7 +3,6 @@ import { hot } from 'react-hot-loader'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 import TextField from '@material-ui/core/TextField'
 import { TimeFormat } from './types'
-import Common from '../../js/Common'
 
 type Props = {
   timeFormat: string
@@ -13,26 +12,22 @@ type Props = {
 const timeFormats = [
   {
     label: 'ISO 8601',
-    value: Common.getDateTimeFormats()['ISO'],
+    value: 'ISO',
   },
   {
     label: '24 Hour Standard',
-    value: Common.getDateTimeFormats()['24'],
+    value: '24',
   },
   {
     label: '12 Hour Standard',
-    value: Common.getDateTimeFormats()['12'],
+    value: '12',
   },
 ] as TimeFormat[]
 
 const TimeFormatSelector = (props: Props) => {
-  const getDefaultFormat = (timeFormat: string) => {
-    return timeFormats.find((format) => format.value.datetimefmt === timeFormat)
-  }
+  const initState = timeFormats.find((tf) => tf.value === props.timeFormat)
 
-  let [currentTimeFormat, setCurrentTimeFormat] = React.useState(
-    getDefaultFormat(props.timeFormat)
-  )
+  const [currentTimeFormat, setCurrentTimeFormat] = React.useState(initState)
 
   return (
     <div>
@@ -45,11 +40,11 @@ const TimeFormatSelector = (props: Props) => {
           props.handleTimeFormatUpdate(newTimeFormat)
           setCurrentTimeFormat(newTimeFormat)
         }}
-        getOptionSelected={(oldFormat: TimeFormat, newFormat: TimeFormat) => {
-          return oldFormat.value.datetimefmt !== newFormat.value.datetimefmt
+        getOptionSelected={(option: TimeFormat, value: TimeFormat) => {
+          return option.value === value.value
         }}
         options={timeFormats}
-        getOptionLabel={(format) => `${format.label}`}
+        getOptionLabel={(format) => format.label}
         style={{ width: '100%', paddingTop: '2em' }}
         renderInput={(params) => (
           <TextField {...params} label="Time Format" variant="outlined" />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-precision-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-precision-picker.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Autocomplete from '@material-ui/lab/Autocomplete'
+import TextField from '@material-ui/core/TextField'
+import { TimePrecision } from '@blueprintjs/datetime'
+
+type Props = {
+  timePrecision: TimePrecision
+  handleTimePrecisionUpdate: (timePrecision: TimePrecision) => any
+}
+
+type PrecisionOption = {
+  label: string,
+  value: TimePrecision
+}
+
+const Options = [
+  {
+    label: "Milliseconds",
+    value: "millisecond"
+  },
+  {
+    label: "Seconds",
+    value: "second"
+  },
+  {
+    label: "Minutes",
+    value: "minute"
+  }
+] as PrecisionOption[]
+
+const TimePrecisionSelector = (props: Props) => {
+  const initState = Options.find((option) => option.value === props.timePrecision)
+
+  const [timePrecision, setTimePrecision] = React.useState(initState)
+
+  return (
+    <div>
+      <Autocomplete
+        id="time-precision-picker"
+        disableClearable={true}
+        autoComplete={true}
+        size={'small'}
+        onChange={(_event: any, newPrecision: PrecisionOption) => {
+          props.handleTimePrecisionUpdate(newPrecision.value)
+          setTimePrecision(newPrecision)
+        }}
+        getOptionSelected={(option, value) => {
+          return option.value === value.value
+        }}
+        options={Options}
+        getOptionLabel={(option) => option.label}
+        style={{ width: '100%', paddingTop: '2em' }}
+        renderInput={(params) => (
+          <TextField {...params} label="Time Precision" variant="outlined" />
+        )}
+        value={timePrecision}
+      />
+    </div>
+  )
+}
+
+export default hot(module)(TimePrecisionSelector)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-precision-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-precision-picker.tsx
@@ -24,27 +24,29 @@ type Props = {
 }
 
 type PrecisionOption = {
-  label: string,
+  label: string
   value: TimePrecision
 }
 
 const Options = [
   {
-    label: "Milliseconds",
-    value: "millisecond"
+    label: 'Milliseconds',
+    value: 'millisecond',
   },
   {
-    label: "Seconds",
-    value: "second"
+    label: 'Seconds',
+    value: 'second',
   },
   {
-    label: "Minutes",
-    value: "minute"
-  }
+    label: 'Minutes',
+    value: 'minute',
+  },
 ] as PrecisionOption[]
 
 const TimePrecisionSelector = (props: Props) => {
-  const initState = Options.find((option) => option.value === props.timePrecision)
+  const initState = Options.find(
+    (option) => option.value === props.timePrecision
+  )
 
   const [timePrecision, setTimePrecision] = React.useState(initState)
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-zone-picker.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/time-zone-picker.tsx
@@ -31,7 +31,7 @@ const TimeZoneSelector = (props: Props) => {
           setCurrentTimeZone(newTimeZone)
         }}
         getOptionSelected={(oldZone: TimeZone, newZone: TimeZone) => {
-          return oldZone.zoneName !== newZone.zoneName
+          return oldZone.zoneName === newZone.zoneName
         }}
         options={props.timeZones}
         getOptionLabel={(zone) =>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/time-settings/types.tsx
@@ -10,5 +10,5 @@ export type TimeZone = {
 
 export type TimeFormat = {
   label: string
-  value: any
+  value: string
 }


### PR DESCRIPTION
In the time settings menu, users can now select `milliseconds` (default), `seconds`, or `minutes` for their time precision.

This affects the behavior of datetime inputs:
* if the precision is `seconds` or `minutes`, then the inputs will not show a milliseconds option, and the resulting datetime value will have its milliseconds field set to 0
* if the precision is `minutes`, then the inputs will not show a seconds option either, and the resulting datetime value will have its seconds field set to 0

Additionally, datetimes in the UI will now be displayed according to this preference.

https://user-images.githubusercontent.com/4495447/234075633-69700f97-8318-44e5-936b-e263ed4e0655.mp4