### PR TITLE
Make export lists admin configurable

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -881,8 +881,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setExportMetacardFormatOptions(String exportMetacardFormatOptions) {
     this.exportMetacardFormatOptions =
-        Arrays.stream(exportMetacardFormatOptions.split(",")).collect(Collectors.toSet());
-    ;
+        Arrays.stream(exportMetacardFormatOptions.replaceAll("\\s+", "").split(","))
+            .collect(Collectors.toSet());
   }
 
   public Set<String> getExportMetacardsFormatOptions() {
@@ -891,7 +891,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setExportMetacardsFormatOptions(String exportMetacardsFormatOptions) {
     this.exportMetacardsFormatOptions =
-        Arrays.stream(exportMetacardsFormatOptions.split(",")).collect(Collectors.toSet());
+        Arrays.stream(exportMetacardsFormatOptions.replaceAll("\\s+", "").split(","))
+            .collect(Collectors.toSet());
   }
 
   public Boolean getSignInEnabled() {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -150,6 +151,10 @@ public class ConfigurationApplication implements SparkApplication {
   private Integer resultCount = 250;
 
   private Integer exportResultLimit = 1000;
+
+  private Set<String> exportMetacardFormatOptions = new HashSet<>();
+
+  private Set<String> exportMetacardsFormatOptions = new HashSet<>();
 
   private String projection = "EPSG:4326";
 
@@ -507,6 +512,8 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("timeout", timeout);
     config.put("resultCount", resultCount);
     config.put("exportResultLimit", exportResultLimit);
+    config.put("exportMetacardFormatOptions", exportMetacardFormatOptions);
+    config.put("exportMetacardsFormatOptions", exportMetacardsFormatOptions);
     config.put("typeNameMapping", typeNameMapping);
     config.put("terrainProvider", proxiedTerrainProvider);
     config.put("imageryProviders", getConfigImageryProviders());
@@ -866,6 +873,25 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setExportResultLimit(Integer exportResultLimit) {
     this.exportResultLimit = exportResultLimit;
+  }
+
+  public Set<String> getExportMetacardFormatOptions() {
+    return exportMetacardFormatOptions;
+  }
+
+  public void setExportMetacardFormatOptions(String exportMetacardFormatOptions) {
+    this.exportMetacardFormatOptions =
+        Arrays.stream(exportMetacardFormatOptions.split(",")).collect(Collectors.toSet());
+    ;
+  }
+
+  public Set<String> getExportMetacardsFormatOptions() {
+    return exportMetacardsFormatOptions;
+  }
+
+  public void setExportMetacardsFormatOptions(String exportMetacardsFormatOptions) {
+    this.exportMetacardsFormatOptions =
+        Arrays.stream(exportMetacardsFormatOptions.split(",")).collect(Collectors.toSet());
   }
 
   public Boolean getSignInEnabled() {

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -27,6 +27,19 @@
             type="Integer"
             default="1000"/>
 
+
+        <AD id="exportMetacardFormatOptions"
+            name="Export Metacard Format Options"
+            description="Specifies the export format option available for export of a single metacard. This should be a comma separated list. Valis options are: audio, csv, csw:Record, deployed-harvested-resource, geojson, gmd:MD_Metadata, html, kml, kmz, resource, rtf, thumbnail, txt, xlsx, xml."
+            type="String"
+            default="audio,csv,csw:Record,deployed-harvested-resource,geojson,gmd:MD_Metadata,html,kml,kmz,resource,rtf,thumbnail,txt,xlsx,xml"/>
+
+        <AD id="exportMetacardsFormatOptions"
+            name="Export Multiple Metacard Format Options"
+            description="Specifies the export format option available for export of a single metacard. This should be a comma separated list. Valid options are: atom, csv, csw:Record, geojson, kml, kmz, xml, html, rtf, xlsx."
+            type="String"
+            default="atom,csv,csw:Record,geojson,kml,kmz,xml,html,rtf,xlsx"/>
+
         <AD id="imageryProviders"
             name="Imagery Providers"
             description='List of imagery providers to use. Valid types are: OSM (OpenStreetMap), AGM (ArcGisMap), BM (BingMap), WMS (WebMapService), WMT (WebMapTile), TMS (TileMapService), and GE (GoogleEarth). Example: {"name": "Example OSM", "show": true, "type": "OSM", "url": "http://a.tile.openstreetmap.org", "fileExtension": "png", "order": 0, "alpha": 1, "proxyEnabled": false}.'

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -30,13 +30,13 @@
 
         <AD id="exportMetacardFormatOptions"
             name="Export Metacard Format Options"
-            description="Specifies the export format option available for export of a single metacard. This should be a comma separated list. Valis options are: audio, csv, csw:Record, deployed-harvested-resource, geojson, gmd:MD_Metadata, html, kml, kmz, resource, rtf, thumbnail, txt, xlsx, xml."
+            description="Specifies the export format options available for export of a single metacard. This should be a comma separated list. Valid options are: audio, csv, csw:Record, deployed-harvested-resource, geojson, gmd:MD_Metadata, html, kml, kmz, resource, rtf, thumbnail, txt, xlsx, xml."
             type="String"
             default="audio,csv,csw:Record,deployed-harvested-resource,geojson,gmd:MD_Metadata,html,kml,kmz,resource,rtf,thumbnail,txt,xlsx,xml"/>
 
         <AD id="exportMetacardsFormatOptions"
             name="Export Multiple Metacard Format Options"
-            description="Specifies the export format option available for export of a single metacard. This should be a comma separated list. Valid options are: atom, csv, csw:Record, geojson, kml, kmz, xml, html, rtf, xlsx."
+            description="Specifies the export format options available for export of multiple metacards. This should be a comma separated list. Valid options are: atom, csv, csw:Record, geojson, kml, kmz, xml, html, rtf, xlsx."
             type="String"
             default="atom,csv,csw:Record,geojson,kml,kmz,xml,html,rtf,xlsx"/>
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -25,6 +25,7 @@ import {
   exportResultSet,
   ExportCountInfo,
   DownloadInfo,
+  ExportFormat,
 } from '../../react-component/utils/export'
 import saveFile from '../../react-component/utils/save-file'
 import { DEFAULT_USER_QUERY_OPTIONS } from '../../js/model/TypedQuery'
@@ -34,11 +35,6 @@ import { AddSnack } from '../snack/snack.provider'
 import contentDisposition from 'content-disposition'
 import { getResultSetCql } from '../../react-component/utils/cql'
 import { StartupDataStore } from '../../js/model/Startup/startup'
-
-type ExportResponse = {
-  displayName: string
-  id: string
-}
 
 export type Props = {
   selectionInterface: any
@@ -200,13 +196,9 @@ const TableExports = ({ selectionInterface }: Props) => {
   useEffect(() => {
     const fetchFormats = async () => {
       const exportFormats = await getExportOptions(Transformer.Query)
-      const sortedExportFormats = exportFormats.sort(
-        (format1: ExportResponse, format2: ExportResponse) => {
-          return format1.displayName.localeCompare(format2.displayName)
-        }
-      )
+
       setFormats(
-        sortedExportFormats.map((exportFormat: ExportResponse) => ({
+        exportFormats.map((exportFormat: ExportFormat) => ({
           label: exportFormat.displayName,
           value: exportFormat.id,
         }))

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
@@ -61,6 +61,12 @@ class Configuration extends Subscribable<{ thing: 'configuration-update' }> {
   getSummaryShow = () => {
     return this.config?.summaryShow || []
   }
+  getExportMetacardFormatOptions = () => {
+    return this.config?.exportMetacardFormatOptions || []
+  }
+  getExportMetacardsFormatOptions = () => {
+    return this.config?.exportMetacardsFormatOptions || []
+  }
   getCommonAttributes = () => {
     return this.config?.commonAttributes || []
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -112,6 +112,8 @@ export interface UIConfigType {
   basicSearchMatchType: string
   onlineGazetteer: boolean
   imageryProviders: ImageryProvider[]
+  exportMetacardFormatOptions: string[]
+  exportMetacardsFormatOptions: string[]
   isCacheDisabled: boolean
   isCustomTextNotationEnabled: boolean
   isVersioningEnabled: boolean

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
@@ -57,7 +57,7 @@ export default hot(module)(
           },
         ],
         exportSize: 'all',
-        exportFormat: 'csv',
+        exportFormat: "",
         customExportCount: StartupDataStore.Configuration.getExportLimit(),
       }
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/table-export/container.tsx
@@ -57,7 +57,7 @@ export default hot(module)(
           },
         ],
         exportSize: 'all',
-        exportFormat: "",
+        exportFormat: '',
         customExportCount: StartupDataStore.Configuration.getExportLimit(),
       }
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -98,7 +98,7 @@ export const getExportOptions = async (type: Transformer) => {
             if (validFormat == undefined)
               console.log(
                 configuredFormat +
-                  ' does not match any valid transformers; Cannot not include format in export list.'
+                  ' does not match any valid transformers; cannot include format in export list.'
               )
             return validFormat
           })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
@@ -22,4 +22,5 @@ export {
   DownloadInfo,
   getColumnOrder,
   aliasMap,
+  ExportFormat,
 } from './export'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
@@ -59,6 +59,8 @@ const mockStartupPayload: StartupPayloadType = {
     isVersioningEnabled: true,
     isSpellcheckEnabled: true,
     attributeSuggestionList: [],
+    exportMetacardFormatOptions: [],
+    exportMetacardsFormatOptions: [],
     summaryShow: ['name', 'age'],
     readOnly: [],
     version: '1.2.3',


### PR DESCRIPTION
**To test**

1. Login as admin
2. Upload some products
3. Run search
4. Attempt to export single item
5. See that the full export list is available
6. Attempt to export multiple items
7. See that the full export list is available
8. Go to admin ui > catalog ui search
9. Configure the export format lists (there should be a description listing the valid formats)
10. attempt exports again and see the format options updated