### PR TITLE
Disallow wildcards in boolean text search phrases

### DIFF
--- a/ui-backend/boolean-search/boolean-search-application/pom.xml
+++ b/ui-backend/boolean-search/boolean-search-application/pom.xml
@@ -101,12 +101,12 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/handlers/QueryHandler.java
+++ b/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/handlers/QueryHandler.java
@@ -1,7 +1,7 @@
 /* Copyright (c) Connexta, LLC */
 package org.codice.ddf.catalog.search.handlers;
 
-import static org.codice.ddf.catalog.javalin.utils.JavalinUtils.message;
+import static java.util.Collections.singletonMap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -10,6 +10,7 @@ import io.javalin.Handler;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+import org.codice.ddf.catalog.search.javacc.CustomParseException;
 import org.codice.ddf.catalog.search.javacc.ParseException;
 import org.codice.ddf.catalog.search.javacc.Parser;
 import org.codice.ddf.catalog.search.javacc.TokenMgrError;
@@ -51,7 +52,14 @@ public class QueryHandler implements Handler {
     } catch (ParseException | TokenMgrError e) {
       LOGGER.debug("Error parsing expression '{}'", searchExpression, e);
       ctx.status(400);
-      ctx.json(message("Invalid Syntax"));
+      ctx.json(singletonMap("error", true));
+    } catch (CustomParseException e) {
+      LOGGER.debug("Error parsing expression '{}'", searchExpression, e);
+      ctx.status(400);
+      final Map<String, Object> json = new HashMap<>();
+      json.put("error", true);
+      json.put("errorMessage", e.getMessage());
+      ctx.json(json);
     }
   }
 }

--- a/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/javacc/CustomParseException.java
+++ b/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/javacc/CustomParseException.java
@@ -1,0 +1,15 @@
+/* Copyright (c) Connexta, LLC */
+package org.codice.ddf.catalog.search.javacc;
+
+/**
+ * An exception intended to be thrown by the generated JavaCC parser to indicate an error message
+ * suitable for displaying to a user. We want to use our own exception class, rather than JavaCC's
+ * ParseException, so we can easily distinguish between our exceptions, with 'nice' messages, and
+ * JavaCC's, with messages that users wouldn't understand, by catching a different exception instead
+ * of parsing the exception message.
+ */
+public class CustomParseException extends Exception {
+  public CustomParseException(String message) {
+    super(message);
+  }
+}

--- a/ui-backend/boolean-search/boolean-search-application/src/main/javacc/Parser.jj
+++ b/ui-backend/boolean-search/boolean-search-application/src/main/javacc/Parser.jj
@@ -52,7 +52,7 @@ TOKEN :
 
 
 
-String SearchExpression() :
+String SearchExpression() throws CustomParseException :
 {
   String cql;
 }
@@ -64,7 +64,7 @@ String SearchExpression() :
     }
 }
 
-String TextSearchExpression() :
+String TextSearchExpression() throws CustomParseException :
 {
   String left, right;
   Token logicalOperator;
@@ -85,7 +85,7 @@ String TextSearchExpression() :
   }
 }
 
