### PR TITLE
New extension points for customizing inspector title and map badges

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
@@ -34,6 +34,7 @@ import MetacardTabs, { TabNames } from '../../tabs/metacard/tabs-metacard'
 import { TypedProperties } from '../../singletons/TypedProperties'
 import { TypedUserInstance } from '../../singletons/TypedUser'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
+import Extensions from '../../../extension-points'
 
 type InspectorType = {
   selectionInterface: any
@@ -66,6 +67,7 @@ export const TitleView = ({ lazyResult }: TitleViewType) => {
       <span
         className={`${getIconClassName({ lazyResult })} font-awesome-span`}
       ></span>
+      <Extensions.inspectorTitleAddOn lazyResult={lazyResult} />
       <OverflowTooltip className={'truncate'}>
         {lazyResult.plain.metacard.properties.title}
       </OverflowTooltip>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/DrawingUtility.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/DrawingUtility.ts
@@ -26,12 +26,15 @@ export default {
       fillColor: defaultColor,
       strokeWidth: 2,
       strokeColor: 'white',
+      badgeOptions: undefined,
     })
+    const badgeOffset = options.badgeOptions ? 8 : 0
     const radius = options.diameter / 2
     const canvas = document.createElement('canvas')
-    canvas.width = options.diameter
-    canvas.height = options.diameter
+    canvas.width = options.diameter + badgeOffset
+    canvas.height = options.diameter + badgeOffset
     const ctx = canvas.getContext('2d')
+
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.beginPath()
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -43,7 +46,7 @@ export default {
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.arc(
       radius,
-      radius,
+      radius + badgeOffset,
       radius - options.strokeWidth / 2,
       0,
       2 * Math.PI,
@@ -53,6 +56,15 @@ export default {
     ctx.fill()
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.stroke()
+
+    if (options.badgeOptions) {
+      return this.addBadge(canvas, {
+        width: options.diameter + badgeOffset,
+        color: options.badgeOptions.color,
+        text: options.badgeOptions.text,
+      })
+    }
+
     return canvas
   },
   getCircleWithText(options: any) {
@@ -63,9 +75,14 @@ export default {
       strokeColor: 'white',
       text: '',
       textColor: 'white',
+      badgeOptions: undefined,
     })
+
+    const badgeOffset = options.badgeOptions ? 8 : 0
+
     const canvas = this.getCircle(options)
     const ctx = canvas.getContext('2d')
+
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.font = '16pt Helvetica'
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -75,7 +92,12 @@ export default {
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.textBaseline = 'middle'
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.fillText(options.text, options.diameter / 2, options.diameter / 2)
+    ctx.fillText(
+      options.text,
+      options.diameter / 2,
+      options.diameter / 2 + badgeOffset
+    )
+
     return canvas
   },
   getCircleWithIcon(options: any) {
@@ -115,10 +137,18 @@ export default {
       strokeWidth: 2,
       strokeColor: 'white',
       textColor: 'white',
+      badgeOptions: undefined,
     })
+
+    const badgeOffset = options.badgeOptions ? 8 : 0
+
+    const getValWithOffset = (val: number) => {
+      return val + badgeOffset
+    }
+
     const canvas = document.createElement('canvas')
-    canvas.width = options.width
-    canvas.height = options.height
+    canvas.width = options.width + badgeOffset
+    canvas.height = options.height + badgeOffset
     const ctx = canvas.getContext('2d')
 
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -131,19 +161,47 @@ export default {
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.beginPath()
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.moveTo(19.36, 2)
+    ctx.moveTo(19.36, getValWithOffset(2))
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.bezierCurveTo(11.52, 2, 4.96, 6.64, 4.96, 14.64)
+    ctx.bezierCurveTo(
+      11.52,
+      getValWithOffset(2),
+      4.96,
+      getValWithOffset(6.64),
+      4.96,
+      getValWithOffset(14.64)
+    )
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.bezierCurveTo(4.96, 17.92, 6.08, 20.96, 7.84, 23.44)
+    ctx.bezierCurveTo(
+      4.96,
+      getValWithOffset(17.92),
+      6.08,
+      getValWithOffset(20.96),
+      7.84,
+      getValWithOffset(23.44)
+    )
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.lineTo(19.52, 38.96)
+    ctx.lineTo(19.52, getValWithOffset(38.96))
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.lineTo(31.2, 23.44)
+    ctx.lineTo(31.2, getValWithOffset(23.44))
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.bezierCurveTo(33.04, 20.96, 34.08, 17.92, 34.08, 14.64)
+    ctx.bezierCurveTo(
+      33.04,
+      getValWithOffset(20.96),
+      34.08,
+      getValWithOffset(17.92),
+      34.08,
+      getValWithOffset(14.64)
+    )
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    ctx.bezierCurveTo(34.08, 6.64, 27.6, 2, 19.52, 2)
+    ctx.bezierCurveTo(
+      34.08,
+      getValWithOffset(6.64),
+      27.6,
+      getValWithOffset(2),
+      19.52,
+      getValWithOffset(2)
+    )
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     ctx.fillStyle = options.fillColor
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
@@ -163,8 +221,65 @@ export default {
       ctx.textBaseline = 'middle'
 
       let icon = String.fromCharCode(parseInt(style.code, 16))
+
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-      ctx.fillText(icon, options.width / 2, options.height / 2 - 5)
+      ctx.fillText(
+        icon,
+        options.width / 2,
+        options.height / 2 - 5 + badgeOffset
+      )
+    }
+
+    if (options.badgeOptions) {
+      return this.addBadge(canvas, {
+        width: options.width + badgeOffset,
+        color: options.badgeOptions.color,
+        text: options.badgeOptions.text,
+      })
+    }
+
+    return canvas
+  },
+  addBadge(canvas: HTMLCanvasElement, options: any) {
+    _.defaults(options, {
+      width: 48,
+      color: '#fff59d',
+    })
+
+    const ctx = canvas.getContext('2d')
+
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.beginPath()
+
+    const radius = 10
+    const badgeX = options.width - (radius + 2)
+    const badgeY = radius + 2
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.arc(badgeX, badgeY, radius, 0, 2 * Math.PI, false)
+
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.fillStyle = options.color
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.strokeStyle = '#000000'
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.lineWidth = 1
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.fill()
+    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+    ctx.stroke()
+
+    if (options.text) {
+      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      ctx.font = '10pt Helvetica'
+      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      ctx.fillStyle = '#000000'
+      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      ctx.textAlign = 'center'
+      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      ctx.textBaseline = 'middle'
+
+      // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+      ctx.fillText(options.text, badgeX, badgeY)
     }
 
     return canvas

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
@@ -647,18 +647,21 @@ export default function CesiumMap(
         text: options.id.length,
         strokeColor: 'white',
         textColor: 'white',
+        badgeOptions: options.badgeOptions,
       })
       billboardRef.partiallySelectedImage = DrawingUtility.getCircleWithText({
         fillColor: options.color,
         text: options.id.length,
         strokeColor: 'black',
         textColor: 'white',
+        badgeOptions: options.badgeOptions,
       })
       billboardRef.selectedImage = DrawingUtility.getCircleWithText({
         fillColor: 'orange',
         text: options.id.length,
         strokeColor: 'white',
         textColor: 'white',
+        badgeOptions: options.badgeOptions,
       })
       switch (options.isSelected) {
         case 'selected':
@@ -719,10 +722,12 @@ export default function CesiumMap(
       billboardRef.unselectedImage = DrawingUtility.getPin({
         fillColor: options.color,
         icon: options.icon,
+        badgeOptions: options.badgeOptions,
       })
       billboardRef.selectedImage = DrawingUtility.getPin({
         fillColor: 'orange',
         icon: options.icon,
+        badgeOptions: options.badgeOptions,
       })
       billboardRef.image = options.isSelected
         ? billboardRef.selectedImage

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -468,14 +468,19 @@ export default function (
       const feature = new Openlayers.Feature({
         geometry: new Openlayers.geom.Point(pointObject),
       })
+      const badgeOffset = options.badgeOptions ? 8 : 0
+      const imgWidth = 44 + badgeOffset
+      const imgHeight = 44 + badgeOffset
+
       feature.setId(options.id)
       ;(feature as any).unselectedStyle = new Openlayers.style.Style({
         image: new Openlayers.style.Icon({
           img: DrawingUtility.getCircleWithText({
             fillColor: options.color,
             text: options.id.length,
+            badgeOptions: options.badgeOptions,
           }),
-          imgSize: [44, 44],
+          imgSize: [imgWidth, imgHeight],
         }),
       })
       ;(feature as any).partiallySelectedStyle = new Openlayers.style.Style({
@@ -485,8 +490,9 @@ export default function (
             text: options.id.length,
             strokeColor: 'black',
             textColor: 'white',
+            badgeOptions: options.badgeOptions,
           }),
-          imgSize: [44, 44],
+          imgSize: [imgWidth, imgHeight],
         }),
       })
       ;(feature as any).selectedStyle = new Openlayers.style.Style({
@@ -496,8 +502,9 @@ export default function (
             text: options.id.length,
             strokeColor: 'white',
             textColor: 'white',
+            badgeOptions: options.badgeOptions,
           }),
-          imgSize: [44, 44],
+          imgSize: [imgWidth, imgHeight],
         }),
       })
       switch (options.isSelected) {
@@ -532,8 +539,9 @@ export default function (
         name: options.title,
       })
       feature.setId(options.id)
