### PR TITLE
fixed filter-group-container typo

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-branch.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-branch.tsx
@@ -198,7 +198,7 @@ const FilterBranch = ({
         <div className=" relative">
           <div
             data-id={
-              root ? 'root-filter-group-container' : 'filter-group-contianer'
+              root ? 'root-filter-group-container' : 'filter-group-container'
             }
             className={`${
               filter.negated ? 'border px-3 py-4 mt-2' : ''


### PR DESCRIPTION
#### What does this PR do and why?
This PR intends to fix spelling typos so that the group contrast feature in ISR-6673 is working. 
In Advanced Search, when users add groups, they should see nested groups to avoid making mistakes in the queries.

#### How should this be tested?
To test
- Build ddf-ui (repo URL: https://github.com/connexta/aus/pull/2027  folderPath: ddf-ui/ui-frontend/packages/catalog-ui-search). In the aus repo 
(repo URL: https://github.com/connexta/aus/pull/2027  folder: ui/packages/intrigue), open package.json and point "catalog-ui-search" to ddf-ui/ui-frontend/packages/catalog-ui-search/dist
- Force build the ui in aus repo (folderPath: ui/packages/intrigue) and you should see a jar file in the target folder
- Deploy the jar to MIO via the dropping jars method

#### PR definition of Done
- Log into DDF, on the left side of the menu bar, locate and click on Search
- Switch to Advanced Search
- Add two groups .
- You should note two things:
a. Groups are nested 
b. Note the green lines covering the search boxes. There are two lines, one going down and one on top, going to the right.
The green line going to the right should be visible.  


UI data-id Change : corrected the spelling to filter-group-container
