### PR TITLE
Update search status/loading/error/warning display

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/StatusImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/StatusImpl.java
@@ -35,6 +35,8 @@ public class StatusImpl implements Status {
 
   private List<String> warnings = new ArrayList<>();
 
+  private List<String> errors = new ArrayList<>();
+
   public StatusImpl(QueryResponse response, String source, long elapsedTime) {
     elapsed = elapsedTime;
     id = source;
@@ -43,6 +45,7 @@ public class StatusImpl implements Status {
     hits = response.getHits();
     successful = isSuccessful(response.getProcessingDetails());
     warnings = getWarnings(response.getProcessingDetails());
+    errors = getErrors(response.getProcessingDetails());
   }
 
   public StatusImpl(
@@ -53,6 +56,7 @@ public class StatusImpl implements Status {
     this.elapsed = elapsedTime;
     this.successful = isSuccessful(details);
     this.warnings = getWarnings(details);
+    this.errors = getErrors(details);
   }
 
   private boolean isSuccessful(final Set<ProcessingDetails> details) {
@@ -68,6 +72,15 @@ public class StatusImpl implements Status {
     return details
         .stream()
         .filter(detail -> !detail.hasException())
+        .map(detail -> detail.getWarnings())
+        .flatMap(procesingWarnings -> procesingWarnings.stream())
+        .collect(Collectors.toList());
+  }
+
+  private List<String> getErrors(final Set<ProcessingDetails> details) {
+    return details
+        .stream()
+        .filter(detail -> detail.hasException())
         .map(detail -> detail.getWarnings())
         .flatMap(procesingWarnings -> procesingWarnings.stream())
         .collect(Collectors.toList());

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -55,7 +55,9 @@ const CellValue = (props: CellValueProps) => {
           title={
             <Paper elevation={Elevations.overlays} className="p-2">
               {(() => {
-                if (message) {
+                if (errors.length > 0) {
+                  return errors.map((error) => <div key={error}>{error}</div>)
+                } else if (message) {
                   return message
                 } else {
                   return 'Something went wrong searching this source.'
@@ -64,22 +66,20 @@ const CellValue = (props: CellValueProps) => {
             </Paper>
           }
         >
-          <ErrorIcon style={{ paddingRight: '5px' }} />
+          <ErrorIcon style={{ paddingRight: '5px' }} color="error" />
         </Tooltip>
       )}
       {warnings.length > 0 && (
         <Tooltip
           title={
             <Paper elevation={Elevations.overlays} className="p-2">
-              {(() => {
-                return warnings.map((warning) => (
-                  <div key={warning}>{warning}</div>
-                ))
-              })()}
+              {warnings.map((warning) => (
+                <div key={warning}>{warning}</div>
+              ))}
             </Paper>
           }
         >
-          <WarningIcon style={{ paddingRight: '5px' }} />
+          <WarningIcon style={{ paddingRight: '5px' }} color="warning" />
         </Tooltip>
       )}
       {alwaysShowValue || (!message && hasReturned && successful)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/status.tsx
@@ -35,6 +35,7 @@ export class Status {
   hasReturned: boolean
   message: string
   warnings: [string]
+  errors: [string]
   constructor({ id }: { id: string }) {
     this.id = id
     this.count = 0


### PR DESCRIPTION
**Previously**
- warnings: 
![image](https://github.com/codice/ddf-ui/assets/14789712/9123332a-84b1-4899-96cf-f1f6b2528a19)
- errors: 
![image](https://github.com/codice/ddf-ui/assets/14789712/d9e3540f-c75b-460f-81eb-0fb49f440b66)
---
Now each warning and error will use the appropriate icon and color in the same place.
Within the heartbeat status by source, warning and error message are split into the respective icons.

<img width="827" alt="image" src="https://github.com/codice/ddf-ui/assets/14789712/10237d06-06f6-44f0-b7e0-d8d3b402cee9">
