### PR TITLE
Update supported browsers

### DIFF
--- a/ui-frontend/package.json
+++ b/ui-frontend/package.json
@@ -16,7 +16,7 @@
     "mvn:install-file": "mvn org.apache.maven.plugins:maven-install-plugin:install-file -Dfile=target/packages-packages.zip -DpomFile=pom.xml -Dclassifier=packages -Dpackaging=zip"
   },
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe",
     "@connexta/eslint-config-connexta": "git+https://github.com/connexta/eslint-config-connexta.git#105393617ec845b009b682882c95313ba50144b1",
     "@connexta/eslint-plugin-connexta": "git+https://github.com/connexta/eslint-plugin-connexta.git#9b366b8924c3dbe03aedcfe6d25c8eb3567cc061",
     "bootstrap-sass": "3.4.1",

--- a/ui-frontend/packages/admin/package.json
+++ b/ui-frontend/packages/admin/package.json
@@ -16,7 +16,7 @@
     "@types/react": "16.9.34",
     "@types/react-dom": "16.9.7",
     "@types/styled-components": "5.1.0",
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   },
   "dependencies": {
     "@connexta/kanri": "connexta/kanri#3218c8bc07b22d1c583c504acbdbb2fb0b099339",

--- a/ui-frontend/packages/admin/yarn.lock
+++ b/ui-frontend/packages/admin/yarn.lock
@@ -1104,9 +1104,9 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889":
+"@connexta/ace@git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+  resolved "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   dependencies:
     "@babel/core" "7.21.3"
     "@babel/preset-env" "7.20.2"
@@ -1136,7 +1136,6 @@
     eslint-plugin-node "11.1.0"
     eslint-plugin-react "7.32.2"
     exports-loader "4.0.0"
-    file-loader "6.2.0"
     find-up "2.1.0"
     glob "7.1.2"
     html-loader "4.2.0"
@@ -1176,7 +1175,6 @@
     tailwindcss "3.2.7"
     ts-loader "9.4.2"
     typescript "4.9.5"
-    url-loader "4.1.1"
     username "3.0.0"
     vkbeautify "0.99.3"
     webpack "5.75.0"
@@ -5132,14 +5130,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 filesize@^8.0.6:
   version "8.0.7"
@@ -9724,15 +9714,6 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
-
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
 
 url@^0.11.0:
   version "0.11.0"

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe",
     "@types/chai": "4.2.14",
     "@types/d3": "5.0.0",
     "@types/enzyme": "3.10.8",
@@ -91,6 +91,7 @@
     "content-disposition": "0.5.3",
     "d3": "5.16.0",
     "density-clustering": "1.3.0",
+    "detect-browser": "5.3.0",
     "dropzone": "4.3.0",
     "focus-visible": "5.1.0",
     "font-awesome": "4.7",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/app.tsx
@@ -12,10 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-// check browser before loading the rest of the app
-import { isSupportedBrowser } from './check-browser'
-;(() => {
-  if (isSupportedBrowser()) {
-    import('./app')
-  }
-})()
+import Entry from './js/Entry'
+
+Entry()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
@@ -58,6 +58,12 @@ export const handleUnsupportedBrowser = () => {
     })
 }
 
