### PR TITLE
Use cql endpoint for all exports

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -16,7 +16,7 @@ import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import fetch from '../utils/fetch'
 import ResultsExportComponent from './presentation'
-import { exportResult, exportResultSet, getColumnOrder } from '../utils/export'
+import { exportResultSet, getColumnOrder } from '../utils/export'
 import { getResultSetCql } from '../utils/cql'
 import saveFile from '../utils/save-file'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
@@ -157,7 +157,7 @@ class ResultsExport extends React.Component<Props, State> {
           transformerId: uriEncodedTransformerId,
         },
       })
-    } else if (this.props.results.length > 1) {
+    } else {
       response = await exportResultSet(uriEncodedTransformerId, {
         searches,
         count,
@@ -171,15 +171,6 @@ class ResultsExport extends React.Component<Props, State> {
             StartupDataStore.Configuration.config?.attributeAliases || {},
         },
       })
-    } else {
-      const result = this.props.results[0]
-
-      response = await exportResult(
-        result.source,
-        result.id,
-        uriEncodedTransformerId,
-        columnOrder.toString()
-      )
     }
 
     if (response.status === 200) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
@@ -61,7 +61,6 @@ export default hot(module)(
         customExportCount: StartupDataStore.Configuration.getExportLimit(),
       }
     }
-    transformUrl = './internal/cql/transform/'
     handleExportFormatChange = (value: string) => {
       this.setState({
         exportFormat: value,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -95,7 +95,7 @@ export const getColumnOrder = () => {
 }
 
 export const aliasMap = () => {
-  encodeURIComponent(
+  return encodeURIComponent(
     Object.entries(
       StartupDataStore.Configuration.config?.attributeAliases || {}
     )
@@ -113,7 +113,7 @@ export const exportResult = async (
   attributes: string
 ) => {
   const response = await fetch(
-    `/services/catalog/sources/${source}/${id}?transform=${transformer}&columnOrder=${attributes}&aliases=${aliasMap}`
+    `/services/catalog/sources/${source}/${id}?transform=${transformer}&columnOrder=${attributes}&aliases=${aliasMap()}`
   )
   await postAuditLog({
     action: 'exported',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -13,7 +13,6 @@
  *
  **/
 import fetch from '../fetch'
-import { postAuditLog } from '../audit/audit-endpoint'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
 import user from '../../../component/singletons/user-instance'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
@@ -104,23 +103,6 @@ export const aliasMap = () => {
       })
       .toString()
   )
-}
-
-export const exportResult = async (
-  source: string,
-  id: string,
-  transformer: string,
-  attributes: string
-) => {
-  const response = await fetch(
-    `/services/catalog/sources/${source}/${id}?transform=${transformer}&columnOrder=${attributes}&aliases=${aliasMap()}`
-  )
-  await postAuditLog({
-    action: 'exported',
-    component: 'metacard',
-    items: [{ id, 'source-id': source }],
-  })
-  return response
 }
 
 export const exportResultSet = async (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
@@ -14,7 +14,6 @@
  **/
 export {
   getExportOptions,
-  exportResult,
   exportResultSet,
   ExportBody,
   Transformer,


### PR DESCRIPTION
* Fixes aliases - the getAlias function was getting sent in the request body rather than the aliases themselves
* Use CQL endpoint for export of single item

To test this, make sure you can do an export via selecting >1 search results, then clicking "X items selected" > Export as