-String TextSearchComponent() :
+String TextSearchComponent() throws CustomParseException :
 {
     String quotedSearchPhrase;
     List<BooleanTextFilter> searchTextFilters = new ArrayList<>();
@@ -98,6 +98,9 @@ String TextSearchComponent() :
     (
         quotedSearchPhrase = QuotedSearchPhrase()
         {
+          if (quotedSearchPhrase.contains("?") || quotedSearchPhrase.contains("*")) {
+            throw new CustomParseException("Wildcards are not allowed in search phrases.");
+          }
           filters.add(new BooleanTextFilter(this.propertyName, quotedSearchPhrase.replace("\"", "").replace("'", "''")));
         }
         |

--- a/ui-backend/boolean-search/boolean-search-application/src/test/java/org/codice/ddf/catalog/search/javacc/ParserTest.java
+++ b/ui-backend/boolean-search/boolean-search-application/src/test/java/org/codice/ddf/catalog/search/javacc/ParserTest.java
@@ -4,12 +4,15 @@ package org.codice.ddf.catalog.search.javacc;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ParserTest {
+  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Test(expected = ParseException.class)
-  public void testBadSyntaxQuery() throws ParseException {
+  public void testBadSyntaxQuery() throws ParseException, CustomParseException {
     String searchExpression = "(a or and b)";
     final Parser parser = new Parser(new StringReader(searchExpression));
 
@@ -17,7 +20,7 @@ public class ParserTest {
   }
 
   @Test(expected = ParseException.class)
-  public void testUnBalancedParenthesis() throws ParseException {
+  public void testUnBalancedParenthesis() throws ParseException, CustomParseException {
     String searchExpression = "(a or (b and c)))";
     final Parser parser = new Parser(new StringReader(searchExpression));
 
@@ -25,7 +28,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testValidSyntax() throws ParseException {
+  public void testValidSyntax() throws ParseException, CustomParseException {
     String searchExpression = "a or b and c";
     String expectedQuery = "(anyText ILIKE 'a') or (anyText ILIKE 'b') and (anyText ILIKE 'c')";
 
@@ -36,7 +39,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testValidGrouping() throws ParseException {
+  public void testValidGrouping() throws ParseException, CustomParseException {
     String searchExpression = "(a or b) and c";
     String expectedQuery = "((anyText ILIKE 'a') or (anyText ILIKE 'b')) and (anyText ILIKE 'c')";
 
@@ -47,7 +50,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testValidNegation() throws ParseException {
+  public void testValidNegation() throws ParseException, CustomParseException {
     String searchExpression = "not (a or b) and c";
     String expectedQuery =
         "(NOT ((anyText ILIKE 'a') or (anyText ILIKE 'b'))) and (anyText ILIKE 'c')";
@@ -59,7 +62,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testAllowSingleCharWildcard() throws ParseException {
+  public void testAllowSingleCharWildcard() throws ParseException, CustomParseException {
     final String searchExpression = "not (?at or b?d) and i?";
     final String expectedQuery =
         "(NOT ((anyText ILIKE '?at') or (anyText ILIKE 'b?d'))) and (anyText ILIKE 'i?')";
@@ -71,7 +74,7 @@ public class ParserTest {
   }
 
   @Test
-  public void testAllowMultiCharWildcard() throws ParseException {
+  public void testAllowMultiCharWildcard() throws ParseException, CustomParseException {
     final String searchExpression = "not (*at or b*d) and i*";
     final String expectedQuery =
         "(NOT ((anyText ILIKE '*at') or (anyText ILIKE 'b*d'))) and (anyText ILIKE 'i*')";
@@ -80,5 +83,29 @@ public class ParserTest {
     String result = parser.SearchExpression();
 
     assertEquals(result, expectedQuery);
+  }
+
+  @Test
+  public void testSingleCharWildcardNotAllowedInPhrase()
+      throws ParseException, CustomParseException {
+    expectedException.expect(CustomParseException.class);
+    expectedException.expectMessage("Wildcards are not allowed in search phrases.");
+
+    final String searchExpression = "\"st?ck index\"";
+
+    final Parser parser = new Parser(new StringReader(searchExpression));
+    parser.SearchExpression();
+  }
+
+  @Test
+  public void testMultiCharWildcardNotAllowedInPhrase()
+      throws ParseException, CustomParseException {
+    expectedException.expect(CustomParseException.class);
+    expectedException.expectMessage("Wildcards are not allowed in search phrases.");
+
+    final String searchExpression = "\"st*ck index\"";
+
+    final Parser parser = new Parser(new StringReader(searchExpression));
+    parser.SearchExpression();
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-bar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-bar.tsx
@@ -106,11 +106,12 @@ const BooleanSearchBar = ({
       fetchCql({
         searchText: searchVal,
         searchProperty: property,
-        callback: ({ cql = '', message }) => {
+        callback: ({ cql = '', error, errorMessage }) => {
           onChange({
             ...value,
             cql,
-            error: Boolean(message),
+            error: !!error,
+            errorMessage,
           })
           setLoading(false)
         },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-utils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/boolean-search-utils.ts
@@ -64,7 +64,8 @@ export const fetchSuggestions = async ({
 
 type BooleanEndpointReturnType = {
   cql?: string
-  message?: string
+  error?: boolean
+  errorMessage?: string
 }
 
 export const fetchCql = async ({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/useBooleanSearchError.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/boolean-search-bar/useBooleanSearchError.tsx
@@ -29,6 +29,7 @@ const ERROR_MESSAGES = {
       <div>Check that syntax of AND / OR / NOT is used correctly.</div>
     </div>
   ),
+  custom: (message: string) => <div>Invalid Query: {message}</div>,
 }
 
 const useBooleanSearchError = (value: BooleanTextType) => {
@@ -36,7 +37,11 @@ const useBooleanSearchError = (value: BooleanTextType) => {
 
   useEffect(() => {
     if (value.error) {
-      setErrorMessage(ERROR_MESSAGES.syntax)
+      if (value.errorMessage) {
+        setErrorMessage(ERROR_MESSAGES.custom(value.errorMessage))
+      } else {
+        setErrorMessage(ERROR_MESSAGES.syntax)
+      }
     }
   }, [value])
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -188,6 +188,7 @@ export type BooleanTextType = {
   text: string
   cql: string
   error: boolean
+  errorMessage?: string
 }
 
 export type ValueTypes = {


### PR DESCRIPTION
Solr's standard query parser does not support wildcards in phrases.

![Screenshot 2023-07-05 at 4 50 57 PM](https://github.com/codice/ddf-ui/assets/4495447/65557b2a-6c9b-458f-9d13-464ed477ed71)