+export const handleSupportedBrowser = () => {
+  document.querySelector('#incompatible-browser-bg')?.remove()
+}
+
 if (!isSupportedBrowser()) {
   handleUnsupportedBrowser()
+} else {
+  handleSupportedBrowser()
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
@@ -44,6 +44,11 @@ export const isSupportedBrowser = () => {
         return false
     }
   } else {
+    /**
+     *  Assumption is that this would happen only in a new browser version where the user agent deprecation
+     *  has gone through (thus it should be a relatively new version of chrome or whatever browser),
+     *  so we let it through as supported.
+     */
     return true
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import './styles/tailwind.css'
+import { detect } from 'detect-browser'
+
+const browser = detect()
+
+/**
+ *  If we can't detect browser, assume it's supported
+ *
+ *  If we can, check if it's supported
+ */
+export const isSupportedBrowser = () => {
+  if (sessionStorage.getItem('ignoreBrowserWarning')) {
+    return true
+  }
+  if (browser && browser.version) {
+    const version = parseInt(browser.version.split('.')[0])
+    switch (browser && browser.name) {
+      case 'chrome':
+        return version >= 90
+      case 'firefox':
+        return version >= 78
+      case 'edge':
+        return version >= 91
+      default:
+        return false
+    }
+  } else {
+    return true
+  }
+}
+
+export const handleUnsupportedBrowser = () => {
+  document.querySelector('#loading')?.classList.add('hidden')
+  document
+    .querySelector('#incompatible-browser-bg button')
+    ?.addEventListener('click', () => {
+      sessionStorage.setItem('ignoreBrowserWarning', 'true')
+      location.reload()
+    })
+}
+
+if (!isSupportedBrowser()) {
+  handleUnsupportedBrowser()
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/check-browser.tsx
@@ -30,10 +30,15 @@ export const isSupportedBrowser = () => {
     const version = parseInt(browser.version.split('.')[0])
     switch (browser && browser.name) {
       case 'chrome':
+        // https://chromium.cypress.io/mac/ for those devs who wish to test old chromium versions
         return version >= 90
       case 'firefox':
+        // https://ftp.mozilla.org/pub/firefox/releases/
         return version >= 78
       case 'edge':
+      case 'edge-chromium':
+        // https://officecdnmac.microsoft.com/pr/03adf619-38c6-4249-95ff-4a01c0ffc962/MacAutoupdate/MicrosoftEdge-90.0.818.39.pkg
+        // change version on end to get to old versions
         return version >= 91
       default:
         return false

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/index.html
@@ -23,21 +23,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
-
-    <script>
-      // hacky but working way to suppress certain html (this is the only foolproof method working on all browsers, including ancient ie versions)
-      // things like setAttribute, className etc just aren't guaranteed to work, so stick to using this!
-      window.suppressNextTag = function() {
-        document.write("<script type='application/x-suppress'>");
-      };
-      // feature detection as opposed to browser sniffing, lookBehind is only supported in relatively recent releases of popular browsers
-      window.isLookBehindSupported = false;
-
-      try {
-          new RegExp("(?<=)");
-          window.isLookBehindSupported = true;
-      } catch (err) {}
-    </script>
 </head>
 
 <body>
@@ -187,12 +172,6 @@
 
         </style>
     </header>
-    <script>
-      // this will suppress the incompatible browser element if we're on a compatible browser
-      if (window.isLookBehindSupported) {
-        window.suppressNextTag();
-      }
-    </script>
     <div id="incompatible-browser-bg" style="color: white;">
       <div style="display: table; width: 100%; height: 100%;">
         <div id="incompatible-browser">
@@ -202,28 +181,27 @@
             system.
           </p>
           <ul id="supported-browsers" style="list-style-type:none; padding: 0px">
-            <li class="browser">
+            <li class="browser" title=">=91">
               <img src="./img/edge.png" alt="edge" style="margin-right: 24px;" />
               <label style="font-size: 12px;">Microsoft Edge</label>
             </li>
-            <li class="browser">
+            <li class="browser" title=">=78">
               <img src="./img/firefox.png" alt="firefox" style="margin-right: 24px;" />
               <label style="font-size: 12px;">Mozilla Firefox</label>
             </li>
-            <li class="browser">
+            <li class="browser" title=">=90">
               <img src="./img/chrome.png" alt="chrome" style="margin-right: 24px;" />
               <label style="font-size: 12px;">Google Chrome</label>
             </li>
           </ul>
+          <div class="">
+            <button  class="px-3 text-base py-2 rounded border-slate-700 border hover:bg-slate-800">
+              Continue anyways?
+            </button>
+          </div>
         </div>
       </div>
     </div>
-    <script>
-      // this will suppress the loading element if we're on an incompatible browser
-      if (window.isLookBehindSupported === false) {
-        window.suppressNextTag();
-      }
-    </script>
     <div id="loading" class="flow-root is-open">
         <div class="loader is-critical-animation"></div>
         <div class="loading-welcome">
@@ -234,12 +212,6 @@
     </div>
     <iframe name="autocomplete" style="display:none" src="./blank.html"></iframe>
     <footer></footer>
-    <script>
-      // this will suppress the first webpack bundle from loading, if we're on an incompatible browser
-      if (window.isLookBehindSupported === false) {
-        window.suppressNextTag();
-      }
-    </script>
 </body>
 
 </html>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.tsx
@@ -13,7 +13,6 @@
  *
  **/
 import 'focus-visible'
-import '../styles/tailwind.css'
 import 'cesium/Build/Cesium/Widgets/widgets.css'
 import '@blueprintjs/core/lib/css/blueprint.css'
 import '@blueprintjs/datetime/lib/css/blueprint-datetime.css'

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -1147,9 +1147,9 @@
   dependencies:
     commander "^2.15.1"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889":
+"@connexta/ace@git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+  resolved "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   dependencies:
     "@babel/core" "7.21.3"
     "@babel/preset-env" "7.20.2"
@@ -1179,7 +1179,6 @@
     eslint-plugin-node "11.1.0"
     eslint-plugin-react "7.32.2"
     exports-loader "4.0.0"
-    file-loader "6.2.0"
     find-up "2.1.0"
     glob "7.1.2"
     html-loader "4.2.0"
@@ -1219,7 +1218,6 @@
     tailwindcss "3.2.7"
     ts-loader "9.4.2"
     typescript "4.9.5"
-    url-loader "4.1.1"
     username "3.0.0"
     vkbeautify "0.99.3"
     webpack "5.75.0"
@@ -8322,6 +8320,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-browser@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.3.0.tgz#9705ef2bddf46072d0f7265a1fe300e36fe7ceca"
+  integrity sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -9543,14 +9546,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -17875,15 +17870,6 @@ urijs@1.19.1:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
 
 url@^0.11.0:
   version "0.11.0"

--- a/ui-frontend/packages/cesium-assets/package.json
+++ b/ui-frontend/packages/cesium-assets/package.json
@@ -18,6 +18,6 @@
   ],
   "context-path": "/search/catalog/cesium/assets",
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   }
 }

--- a/ui-frontend/packages/cesium-assets/yarn.lock
+++ b/ui-frontend/packages/cesium-assets/yarn.lock
@@ -1036,9 +1036,9 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889":
+"@connexta/ace@git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+  resolved "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   dependencies:
     "@babel/core" "7.21.3"
     "@babel/preset-env" "7.20.2"
@@ -1068,7 +1068,6 @@
     eslint-plugin-node "11.1.0"
     eslint-plugin-react "7.32.2"
     exports-loader "4.0.0"
-    file-loader "6.2.0"
     find-up "2.1.0"
     glob "7.1.2"
     html-loader "4.2.0"
@@ -1108,7 +1107,6 @@
     tailwindcss "3.2.7"
     ts-loader "9.4.2"
     typescript "4.9.5"
-    url-loader "4.1.1"
     username "3.0.0"
     vkbeautify "0.99.3"
     webpack "5.75.0"
@@ -4637,14 +4635,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 filesize@^8.0.6:
   version "8.0.7"
@@ -8803,15 +8793,6 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
-
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
 
 url@^0.11.0:
   version "0.11.0"

--- a/ui-frontend/yarn.lock
+++ b/ui-frontend/yarn.lock
@@ -1036,9 +1036,9 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889":
+"@connexta/ace@git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#dd6665cb31dc9041ef32983f1e0e246e4a97e889"
+  resolved "git+https://github.com/connexta/ace.git#4cc376863e82757699cdaa1301f30266e66a1efe"
   dependencies:
     "@babel/core" "7.21.3"
     "@babel/preset-env" "7.20.2"
@@ -1068,7 +1068,6 @@
     eslint-plugin-node "11.1.0"
     eslint-plugin-react "7.32.2"
     exports-loader "4.0.0"
-    file-loader "6.2.0"
     find-up "2.1.0"
     glob "7.1.2"
     html-loader "4.2.0"
@@ -1108,7 +1107,6 @@
     tailwindcss "3.2.7"
     ts-loader "9.4.2"
     typescript "4.9.5"
-    url-loader "4.1.1"
     username "3.0.0"
     vkbeautify "0.99.3"
     webpack "5.75.0"
@@ -6819,14 +6817,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 filesize@^8.0.6:
   version "8.0.7"
@@ -14170,15 +14160,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Updates our supported browsers to be inline with https://mui.com/material-ui/getting-started/supported-platforms/#browser
- Change from feature detection to looking at user agent string to determine browser + version.  In the future this may get deprecated, so we might have to migrate it then.  But I couldn't find a feature overlapping those browser versions to test.
- Adds a "continue" button to the unsupported screen in case folks want to use the application anyways.  It sets a session flag, so each time the browser is reopened they'll have to confirm again.  

<img width="1299" alt="Screenshot 2023-06-06 at 6 27 09 PM" src="https://github.com/codice/ddf-ui/assets/11984853/b9bd8a4c-0cd3-47e6-b689-d76823a9a76b">
<img width="1312" alt="Screenshot 2023-06-06 at 6 27 38 PM" src="https://github.com/codice/ddf-ui/assets/11984853/d1919f3a-ed9d-4a34-b8b6-89440ad0bb9d">
