### PR TITLE
Add New Attribute to Query Metacard 

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
@@ -26,6 +26,7 @@ import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUER
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SCHEDULES;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SEARCH_AREA_IDS;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SPELLCHECK;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -77,6 +78,15 @@ public class QueryMetacardTypeImpl extends MetacardTypeImpl {
             true /* stored */,
             false /* tokenized */,
             false /* multivalued */,
+            BasicTypes.STRING_TYPE));
+
+    QUERY_DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            SEARCH_AREA_IDS,
+            false /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
             BasicTypes.STRING_TYPE));
 
     QUERY_DESCRIPTORS.add(

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -25,6 +25,7 @@ import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUER
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SOURCES;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SCHEDULES;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SEARCH_AREA_IDS;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SPELLCHECK;
 
 import com.google.gson.Gson;
@@ -79,6 +80,9 @@ public class QueryBasic {
   @SerializedName("sources")
   private List<String> sources;
 
+  @SerializedName("searchAreaIds")
+  private List<String> searchAreaIds;
+
   @SerializedName("sorts")
   private List<Map<String, String>> sorts;
 
@@ -132,6 +136,7 @@ public class QueryBasic {
     this.filterTree = getAttributeValue(metacard, QUERY_FILTER_TREE, String.class);
     this.enterprise = getAttributeValue(metacard, QUERY_ENTERPRISE, Boolean.class);
     this.sources = getAttributeValues(metacard, QUERY_SOURCES, String.class);
+    this.searchAreaIds = getAttributeValues(metacard, SEARCH_AREA_IDS, String.class);
 
     Class<Map<String, String>> clazz = (Class<Map<String, String>>) (Class) Map.class;
     this.sorts =
@@ -172,6 +177,7 @@ public class QueryBasic {
     metacard.setAttribute(new AttributeImpl(QUERY_FILTER_TREE, this.filterTree));
     metacard.setAttribute(new AttributeImpl(QUERY_ENTERPRISE, this.enterprise));
     metacard.setAttribute(new AttributeImpl(QUERY_SOURCES, (Serializable) this.sources));
+    metacard.setAttribute(new AttributeImpl(SEARCH_AREA_IDS, (Serializable) this.searchAreaIds));
 
     List<String> sortFields = getSortsField();
     metacard.setAttribute(new AttributeImpl(QUERY_SORTS, (Serializable) sortFields));

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/util/QueryAttributes.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/util/QueryAttributes.java
@@ -23,6 +23,8 @@ public class QueryAttributes {
 
   public static final String QUERY_FILTER_TREE = "filterTree";
 
+  public static final String SEARCH_AREA_IDS = "searchAreaIds";
+
   public static final String QUERY_SOURCES = "sources";
 
   public static final String QUERY_ENTERPRISE = "enterprise";

--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasicTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasicTest.java
@@ -19,6 +19,7 @@ import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUER
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_FILTER_TREE;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_SORTS;
 import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.QUERY_TYPE;
+import static org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes.SEARCH_AREA_IDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -28,7 +29,10 @@ import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.codice.ddf.catalog.ui.metacard.QueryMetacardApplicationTest;
 import org.junit.Test;
@@ -57,11 +61,21 @@ public class QueryBasicTest {
 
     assertAttribute(metacard, QUERY_TYPE, "advanced");
     assertAttribute(metacard, TITLE, "(\"anyText\" ILIKE 'foo bar')");
+
+    List<String> searchAreaIds =
+        Arrays.asList(
+            "a5113f24-3c8d-49ec-8a5d-9716009dbe53", "b5113f24-3c8d-49ec-8a5d-9716009dbe53");
+    assertAttribute(metacard, SEARCH_AREA_IDS, searchAreaIds);
   }
 
   private void assertAttribute(Metacard metacard, String attrName, Object value) {
     Attribute attr = metacard.getAttribute(attrName);
-    assertThat(attr.getValue(), is(value));
+    List<Serializable> values = attr.getValues();
+    if (values.size() > 1) {
+      assertThat(values, is(value));
+    } else {
+      assertThat(values.get(0), is(value));
+    }
   }
 
   private static String getFileContents(String resource) {

--- a/ui-backend/catalog-ui-search/src/test/resources/queries/basic.json
+++ b/ui-backend/catalog-ui-search/src/test/resources/queries/basic.json
@@ -9,5 +9,6 @@
     }
   ],
   "type":"advanced",
-  "title":"(\"anyText\" ILIKE 'foo bar')"
+  "title":"(\"anyText\" ILIKE 'foo bar')",
+  "searchAreaIds":["a5113f24-3c8d-49ec-8a5d-9716009dbe53", "b5113f24-3c8d-49ec-8a5d-9716009dbe53"]
 }


### PR DESCRIPTION
This PR adds the `searchAreaIds` attribute to the query metacard.