-      let x = 39,
-        y = 40
+      const badgeOffset = options.badgeOptions ? 8 : 0
+      let x = 39 + badgeOffset,
+        y = 40 + badgeOffset
       if (options.size) {
         x = options.size.x
         y = options.size.y
@@ -543,9 +551,10 @@ export default function (
           img: DrawingUtility.getPin({
             fillColor: options.color,
             icon: options.icon,
+            badgeOptions: options.badgeOptions,
           }),
           imgSize: [x, y],
-          anchor: [x / 2, 0],
+          anchor: [x / 2 - badgeOffset / 2, 0],
           anchorOrigin: 'bottom-left',
           anchorXUnits: 'pixels',
           anchorYUnits: 'pixels',
@@ -556,9 +565,10 @@ export default function (
           img: DrawingUtility.getPin({
             fillColor: 'orange',
             icon: options.icon,
+            badgeOptions: options.badgeOptions,
           }),
           imgSize: [x, y],
-          anchor: [x / 2, 0],
+          anchor: [x / 2 - badgeOffset / 2, 0],
           anchorOrigin: 'bottom-left',
           anchorXUnits: 'pixels',
           anchorYUnits: 'pixels',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/react/cluster.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/react/cluster.tsx
@@ -5,6 +5,7 @@ import { useSelectionOfLazyResults } from '../../../../js/model/LazyQueryResult/
 import _ from 'underscore'
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'geo-... Remove this comment to see the full error message
 import calculateConvexHull from 'geo-convex-hull'
+import extension from '../../../../extension-points'
 
 type Props = {
   cluster: ClusterType
@@ -49,11 +50,18 @@ const Cluster = ({ cluster, map }: Props) => {
 
   const handleCluster = () => {
     const center = map.getCartographicCenterOfClusterInDegrees(cluster)
+
+    const badgeOptions = extension.customMapBadge({
+      results: cluster.results,
+      isCluster: true,
+    })
+
     geometries.current.push(
       map.addPointWithText(center, {
         id: cluster.results.map((result) => result['metacard.id']),
         color: cluster.results[0].getColor(),
         isSelected,
+        badgeOptions,
       })
     )
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/react/geometry.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/react/geometry.tsx
@@ -9,6 +9,8 @@ import metacardDefinitions from '../../../singletons/metacard-definitions'
 import iconHelper from '../../../../js/IconHelper'
 import { useUpdateEffect } from 'react-use'
 import { useSelectionOfLazyResult } from '../../../../js/model/LazyQueryResult/hooks'
+import extension from '../../../../extension-points'
+
 type Props = {
   lazyResult: LazyQueryResult
   map: any
@@ -56,6 +58,10 @@ const Geometry = ({ lazyResult, map, clusters }: Props) => {
   }, [lazyResult.plain])
 
   const handlePoint = React.useMemo(() => {
+    const badgeOptions = extension.customMapBadge({
+      results: [lazyResult],
+      isCluster: false,
+    })
     return (point: any) => {
       geometries.current.push(
         map.addPoint(point, {
@@ -64,6 +70,7 @@ const Geometry = ({ lazyResult, map, clusters }: Props) => {
           color,
           icon,
           isSelected,
+          badgeOptions,
         })
       )
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -195,7 +195,7 @@ const RowComponent = ({
                       style={{
                         width: 'auto',
                       }}
-                      className="pt-3 pr-4"
+                      className="pt-3"
                       ref={addOnRef}
                     >
                       {ResultItemAddOnInstance}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -50,6 +50,11 @@ export type ExtensionPointsType = {
   }: {
     lazyResult: LazyQueryResult
   }) => JSX.Element | null
+  inspectorTitleAddOn: ({
+    lazyResult,
+  }: {
+    lazyResult: LazyQueryResult
+  }) => JSX.Element | null
   layoutDropdown: (props: {
     goldenLayout: any
     layoutResult?: ResultType
@@ -78,6 +83,10 @@ export type ExtensionPointsType = {
   userInformation: PermissiveComponentType
   extraHeader: PermissiveComponentType
   extraFooter: PermissiveComponentType
+  customMapBadge: (props: {
+    results: LazyQueryResult[]
+    isCluster: boolean
+  }) => { text: string; color: string } | undefined
 }
 
 const ExtensionPoints: ExtensionPointsType = {
@@ -87,6 +96,7 @@ const ExtensionPoints: ExtensionPointsType = {
   customCanWritePermission: () => undefined,
   customEditableAttributes: async () => undefined,
   resultItemTitleAddOn: () => null,
+  inspectorTitleAddOn: () => null,
   resultItemRowAddOn: () => null,
   layoutDropdown: () => null,
   customSourcesPage: null,
@@ -99,6 +109,7 @@ const ExtensionPoints: ExtensionPointsType = {
   userInformation: () => null,
   extraFooter: () => null,
   extraHeader: () => null,
+  customMapBadge: () => undefined,
 }
 
 export default ExtensionPoints


### PR DESCRIPTION
Adds new extension points to customize the metacard title in the inspector visual and to add custom badges to map markers. The map badges are used for both pin and cluster markers in the 2D and 3D map visuals.