### PR TITLE
Fix issue with datepickers not closing when clicking away after changing the hrs / minutes / seconds fields

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -60,6 +60,7 @@ const validateDate = (
 
 export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
   const dateRef = React.useRef(value.date)
+  const blueprintDateRef = React.useRef<DateInput>(null)
 
   useTimePrefs(() => {
     const shiftedDate = DateHelpers.Blueprint.DateProps.generateValue(
@@ -83,6 +84,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
     <Grid container alignItems="stretch" direction="column" wrap="nowrap">
       <Grid item className="w-full pb-2">
         <DateInput
+          ref={blueprintDateRef}
           timePickerProps={{
             useAmPm: user.getAmPmDisplay(),
           }}
@@ -106,6 +108,17 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           timePrecision={DateHelpers.General.getTimePrecision()}
           inputProps={{
             ...EnterKeySubmitProps,
+          }}
+          popoverProps={{
+            modifiers: {
+              preventOverflow: { enabled: false },
+              hide: { enabled: false },
+            },
+            onClose: () => {
+              setTimeout(() => {
+                blueprintDateRef.current?.setState({ isOpen: false })
+              }, 0)
+            },
           }}
           {...(value.date
             ? {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -53,6 +53,7 @@ const validateDate = (
 
 export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
   const valueRef = useRef(value)
+  const blueprintDateRef = useRef<DateInput>(null)
 
   useTimePrefs(() => {
     const shiftedDate = DateHelpers.Blueprint.DateProps.generateValue(
@@ -69,6 +70,7 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
   return (
     <>
       <DateInput
+        ref={blueprintDateRef}
         className={MuiOutlinedInputBorderClasses}
         minDate={DefaultMinDate}
         maxDate={DefaultMaxDate}
@@ -94,6 +96,11 @@ export const DateField = ({ value, onChange, BPDateProps }: DateFieldProps) => {
           modifiers: {
             preventOverflow: { enabled: false },
             hide: { enabled: false },
+          },
+          onClose: () => {
+            setTimeout(() => {
+              blueprintDateRef.current?.setState({ isOpen: false })
+            }, 0)
           },
         }}
         {...(value


### PR DESCRIPTION
 - This fixes an issue with datepickers reopening immediately after closing, in the case of users editing hrs / minutes / seconds fields and clicking away.
 - I  couldn't track down a better solution to fix this.  I tried a number of things, and this ended up being the most consistent / simple fix.  In the future, it might be worth upgrading blueprint to latest and see if that fixes the issue.  As far as I could tell by debugging their code, the popover would close, then the change date function would run and set isOpen again.   It might be an issue with how we're using the picker, but I couldn't determine where.