### PR TITLE
Fix backspace on radius field crashes edit location dialogue

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
@@ -71,12 +71,16 @@ function ddToWkt(dd: any) {
       break
     case 'circle':
       if (
-          dd.circle.radius > 0 && 
-          isNaN(dd.circle.point.latitude) === false && 
-          isNaN(dd.circle.point.longitude) === false
+        !isNaN(dd.circle.point.latitude) &&
+        !isNaN(dd.circle.point.longitude) &&
+        dd.circle.radius > 0
       ) {
         const distance = toKilometers(dd.circle.radius, dd.circle.units)
-        wkt = computeCircle(ddPointToWkt(dd.circle.point), distance, 36)?.toWkt()
+        wkt = computeCircle(
+          ddPointToWkt(dd.circle.point),
+          distance,
+          36
+        )?.toWkt()
       }
       break
     case 'line':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
@@ -72,8 +72,8 @@ function ddToWkt(dd: any) {
     case 'circle':
       if (
           dd.circle.radius > 0 && 
-          dd.circle.point.latitude === "" && 
-          dd.circle.point.longitude === ""
+          isNaN(dd.circle.point.latitude) === false && 
+          isNaN(dd.circle.point.longitude) === false
       ) {
         const distance = toKilometers(dd.circle.radius, dd.circle.units)
         wkt = computeCircle(ddPointToWkt(dd.circle.point), distance, 36)?.toWkt()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
@@ -70,7 +70,11 @@ function ddToWkt(dd: any) {
       wkt = ddPointToWkt(dd.point).toWkt()
       break
     case 'circle':
-      if (dd.circle.radius > 0) {
+      if (
+          dd.circle.radius > 0 && 
+          dd.circle.point.latitude === "" && 
+          dd.circle.point.longitude === ""
+      ) {
         const distance = toKilometers(dd.circle.radius, dd.circle.units)
         wkt = computeCircle(ddPointToWkt(dd.circle.point), distance, 36)?.toWkt()
       }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dd-utils.ts
@@ -70,8 +70,10 @@ function ddToWkt(dd: any) {
       wkt = ddPointToWkt(dd.point).toWkt()
       break
     case 'circle':
-      const distance = toKilometers(dd.circle.radius, dd.circle.units)
-      wkt = computeCircle(ddPointToWkt(dd.circle.point), distance, 36)?.toWkt()
+      if (dd.circle.radius > 0) {
+        const distance = toKilometers(dd.circle.radius, dd.circle.units)
+        wkt = computeCircle(ddPointToWkt(dd.circle.point), distance, 36)?.toWkt()
+      }
       break
     case 'line':
       if (dd.line.list.length > 0) {


### PR DESCRIPTION
**What does this PR do, and why?**
The purpose of this PR is bug fixes. 
Bug 1. When a user edits the location of an informal product, if they enter values for lon and lat and then remove the radius, the dialogue window will crash. The PR fixes the bug of the window crash. 
Bug 2. In the same dialogue window, if you click the longitude or the latitude textbox and click anywhere within the window, you used to see a crash. This PR fixes the bug. 

**How should this be tested?**
Setting up:
- cd into ui-frontend/packages/catalog-ui-search/
- run yarn install
- run yarn build
- You should see a dist folder 
- Copy the path of the dist folder 
- For the next part, you need the aus repo.
- In the aus repo, cd into ui/packages/intrigue 
- Update the package.json file, first locate the dependencies section and find catalog-ui-search
- Paste in the path from the dist folder into the url string (eg "catalog-ui-search": "file:///opt/repos/ddf-ui/ui-frontend/packages/catalog-ui-search/dist",)
- run yarn install --force
- run yarn start:transpile

Testing:

1. In the frontend application, upload a file in the Create section (can be a txt file) in the left menu bar
2. Go to the Search function in the left side menu bar
3. Search for the file you uploaded
4. Click on the file, then click on layout and click on the inspector button
5. You should see data related to the file in the Details tab
6. Click view all, scroll down until you see Location and click on it
7. A popup dialogue window appears
8. Click on Lat/Lon(DD) and Circle
9. Enter data for latitude and longitude, then remove the default radius value
10. You should see a text asking you to enter a radius greater than 0. (before, the dialogue window would crash)
11. Click either the longitude or latitude textbox then click anywhere within the dialogue window
12. You should see a text "Invalid coordinates". (before, the dialogue window would crash)

**PR Definition of Done**
- Passing the build in the catalog-ui-search folder
- Seeing a text prompt asking you to enter a radius greater than 0 by following step 9 in the Testing section (please see the screenshot)
- Does not encounter crashes of the location edit dialogue window when removing the default radius value, by following step 9 in the Testing section
- Seeing a text prompt "Invalid coordinates" by following step 11 in the Testing section
- Does not encounter crashes of the location edit dialogue window when clicking in and out of longitude or latitude textboxes, by following step 11 in the Testing section

**Screenshot**
Bug 1 fix
<img width="313" alt="13084 PR" src="https://github.com/codice/ddf-ui/assets/131846181/90e947e3-3d7d-48a7-b46b-2dca1bf1565b">

Bug 2 fix
<img width="536" alt="13084-bug2" src="https://github.com/codice/ddf-ui/assets/131846181/ede5e747-e8c2-4d30-8309-308d8b9b17b7">

