### PR TITLE
Update padding in various areas to improve UX

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.tsx
@@ -36,7 +36,7 @@ export const GoldenLayout = ({ selectionInterface }: Props) => {
       <Grid item className="w-full relative z-1 pb-2 pt-2 pr-2 shrink-0">
         <Paper
           elevation={Elevations.panels}
-          className="w-full p-3 overflow-hidden"
+          className="w-full py-1 px-2 overflow-hidden"
         >
           {goldenLayout ? (
             <ResultSelector

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.tsx
@@ -448,7 +448,7 @@ const QueryBasic = ({ model, errorListener }: QueryBasicProps) => {
             }}
           />
         </div>
-        <div className="pt-2">
+        <div className="">
           <FormControlLabel
             labelPlacement="end"
             control={
@@ -508,7 +508,7 @@ const QueryBasic = ({ model, errorListener }: QueryBasicProps) => {
             </Grid>
           ) : null}
         </div>
-        <div className="pt-2">
+        <div className="">
           <FormControlLabel
             labelPlacement="end"
             control={
@@ -597,7 +597,7 @@ const QueryBasic = ({ model, errorListener }: QueryBasicProps) => {
             </Grid>
           ) : null}
         </div>
-        <div className="py-5 w-full">
+        <div className="py-2 w-full">
           <Swath className="w-full h-1" />
         </div>
         <div className="basic-settings">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -3,7 +3,6 @@ import { hot } from 'react-hot-loader'
 import Paper from '@mui/material/Paper'
 import moment from 'moment'
 import styled from 'styled-components'
-import Grid from '@mui/material/Grid'
 import Button from '@mui/material/Button'
 import { Status } from '../../js/model/LazyQueryResult/status'
 import { useLazyResultsStatusFromSelectionInterface } from '../selection-interface/hooks'
@@ -247,12 +246,12 @@ const QueryFeed = ({ selectionInterface }: Props) => {
 
   return (
     <>
-      <Grid container direction="row" alignItems="center" wrap="nowrap">
-        <Grid item>
+      <div className="flex flex-row items-center flex-nowrap">
+        <div className="leading-5">
           <div
             data-id="results-count-label"
             title={resultMessage}
-            style={{ whiteSpace: 'nowrap' }}
+            className=" whitespace-nowrap"
           >
             {pending ? (
               <i className="fa fa-circle-o-notch fa-spin is-critical-animation" />
@@ -263,8 +262,8 @@ const QueryFeed = ({ selectionInterface }: Props) => {
             {resultMessage}
           </div>
           <LastRan currentAsOf={currentAsOf} />
-        </Grid>
-        <Grid item>
+        </div>
+        <div>
           <div>
             <div className="relative">
               <Button
@@ -294,8 +293,8 @@ const QueryFeed = ({ selectionInterface }: Props) => {
               )}
             </div>
           </div>
-        </Grid>
-      </Grid>
+        </div>
+      </div>
     </>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -9,6 +9,7 @@ import {
   Theme as ThemeInterface,
   lighten,
   alpha,
+  ThemeOptions,
 } from '@mui/material/styles'
 import StylesProvider from '@mui/styles/StylesProvider'
 import { ThemeContext } from 'styled-components'
@@ -403,6 +404,13 @@ const darkenUntilContrasting = (color: string, background: string): string => {
   return darkenUntilContrasting(darken(color, 0.1), background)
 }
 
+// https://stackoverflow.com/questions/72720524/typescript-react-mui-use-custom-color-on-button-component
+declare module '@mui/material' {
+  interface ButtonPropsColorOverrides {
+    grey: true
+  }
+}
+
 export const Provider = ({ children }: { children: any }) => {
   const styledTheme = React.useContext(ThemeContext)
   const darkMode = styledTheme.theme === 'dark'
@@ -458,7 +466,10 @@ export const Provider = ({ children }: { children: any }) => {
     },
   })
 
-  const theme = createTheme(initialTheme, {
+  /**
+   *  We split these out to so that we can access theme variables within our custom theme
+   */
+  const themeBasedTheme: ThemeOptions = {
     typography: {
       fontFamily: `'Open Sans', arial, sans-serif`,
       h6: {
@@ -613,7 +624,9 @@ export const Provider = ({ children }: { children: any }) => {
       snackbar: 101,
       tooltip: 101,
     },
-  })
+  }
+
+  const theme = createTheme(initialTheme, themeBasedTheme)
 
   React.useEffect(() => {
     const htmlElement = document.querySelector('html') as HTMLElement

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -593,16 +593,6 @@ export const Provider = ({ children }: { children: any }) => {
           },
         },
       },
-      // MuiCheckbox: {
-      //   defaultProps: {
-      //     size: 'small',
-      //   },
-      // },
-      // MuiTextField: {
-      //   defaultProps: {
-      //     size: 'small',
-      //   },
-      // },
       MuiPaper: {
         styleOverrides: {
           root: { backgroundImage: 'unset' },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -479,6 +479,7 @@ export const Provider = ({ children }: { children: any }) => {
       },
       MuiButton: {
         defaultProps: {
+          size: 'small',
           color: 'grey',
         },
         variants: [
@@ -581,6 +582,16 @@ export const Provider = ({ children }: { children: any }) => {
           },
         },
       },
+      // MuiCheckbox: {
+      //   defaultProps: {
+      //     size: 'small',
+      //   },
+      // },
+      // MuiTextField: {
+      //   defaultProps: {
+      //     size: 'small',
+      //   },
+      // },
       MuiPaper: {
         styleOverrides: {
           root: { backgroundImage: 'unset' },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
@@ -13,7 +13,7 @@
  **/
  -->
 
-<html class="no-js bp3-dark theme-dark dark text-xs xl:text-sm 2xl:text-base">
+<html class="no-js bp3-dark theme-dark dark">
 
 <head>
     <meta charset="utf-8">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
@@ -13,7 +13,7 @@
  **/
  -->
 
-<html class="no-js bp3-dark theme-dark dark">
+<html class="no-js bp3-dark theme-dark dark text-xs xl:text-sm 2xl:text-base">
 
 <head>
     <meta charset="utf-8">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
@@ -13,7 +13,7 @@
  **/
  -->
 
-<html class="no-js">
+<html class="no-js bp3-dark theme-dark dark">
 
 <head>
     <meta charset="utf-8">

--- a/ui-frontend/packages/catalog-ui-search/tailwind.config.js
+++ b/ui-frontend/packages/catalog-ui-search/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   darkMode: 'class',
-  content: ['./src/**/*.{tsx,js,jsx,ts}'],
+  content: ['./src/**/*.{tsx,js,jsx,ts,html}'],
   theme: {
     namedGroups: ['1', '2'],
     minWidth: {


### PR DESCRIPTION
 - Update result selector to have less padding (is above the golden layout visualizations)
 - Update basic query view to have less padding
 - Update a few usages of Grid to instead use tailwind + normal divs
 - Update how we construct the Theme so that we have type checking.  In addition, adds some type declaration for the addition we made of the color grey previously.  Also updates the default size for buttons to be small.
 - Update the index.html so dark theme is assumed until preferences load.  This is less jarring for dark mode users.  And for light mode users, seeing dark mode for a moment is fine.
 - Update tailwind config to include html files as part of it's content determination