### PR TITLE
Add logic to make scroll to item more intuitive

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.collection.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.collection.tsx
@@ -109,8 +109,10 @@ export const useScrollToItemOnSelection = ({
 }: {
   selectionInterface: Props['selectionInterface']
 }) => {
+  const [lastInteraction, setLastInteraction] = React.useState<number | null>(
+    null
+  )
   const listRef = React.useRef<VariableSizeList | null>(null)
-
   const lazyResults = useLazyResultsFromSelectionInterface({
     selectionInterface,
   })
@@ -122,7 +124,11 @@ export const useScrollToItemOnSelection = ({
   React.useEffect(() => {
     const allResults = Object.values(lazyResults.results)
     const selected = Object.values(selectedResults)
-    if (listRef.current && selected.length >= 1) {
+    if (
+      listRef.current &&
+      selected.length >= 1 &&
+      Date.now() - (lastInteraction || 0) > 500
+    ) {
       startScrollingToItem({
         listRef: listRef.current,
         index: allResults.indexOf(selected[0]),
@@ -134,8 +140,8 @@ export const useScrollToItemOnSelection = ({
     return () => {
       window.cancelAnimationFrame(animationFrameId.current as number)
     }
-  }, [selectedResults, lazyResults])
-  return { listRef }
+  }, [selectedResults, lazyResults, lastInteraction])
+  return { listRef, setLastInteraction }
 }
 
 const ResultCards = ({ mode, setMode, selectionInterface }: Props) => {
@@ -153,7 +159,9 @@ const ResultCards = ({ mode, setMode, selectionInterface }: Props) => {
    */
   const [isMounted, setIsMounted] = React.useState(false)
 
-  const { listRef } = useScrollToItemOnSelection({ selectionInterface })
+  const { listRef, setLastInteraction } = useScrollToItemOnSelection({
+    selectionInterface,
+  })
 
   React.useEffect(() => {
     const mountedTimeout = setTimeout(() => {
@@ -289,6 +297,14 @@ const ResultCards = ({ mode, setMode, selectionInterface }: Props) => {
                       No Results Found
                     </div>
                   )
+                }}
+                outerElementProps={{
+                  onMouseEnter: () => {
+                    setLastInteraction(Date.now())
+                  },
+                  onMouseUp: () => {
+                    setLastInteraction(Date.now())
+                  },
                 }}
                 variableSizeListRef={listRef}
               />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -108,7 +108,9 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
    * This is solely to keep the illusion of responsiveness when switching from table mode to list mode (or dropping a new result visual in)
    */
   const [isMounted, setIsMounted] = React.useState(false)
-  const { listRef } = useScrollToItemOnSelection({ selectionInterface })
+  const { listRef, setLastInteraction } = useScrollToItemOnSelection({
+    selectionInterface,
+  })
 
   React.useEffect(() => {
     const mountedTimeout = setTimeout(() => {
@@ -238,6 +240,12 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
                             e.target as any
                           ).scrollLeft
                         }
+                      },
+                      onMouseEnter: () => {
+                        setLastInteraction(Date.now())
+                      },
+                      onMouseUp: () => {
+                        setLastInteraction(Date.now())
                       },
                     }}
                     defaultSize={76}


### PR DESCRIPTION
 - Will no longer initiate due to selections made within the visual itself
 - Will stop if the user interacts (particularly useful if it ends up in an infinite cycle due to small visual + big item, where it can't get it in the viewport entirely)


Current
https://github.com/codice/ddf-ui/assets/11984853/d56f6aad-98b3-49aa-ad9a-3493e3b0d27b

Improvement
https://github.com/codice/ddf-ui/assets/11984853/25731743-de93-4f76-9481-068d34abdeb4

