### PR TITLE
Create an audit log entry for searches that includes all selected sources

### DIFF
--- a/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/SimpleAuditRequestBasic.java
+++ b/ui-backend/audit/audit-api/src/main/java/org/codice/ddf/catalog/audit/api/SimpleAuditRequestBasic.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.audit.api;
+
+import com.google.gson.annotations.SerializedName;
+
+public class SimpleAuditRequestBasic {
+
+  @SerializedName("action")
+  private String action;
+
+  @SerializedName("component")
+  private String component;
+
+  private SimpleAuditRequestBasic() {
+    // implementation not needed
+  }
+
+  public String getAction() {
+    return action;
+  }
+
+  public String getComponent() {
+    return component;
+  }
+}

--- a/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditApplication.java
+++ b/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditApplication.java
@@ -33,10 +33,11 @@ public class AuditApplication extends HttpServlet {
 
   private final JavalinServlet javalinServlet = JavalinUtils.createServlet(LOOKUP_PATH);
 
-  public AuditApplication(Handler auditHandler) {
+  public AuditApplication(Handler auditHandler, Handler simpleAuditHandler) {
     final Javalin app = javalinServlet.getJavalin();
     JavalinUtils.initializeStandardExceptionHandlers(app);
     app.post("/", auditHandler);
+    app.post("/simple", simpleAuditHandler);
   }
 
   @Override

--- a/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditHandler.java
+++ b/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/AuditHandler.java
@@ -44,7 +44,8 @@ public class AuditHandler implements Handler {
       auditService.log(requestBasic.getAction(), requestBasic.getComponent(), items);
       context.status(HttpStatus.SC_OK);
     } catch (AuditException e) {
-      LOGGER.error("Unable to log the user's action. Error message: {}", e.getLocalizedMessage());
+      LOGGER.error(
+          "Unable to log the user's action. Error message: {}", e.getLocalizedMessage(), e);
       context.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
   }

--- a/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/SimpleAuditHandler.java
+++ b/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/SimpleAuditHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.audit.application;
+
+import io.javalin.Context;
+import io.javalin.Handler;
+import org.apache.http.HttpStatus;
+import org.codice.ddf.catalog.audit.api.AuditException;
+import org.codice.ddf.catalog.audit.api.AuditRequestBasic;
+import org.codice.ddf.catalog.audit.api.AuditService;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SimpleAuditHandler implements Handler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SimpleAuditHandler.class);
+
+  private final AuditService auditService;
+
+  public SimpleAuditHandler(AuditService auditService) {
+    this.auditService = auditService;
+  }
+
+  @Override
+  public void handle(@NotNull Context context) {
+    AuditRequestBasic requestBasic = context.bodyAsClass(AuditRequestBasic.class);
+
+    try {
+      auditService.log(requestBasic.getAction(), requestBasic.getComponent());
+      context.status(HttpStatus.SC_OK);
+    } catch (AuditException e) {
+      LOGGER.error("Unable to log the user's action. Error message: {}", e.getLocalizedMessage());
+      context.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/SimpleAuditHandler.java
+++ b/ui-backend/audit/audit-application/src/main/java/org/codice/ddf/catalog/audit/application/SimpleAuditHandler.java
@@ -41,7 +41,8 @@ public class SimpleAuditHandler implements Handler {
       auditService.log(requestBasic.getAction(), requestBasic.getComponent());
       context.status(HttpStatus.SC_OK);
     } catch (AuditException e) {
-      LOGGER.error("Unable to log the user's action. Error message: {}", e.getLocalizedMessage());
+      LOGGER.error(
+          "Unable to log the user's action. Error message: {}", e.getLocalizedMessage(), e);
       context.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
   }

--- a/ui-backend/audit/audit-application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/audit/audit-application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,9 +25,14 @@
         <argument ref="auditService"/>
     </bean>
 
+    <bean id="simpleAuditHandler" class="org.codice.ddf.catalog.audit.application.SimpleAuditHandler">
+        <argument ref="auditService"/>
+    </bean>
+
     <bean id="auditApplication"
           class="org.codice.ddf.catalog.audit.application.AuditApplication">
         <argument ref="auditHandler"/>
+        <argument ref="simpleAuditHandler"/>
     </bean>
 
     <service ref="auditApplication" interface="javax.servlet.Servlet">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -17,6 +17,7 @@ import _ from 'underscore'
 import properties from '../properties'
 import QueryResponse from './QueryResponse'
 import Sources from '../../component/singletons/sources-instance'
+import { postSimpleAuditLog } from '../../react-component/utils/audit/audit-endpoint'
 import cql from '../cql'
 import _merge from 'lodash/merge'
 import 'backbone-associations'
@@ -440,6 +441,13 @@ export default Backbone.AssociatedModel.extend({
       queryRef: this,
     })
     this.currentIndexForSourceGroup = this.nextIndexForSourceGroup
+
+    postSimpleAuditLog({
+      action: 'SEARCH_SUBMITTED',
+      component:
+        'query: [' + cqlString + '] sources: [' + selectedSources + ']',
+    })
+
     const localSearchToRun = {
       ...data,
       cql: cqlString,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/audit/audit-endpoint.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/audit/audit-endpoint.tsx
@@ -11,6 +11,11 @@ export type AuditLog = {
   items: AuditItem[]
 }
 
+export type SimpleAuditLog = {
+  action: string
+  component: string
+}
+
 export const postAuditLog = async ({ action, component, items }: AuditLog) => {
   const body = {
     action,
@@ -18,6 +23,20 @@ export const postAuditLog = async ({ action, component, items }: AuditLog) => {
     items,
   }
   await fetch(`./internal/audit/`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export const postSimpleAuditLog = async ({
+  action,
+  component,
+}: SimpleAuditLog) => {
+  const body = {
+    action,
+    component,
+  }
+  await fetch(`./internal/audit/simple`, {
     method: 'POST',
     body: JSON.stringify(body),
   })


### PR DESCRIPTION
Since the UI breaks searches into two backend calls (one for harvested and one for non-harvested), there wasn't a single audit log entry that included all of the selected sources. This PR calls the audit log endpoint to create a new audit log entry with all of the selected sources.

Example:

```
[INFO ] 2023-04-24T05:58:58,663 | tp1767707945-801 | securityLogger  |  trace-id 8966a4f167044cb59329faac2c3c1b23, Subject: admin,  Client IP: 127.0.0.1, Port: 60302, SEARCH_SUBMITTED a query: [((anyText ILIKE '*'))] sources: [EARTHQUAKES,GEOSERVER,BAR,CAT,DOG,FOO,HARVESTED SOURCE,ISRI,WITH SPACE]
```
