### PR TITLE
Use admin configured summaryShown if user does not have their own preferences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <errorprone.version>2.2.0</errorprone.version>
 
     <!--Backend properties-->
-    <ddf.version>2.26.29</ddf.version>
+    <ddf.version>2.26.30</ddf.version>
     <ddf-jsonrpc.version>0.6</ddf-jsonrpc.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <antlr.version>4.3</antlr.version>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -18,6 +18,7 @@ import TableExport from '../../react-component/table-export'
 import {
   getExportOptions,
   Transformer,
+  getColumnOrder,
 } from '../../react-component/utils/export'
 import user from '../../component/singletons/user-instance'
 import {
@@ -50,14 +51,6 @@ type Source = {
 
 function getSrcs(selectionInterface: any) {
   return selectionInterface.getCurrentQuery().getSelectedSources()
-}
-
-function getColumnOrder(): string[] {
-  return user
-    .get('user')
-    .get('preferences')
-    .get('inspector-summaryShown')
-    .filter((property: string) => !properties.isHidden(property))
 }
 
 function getHiddenFields(): string[] {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-actions/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-actions/container.tsx
@@ -18,8 +18,7 @@ import * as React from 'react'
 import _ from 'underscore'
 import MetacardActionsPresentation from './presentation'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
-import user from '../../component/singletons/user-instance'
-import properties from '../../js/properties'
+import { getColumnOrder, aliasMap } from '../utils/export'
 
 type Props = {
   result: LazyQueryResult
@@ -27,20 +26,10 @@ type Props = {
 
 const MetacardActions = (props: Props) => {
   const model = props.result
-  const columnOrder = user
-    .get('user')
-    .get('preferences')
-    .get('inspector-summaryShown')
-  const aliasMap = encodeURIComponent(
-    Object.entries(properties.attributeAliases)
-      .map(([k, v]) => {
-        return `${k}=${v}`
-      })
-      .toString()
-  )
+
   const exportActions = _.sortBy(
     model.getExportActions().map((action) => ({
-      url: action.url + `&columnOrder=${columnOrder}&aliases=${aliasMap}`,
+      url: action.url + `&columnOrder=${getColumnOrder()}&aliases=${aliasMap}`,
       title: action.displayName,
     })),
     (action: any) => action.title.toLowerCase()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -16,12 +16,11 @@ import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import fetch from '../utils/fetch'
 import ResultsExportComponent from './presentation'
-import { exportResult, exportResultSet } from '../utils/export'
+import { exportResult, exportResultSet, getColumnOrder } from '../utils/export'
 import { getResultSetCql } from '../utils/cql'
 import saveFile from '../utils/save-file'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResults'
-import user from '../../component/singletons/user-instance'
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'cont... Remove this comment to see the full error message
 import contentDisposition from 'content-disposition'
 import properties from '../../js/properties'
@@ -148,10 +147,7 @@ class ResultsExport extends React.Component<Props, State> {
         count,
       },
     ]
-    const columnOrder = user
-      .get('user')
-      .get('preferences')
-      .get('inspector-summaryShown')
+    const columnOrder = getColumnOrder()
     if (this.props.isZipped) {
       response = await exportResultSet('zipCompression', {
         searches,
@@ -170,7 +166,7 @@ class ResultsExport extends React.Component<Props, State> {
         }),
         args: {
           hiddenFields: [],
-          columnOrder: columnOrder.length > 0 ? columnOrder : [],
+          columnOrder: columnOrder,
           columnAliasMap: properties.attributeAliases,
         },
       })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -16,6 +16,7 @@ import fetch from '../fetch'
 import { postAuditLog } from '../audit/audit-endpoint'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
 import properties from '../../../js/properties'
+import user from '../../../component/singletons/user-instance'
 
 export enum Transformer {
   Metacard = 'metacard',
@@ -79,19 +80,34 @@ export const getExportOptions = async (type: Transformer) => {
   return await response.json()
 }
 
+export const getColumnOrder = () => {
+  const userchoices = user
+    .get('user')
+    .get('preferences')
+    .get('inspector-summaryShown')
+  if (userchoices.length > 0) {
+    return userchoices
+  }
+  if ((properties as any).summaryShow.length > 0) {
+    return (properties as any).summaryShow
+  }
+  return ['title', 'created', 'thumbnail']
+}
+
+export const aliasMap = encodeURIComponent(
+  Object.entries(properties.attributeAliases)
+    .map(([k, v]) => {
+      return `${k}=${v}`
+    })
+    .toString()
+)
+
 export const exportResult = async (
   source: string,
   id: string,
   transformer: string,
   attributes: string
 ) => {
-  const aliasMap = encodeURIComponent(
-    Object.entries(properties.attributeAliases)
-      .map(([k, v]) => {
-        return `${k}=${v}`
-      })
-      .toString()
-  )
   const response = await fetch(
     `/services/catalog/sources/${source}/${id}?transform=${transformer}&columnOrder=${attributes}&aliases=${aliasMap}`
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
@@ -21,4 +21,6 @@ export {
   ResultSet,
   ExportCountInfo,
   DownloadInfo,
+  getColumnOrder,
+  aliasMap,
 } from './export'


### PR DESCRIPTION
This is just copying the same same code from:

https://github.com/codice/ddf-ui/blob/a6fe58cc681d1dccf81f564b3ba431f8f32bebb6/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx#L40-L52

and refactoring to export `getColumnOrder()` and `aliasMap` from one place