### PR TITLE
Various improvements to cross window communication for golden layout visuals, specifically focused on displaying / drawing for the maps, and some handling of outside app query params

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -1004,10 +1004,15 @@ const useProvideStateChange = ({
         subscribableThing: 'status',
         callback,
       })
+      const filterTreeSubscription = lazyResults.subscribeTo({
+        subscribableThing: 'filterTree',
+        callback,
+      })
       return () => {
         filteredResultsSubscription()
         selectedResultsSubscription()
         statusSubscription()
+        filterTreeSubscription()
       }
     }
     return () => {}
@@ -1084,6 +1089,7 @@ const useConsumeInitialState = ({
       }) => {
         setHasConsumedInitialState(true)
         lazyResults.reset({
+          filterTree: eventData.lazyResults.filterTree,
           results: Object.values(eventData.lazyResults.results).map((result) =>
             _cloneDeep(result.plain)
           ),
@@ -1150,8 +1156,14 @@ const useConsumeStateChange = ({
             isSelected: lazyResult.isSelected,
           }
         })
-        if (!_isEqualWith(results, callbackResults)) {
+        const filterTree = lazyResults.filterTree
+        const callbackFilterTree = eventData.lazyResults.filterTree
+        if (
+          !_isEqualWith(results, callbackResults) ||
+          !_isEqualWith(filterTree, callbackFilterTree)
+        ) {
           lazyResults.reset({
+            filterTree: eventData.lazyResults.filterTree,
             results: Object.values(eventData.lazyResults.results).map(
               (result) => _cloneDeep(result.plain)
             ),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/hooks.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/selection-interface/hooks.tsx
@@ -5,6 +5,7 @@ import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResult
 import {
   useStatusOfLazyResults,
   useSelectedResults,
+  useFilterTreeOfLazyResults,
 } from '../../js/model/LazyQueryResult/hooks'
 
 type useLazyResultsProps = {
@@ -49,6 +50,17 @@ export const useLazyResultsStatusFromSelectionInterface = ({
   const status = useStatusOfLazyResults({ lazyResults })
 
   return status
+}
+
+export const useLazyResultsFilterTreeFromSelectionInterface = ({
+  selectionInterface,
+}: useLazyResultsProps) => {
+  const lazyResults = useLazyResultsFromSelectionInterface({
+    selectionInterface,
+  })
+  const filterTree = useFilterTreeOfLazyResults({ lazyResults })
+
+  return filterTree
 }
 
 export const useLazyResultsFromSelectionInterface = ({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -28,7 +28,6 @@ import { Editor } from '../draw-menu'
 import { menu } from 'geospatialdraw'
 import { Shape } from 'geospatialdraw/target/webapp/shape-utils'
 import { DRAWING_STYLE } from '../openlayers/draw-styles'
-import { Drawing } from '../../../../component/singletons/drawing'
 import wreqr from '../../../../js/wreqr'
 import _ from 'lodash'
 
@@ -121,7 +120,7 @@ export const CesiumDrawings = ({
       `search:${getDrawModeFromShape(drawingShape)}-end`,
       drawingModel
     )
-    Drawing.turnOffDrawing()
+    wreqr.vent.trigger(`search:drawend`, drawingModel)
     if (drawingShape === 'Polygon') {
       ensurePolygonIsClosed(drawingLocation)
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
@@ -219,7 +219,7 @@ export const useDrawingAndDisplayModels = ({
   )
   useListenTo(
     (wreqr as any).vent,
-    'search:drawline-end search:drawpoly-end search:drawbbox-end search:drawcircle-end search:drawcancel',
+    'search:line-end search:poly-end search:bbox-end search:circle-end search:drawcancel',
     (model: any) => {
       if (drawingModels.includes(model)) {
         setDrawingModels(
@@ -228,18 +228,6 @@ export const useDrawingAndDisplayModels = ({
       }
     }
   )
-  useListenTo((wreqr as any).vent, 'search:drawend', (drawendModels: any[]) => {
-    setDrawingModels(
-      drawingModels.filter((drawingModel) => {
-        return !drawendModels.includes(drawingModel)
-      })
-    )
-    setModels(
-      models.filter((drawingModel) => {
-        return !drawendModels.includes(drawingModel)
-      })
-    )
-  })
   React.useEffect(() => {
     if (!isDrawing) {
       setDrawingModels([])

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
@@ -20,6 +20,7 @@ import { TypedUserInstance } from '../../singletons/TypedUser'
 import { zoomToHome } from './home'
 import LocationModel from '../../location-old/location-old'
 import { Shape } from 'geospatialdraw/target/webapp/shape-utils'
+import { useLazyResultsFilterTreeFromSelectionInterface } from '../../selection-interface/hooks'
 export const SHAPE_ID_PREFIX = 'shape'
 export const getIdFromModelForDisplay = ({ model }: { model: any }) => {
   return `${SHAPE_ID_PREFIX}-${model.cid}-display`
@@ -161,6 +162,9 @@ export const useDrawingAndDisplayModels = ({
   const [filterModels, setFilterModels] = React.useState<Array<any>>([])
   const [drawingModels, setDrawingModels] = React.useState<Array<any>>([])
   const isDrawing = useIsDrawing()
+  const filterTree = useLazyResultsFilterTreeFromSelectionInterface({
+    selectionInterface,
+  })
   useListenTo(
     (wreqr as any).vent,
     'search:linedisplay search:polydisplay search:bboxdisplay search:circledisplay search:keyworddisplay',
@@ -178,12 +182,11 @@ export const useDrawingAndDisplayModels = ({
   )
   const updateFilterModels = React.useMemo(() => {
     return () => {
-      const currentQuery = selectionInterface.get('currentQuery')
       const resultFilter = TypedUserInstance.getEphemeralFilter()
       const extractedModels = [] as any[]
-      if (currentQuery) {
+      if (filterTree) {
         extractModelsFromFilter({
-          filter: currentQuery.get('filterTree'),
+          filter: filterTree,
           extractedModels,
         })
       }
@@ -195,7 +198,10 @@ export const useDrawingAndDisplayModels = ({
       }
       setFilterModels(extractedModels)
     }
-  }, [selectionInterface])
+  }, [filterTree])
+  React.useEffect(() => {
+    updateFilterModels()
+  }, [updateFilterModels])
   useListenTo(selectionInterface, 'change:currentQuery', updateFilterModels)
   useListenTo(
     TypedUserInstance.getPreferences(),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
@@ -39,7 +39,6 @@ import {
 import * as ol from 'openlayers'
 import Common from '../../../../js/Common'
 import wreqr from '../../../../js/wreqr'
-import { Drawing } from '../../../../component/singletons/drawing'
 import * as Turf from '@turf/turf'
 import { Point, Polygon, LineString } from '@turf/turf'
 import { validateGeo } from '../../../../react-component/utils/validation'
@@ -336,7 +335,7 @@ export const OpenlayersDrawings = ({
       `search:${getDrawModeFromShape(drawingShape)}-end`,
       drawingModel
     )
-    Drawing.turnOffDrawing()
+    wreqr.vent.trigger(`search:drawend`, drawingModel)
     drawingModel.set('drawing', false)
     drawingModel.set(convertToModel(drawingLocation, drawingShape))
     setIsDrawing(false)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -28,6 +28,7 @@ import wreqr from '../../../../js/wreqr'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { ClusterType } from '../react/geometries'
 import { LazyQueryResult } from '../../../../js/model/LazyQueryResult/LazyQueryResult'
+import _debounce from 'lodash.debounce'
 const defaultColor = '#3c6dd5'
 const rulerColor = '#506f85'
 function createMap(insertionElement: any) {
@@ -85,7 +86,7 @@ export default function (
   let overlays = {}
   let shapes: any = []
   const map = createMap(insertionElement)
-  listenToResize()
+
   setupTooltip(map)
   function setupTooltip(map: any) {
     map.on('pointermove', (e: any) => {
@@ -103,12 +104,16 @@ export default function (
   function resizeMap() {
     map.updateSize()
   }
+  const debouncedResizeMap = _debounce(resizeMap, 250)
   function listenToResize() {
-    ;(wreqr as any).vent.on('resize', resizeMap)
+    ;(wreqr as any).vent.on('resize', debouncedResizeMap)
+    window.addEventListener('resize', debouncedResizeMap)
   }
   function unlistenToResize() {
-    ;(wreqr as any).vent.off('resize', resizeMap)
+    ;(wreqr as any).vent.off('resize', debouncedResizeMap)
+    window.removeEventListener('resize', debouncedResizeMap)
   }
+  listenToResize()
   /*
    * Returns a visible label that is in the same location as the provided label (geometryInstance) if one exists.
    * If findSelected is true, the function will also check for hidden labels in the same location but are selected.

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/handle-query-params.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/handle-query-params.tsx
@@ -12,12 +12,11 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-// check browser before loading the rest of the app
-import { isSupportedBrowser } from './check-browser'
-import { removeRedirectQueryParams } from './handle-query-params'
-;(() => {
-  if (isSupportedBrowser()) {
-    removeRedirectQueryParams()
-    import('./app')
+
+// some systems like keycloak attach query params which interfere with react router / golden layout and their use of query params (when using hash routing)
+export function removeRedirectQueryParams() {
+  if (location.href.includes(`${location.pathname}?`)) {
+    const preHashStuff = location.href.split('?')[0]
+    location.href = preHashStuff + location.hash
   }
-})()
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/hooks.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/hooks.tsx
@@ -201,6 +201,31 @@ export const useStatusOfLazyResults = ({
 }
 
 /**
+ * If a view cares about the status of a LazyQueryResults object
+ */
+export const useFilterTreeOfLazyResults = ({
+  lazyResults,
+}: {
+  lazyResults: LazyQueryResults
+}) => {
+  const [filterTree, setFilterTree] = React.useState(lazyResults.filterTree)
+  React.useEffect(() => {
+    setFilterTree(lazyResults.filterTree)
+    const unsubscribeCall = lazyResults.subscribeTo({
+      subscribableThing: 'filterTree',
+      callback: () => {
+        setFilterTree(lazyResults.filterTree)
+      },
+    })
+    return () => {
+      unsubscribeCall()
+    }
+  }, [lazyResults])
+
+  return filterTree
+}
+
+/**
  *  Allow a view to rerender when the backbone model resyncs to the plain model
  */
 export const useRerenderOnBackboneSync = ({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -190,6 +190,7 @@ export default Backbone.AssociatedModel.extend({
         // initialize this here so we can avoid creating spurious references to LazyQueryResults objects
         result: new QueryResponse({
           lazyResults: new LazyQueryResults({
+            filterTree: this.get('filterTree'),
             sorts: [],
             sources: [],
             transformSorts: ({ originalSorts }) => {
@@ -275,6 +276,11 @@ export default Backbone.AssociatedModel.extend({
         this.set('isOutdated', true)
       }
     )
+    this.listenTo(this, 'change:filterTree', () => {
+      this.get('result')
+        .get('lazyResults')
+        ._resetFilterTree(this.get('filterTree'))
+    })
     // basically remove invalid filters when going from basic to advanced, and make it basic compatible
     this.listenTo(this, 'change:type', () => {
       if (this.get('type') === 'basic') {
@@ -395,6 +401,7 @@ export default Backbone.AssociatedModel.extend({
     }
     let result = this.get('result')
     result.get('lazyResults').reset({
+      filterTree: this.get('filterTree'),
       sorts: this.get('sorts'),
       sources: selectedSources,
       transformSorts: ({ originalSorts }: any) => {


### PR DESCRIPTION
 -  Adds drawing / display across popped out map visuals
 - Updates the app to remove outside query params immediately before initial load of the rest of the app.  These tend to interfere with the hash routing / other libraries like golden layout.
 - Adds more robust listening to resize events so that openlayers does not get out of sync with the dimensions of the container resulting in skewed maps.



https://github.com/codice/ddf-ui/assets/11984853/d1ee6ff1-a99a-4ddf-a0ab-d25ac0f5cc40

