### PR TITLE
Reduce font, icon, and padding sizes within goldenlayout panel tabs

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/stack-toolbar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/stack-toolbar.tsx
@@ -12,7 +12,7 @@ import Paper from '@mui/material/Paper'
 import { Elevations } from '../theme/theme'
 import ExtensionPoints from '../../extension-points/extension-points'
 
-export const HeaderHeight = 44
+export const HeaderHeight = 32
 export const MinimizedHeight = HeaderHeight + 5
 
 /**
@@ -376,7 +376,7 @@ export const StackToolbar = ({
             <div>
               <CloseOnClickTooltip
                 title={
-                  <Paper elevation={Elevations.overlays} className="p-2">
+                  <Paper elevation={Elevations.overlays} className="p-1">
                     Minimize stack of visuals to bottom of layout
                   </Paper>
                 }
@@ -385,7 +385,7 @@ export const StackToolbar = ({
                   data-id="minimise-layout-button"
                   onClick={minimizeCallback}
                 >
-                  <MinimizeIcon />
+                  <MinimizeIcon fontSize="small"/>
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -394,7 +394,7 @@ export const StackToolbar = ({
             <div>
               <CloseOnClickTooltip
                 title={
-                  <Paper elevation={Elevations.overlays} className="p-2">
+                  <Paper elevation={Elevations.overlays} className="p-1">
                     Restore stack of visuals to original size
                   </Paper>
                 }
@@ -405,7 +405,7 @@ export const StackToolbar = ({
                     stack.toggleMaximise()
                   }}
                 >
-                  <FullscreenExitIcon />
+                  <FullscreenExitIcon fontSize="small"/>
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -413,7 +413,7 @@ export const StackToolbar = ({
             <div>
               <CloseOnClickTooltip
                 title={
-                  <Paper elevation={Elevations.overlays} className="p-2">
+                  <Paper elevation={Elevations.overlays} className="p-1">
                     Maximize stack of visuals
                   </Paper>
                 }
@@ -424,7 +424,7 @@ export const StackToolbar = ({
                     stack.toggleMaximise()
                   }}
                 >
-                  <FullscreenIcon />
+                  <FullscreenIcon fontSize="small"/>
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -434,7 +434,7 @@ export const StackToolbar = ({
             <div>
               <CloseOnClickTooltip
                 title={
-                  <Paper elevation={Elevations.overlays} className="p-2">
+                  <Paper elevation={Elevations.overlays} className="p-1">
                     Open stack of visuals in new window
                   </Paper>
                 }
@@ -455,7 +455,7 @@ export const StackToolbar = ({
             {(stack.header as any)._isClosable() ? (
               <CloseOnClickTooltip
                 title={
-                  <Paper elevation={Elevations.overlays} className="p-2">
+                  <Paper elevation={Elevations.overlays} className="p-1">
                     Close stack of visuals
                   </Paper>
                 }
@@ -469,7 +469,7 @@ export const StackToolbar = ({
                     stack.remove()
                   }}
                 >
-                  <CloseIcon />
+                  <CloseIcon fontSize="small"/>
                 </Button>
               </CloseOnClickTooltip>
             ) : null}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/stack-toolbar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/stack-toolbar.tsx
@@ -385,7 +385,7 @@ export const StackToolbar = ({
                   data-id="minimise-layout-button"
                   onClick={minimizeCallback}
                 >
-                  <MinimizeIcon fontSize="small"/>
+                  <MinimizeIcon fontSize="small" />
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -405,7 +405,7 @@ export const StackToolbar = ({
                     stack.toggleMaximise()
                   }}
                 >
-                  <FullscreenExitIcon fontSize="small"/>
+                  <FullscreenExitIcon fontSize="small" />
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -424,7 +424,7 @@ export const StackToolbar = ({
                     stack.toggleMaximise()
                   }}
                 >
-                  <FullscreenIcon fontSize="small"/>
+                  <FullscreenIcon fontSize="small" />
                 </Button>
               </CloseOnClickTooltip>
             </div>
@@ -469,7 +469,7 @@ export const StackToolbar = ({
                     stack.remove()
                   }}
                 >
-                  <CloseIcon fontSize="small"/>
+                  <CloseIcon fontSize="small" />
                 </Button>
               </CloseOnClickTooltip>
             ) : null}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-toolbar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-toolbar.tsx
@@ -199,7 +199,7 @@ export const GoldenLayoutComponentHeader = ({
         data-id={`${name}-tab`}
         className={`flex flex-row items-center flex-nowrap`}
       >
-        <Grid item className="px-2 text-lg">
+        <Grid item className="px-1 text-base">
           <div>{tab.titleElement.text()}</div>
         </Grid>
         <Grid item>
@@ -217,13 +217,13 @@ export const GoldenLayoutComponentHeader = ({
           <Grid item>
             <CloseOnClickTooltip
               title={
-                <Paper elevation={Elevations.overlays} className="p-2">
+                <Paper elevation={Elevations.overlays} className="p-1">
                   Minimize visual to bottom of layout
                 </Paper>
               }
             >
               <Button onClick={minimizeCallback}>
-                <MinimizeIcon />
+                <MinimizeIcon fontSize="small"/>
               </Button>
             </CloseOnClickTooltip>
           </Grid>
@@ -234,7 +234,7 @@ export const GoldenLayoutComponentHeader = ({
           tab.closeElement[0].style.display !== 'none' ? (
             <CloseOnClickTooltip
               title={
-                <Paper elevation={Elevations.overlays} className="p-2">
+                <Paper elevation={Elevations.overlays} className="p-1">
                   Open visual in new window
                 </Paper>
               }
@@ -245,7 +245,7 @@ export const GoldenLayoutComponentHeader = ({
                   tab.contentItem.popout()
                 }}
               >
-                <PopoutIcon />
+                <PopoutIcon fontSize="small"/>
               </Button>
             </CloseOnClickTooltip>
           ) : null}
@@ -254,7 +254,7 @@ export const GoldenLayoutComponentHeader = ({
           {tab.closeElement[0].style.display !== 'none' ? (
             <CloseOnClickTooltip
               title={
-                <Paper elevation={Elevations.overlays} className="p-2">
+                <Paper elevation={Elevations.overlays} className="p-1">
                   Close visual
                 </Paper>
               }
@@ -265,7 +265,7 @@ export const GoldenLayoutComponentHeader = ({
                   ;(tab as any)._onCloseClickFn(e)
                 }}
               >
-                <CloseIcon />
+                <CloseIcon fontSize="small"/>
               </Button>
             </CloseOnClickTooltip>
           ) : null}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-toolbar.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-toolbar.tsx
@@ -223,7 +223,7 @@ export const GoldenLayoutComponentHeader = ({
               }
             >
               <Button onClick={minimizeCallback}>
-                <MinimizeIcon fontSize="small"/>
+                <MinimizeIcon fontSize="small" />
               </Button>
             </CloseOnClickTooltip>
           </Grid>
@@ -245,7 +245,7 @@ export const GoldenLayoutComponentHeader = ({
                   tab.contentItem.popout()
                 }}
               >
-                <PopoutIcon fontSize="small"/>
+                <PopoutIcon fontSize="small" />
               </Button>
             </CloseOnClickTooltip>
           ) : null}
@@ -265,7 +265,7 @@ export const GoldenLayoutComponentHeader = ({
                   ;(tab as any)._onCloseClickFn(e)
                 }}
               >
-                <CloseIcon fontSize="small"/>
+                <CloseIcon fontSize="small" />
               </Button>
             </CloseOnClickTooltip>
           ) : null}


### PR DESCRIPTION
before:
<img width="989" alt="Screenshot 2023-09-20 at 9 44 46 PM" src="https://github.com/codice/ddf-ui/assets/14789712/77924d3e-073b-4f51-8610-6d73563dbb1d">

<br>
after:
<img width="987" alt="Screenshot 2023-09-20 at 9 43 59 PM" src="https://github.com/codice/ddf-ui/assets/14789712/0a54d476-43c9-4ce8-852c-6f40a5752331">
