### PR TITLE
Enable double click to edit a geometry

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.ts
@@ -40,6 +40,7 @@ const Direction = dmsUtils.Direction
 export default Backbone.AssociatedModel.extend({
   defaults: () => {
     return {
+      locationId: Date.now(),
       color: Object.values(locationColors)[0],
       drawing: false,
       north: undefined,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
@@ -173,6 +173,7 @@ const drawGeometry = ({
   }
 
   primitive.id = id
+  primitive.locationId = model.attributes.locationId
   map.getMap().scene.primitives.add(primitive)
   map.getMap().scene.requestRender()
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
@@ -181,6 +181,7 @@ const drawGeometry = ({
   }
 
   primitive.id = id
+  primitive.locationId = modelProp.locationId
   map.getMap().scene.primitives.add(primitive)
   map.getMap().scene.requestRender()
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -103,7 +103,7 @@ export const CesiumDrawings = ({
         cancelDrawing()
       }
     },
-    [drawingModel]
+    [drawingModel, drawingShape, drawingLocation]
   )
 
   useEffect(() => {
@@ -116,6 +116,7 @@ export const CesiumDrawings = ({
     } else {
       window.removeEventListener('keydown', handleKeydown)
     }
+    return () => window.removeEventListener('keydown', handleKeydown)
   }, [drawingModel])
 
   const cancelDrawing = () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -93,12 +93,28 @@ export const CesiumDrawings = ({
   const [isDrawing, setIsDrawing] = useState(false)
   const [drawingShape, setDrawingShape] = useState<Shape>(DEFAULT_SHAPE)
 
+  const handleKeydown = React.useCallback(
+    (e: any) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        finishDrawing()
+      }
+      if (e.key === 'Escape') {
+        cancelDrawing()
+      }
+    },
+    [drawingModel]
+  )
+
   useEffect(() => {
     setIsDrawing(!!drawingModel)
     if (drawingModel) {
+      window.addEventListener('keydown', handleKeydown)
       setDrawingShape(
         getShapeFromDrawMode(getDrawModeFromModel({ model: drawingModel }))
       )
+    } else {
+      window.removeEventListener('keydown', handleKeydown)
     }
   }, [drawingModel])
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
@@ -244,6 +244,7 @@ const drawGeometry = ({
 
     primitive = new Cesium.PolylineCollection()
     primitive.id = id
+    primitive.locationId = json.locationId
     primitive.add(
       constructOutlinedLinePrimitive({
         coordinates: bufferedLine.geometry.coordinates,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
@@ -170,6 +170,7 @@ const drawGeometry = ({
   } else {
     const pc = new Cesium.PolylineCollection()
     pc.id = id
+    pc.locationId = json.locationId
     polygons.forEach((polygonPoints) => {
       if (!validateAndFixPolygon(polygonPoints)) {
         return

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
@@ -117,6 +117,7 @@ const extractModelsFromFilter = ({
       if (filter.value?.areaDetails?.locations) {
         filter.value.areaDetails.locations.map((location: any) => {
           const newLocationModel = new LocationModel(location)
+          newLocationModel.set('locationId', undefined)
           extractedModels.push(newLocationModel)
         })
       } else {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.ts
@@ -22,6 +22,7 @@ function throwUnimplementedException() {
 const exposedMethods = [
   'onLeftClick',
   'onRightClick',
+  'onDoubleClick',
   'onMouseDown',
   'onMouseMove',
   'onCameraMoveStart',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/bbox-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/bbox-display.tsx
@@ -109,6 +109,7 @@ export const drawBbox = ({
     geometry: rectangle,
   })
   billboard.setId(id)
+  billboard.set('locationId', model.get('locationId'))
   const color = model.get('color')
   const iconStyle = new ol.style.Style({
     stroke: new ol.style.Stroke({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/circle-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/circle-display.tsx
@@ -87,6 +87,7 @@ export const drawCircle = ({
     geometry: geometryRepresentation,
   })
   billboard.setId(id)
+  billboard.set('locationId', model.get('locationId'))
   const color = model.get('color')
   const iconStyle = new ol.style.Style({
     stroke: new ol.style.Stroke({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
@@ -315,7 +315,7 @@ export const OpenlayersDrawings = ({
         cancelDrawing()
       }
     },
-    [drawingModel, drawingShape, map]
+    [drawingModel, drawingShape, drawingLocation]
   )
 
   useEffect(() => {
@@ -329,6 +329,7 @@ export const OpenlayersDrawings = ({
     } else {
       window.removeEventListener('keydown', handleKeydown)
     }
+    return () => window.removeEventListener('keydown', handleKeydown)
   }, [drawingModel])
 
   const cancelDrawing = () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
@@ -305,13 +305,29 @@ export const OpenlayersDrawings = ({
     null
   )
 
+  const handleKeydown = React.useCallback(
+    (e: any) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        finishDrawing()
+      }
+      if (e.key === 'Escape') {
+        cancelDrawing()
+      }
+    },
+    [drawingModel, drawingShape, map]
+  )
+
   useEffect(() => {
     setIsDrawing(!!drawingModel)
     if (drawingModel) {
+      window.addEventListener('keydown', handleKeydown)
       setDrawingShape(
         getShapeFromDrawMode(getDrawModeFromModel({ model: drawingModel }))
       )
       setDrawingGeometry(getDrawingGeometryFromModel(drawingModel))
+    } else {
+      window.removeEventListener('keydown', handleKeydown)
     }
   }, [drawingModel])
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/line-display.tsx
@@ -137,6 +137,7 @@ export const drawLine = ({
     geometry: geometryRepresentation,
   })
   billboard.setId(id)
+  billboard.set('locationId', model.get('locationId'))
   const drawnLineFeature = new ol.Feature({
     geometry: drawnGeometryRepresentation,
   })
@@ -153,7 +154,6 @@ export const drawLine = ({
       width: 2,
       lineDash: [10, 5],
     }),
-    zIndex: 0,
   })
   billboard.setStyle(iconStyle)
   drawnLineFeature.setStyle(drawnLineIconStyle)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -55,6 +55,15 @@ function determineIdFromPosition(position: any, map: any) {
     return features[0].getId()
   }
 }
+function determineLocationIdFromPosition(position: any, map: any) {
+  const features: any = []
+  map.forEachFeatureAtPixel(position, (feature: any) => {
+    features.push(feature)
+  })
+  if (features.length > 0) {
+    return features[0].get('locationId')
+  }
+}
 function convertPointCoordinate(point: any) {
   const coords = [point[0], point[1]]
   return Openlayers.proj.transform(
@@ -204,6 +213,18 @@ export default function (
         callback(e)
       })
     },
+    onDoubleClick() {
+      $(map.getTargetElement()).on('dblclick', (e) => {
+        const boundingRect = map.getTargetElement().getBoundingClientRect()
+        const id = determineLocationIdFromPosition(
+          [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
+          map
+        )
+        if (id) {
+          ;(wreqr as any).vent.trigger('location:doubleClick', id)
+        }
+      })
+    },
     onMouseTrackingForPopup(
       downCallback: any,
       moveCallback: any,
@@ -220,11 +241,13 @@ export default function (
     onMouseMove(callback: any) {
       $(map.getTargetElement()).on('mousemove', (e) => {
         const boundingRect = map.getTargetElement().getBoundingClientRect()
+        const position = [
+          e.clientX - boundingRect.left,
+          e.clientY - boundingRect.top,
+        ]
         callback(e, {
-          mapTarget: determineIdFromPosition(
-            [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
-            map
-          ),
+          mapTarget: determineIdFromPosition(position, map),
+          mapLocationId: determineLocationIdFromPosition(position, map),
         })
       })
     },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/polygon-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/polygon-display.tsx
@@ -168,6 +168,7 @@ export const drawPolygon = ({
     geometry: bufferGeometryRepresentation,
   })
   billboard.setId(id)
+  billboard.set('locationId', model.get('locationId'))
   const drawnPolygonFeature = new ol.Feature({
     geometry: drawnGeometryRepresentation,
   })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
@@ -135,21 +135,25 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
   const isDrawing = useIsDrawing()
   const { listenTo, stopListening } = useBackbone()
   const { MuiButtonProps, MuiPopoverProps } = useMenuState()
+  const onDraw = () => {
+    ;(wreqr as any).vent.trigger('search:draw' + state.mode, locationModel)
+  }
+  const onDrawCancel = () => {
+    ;(wreqr as any).vent.trigger('search:drawcancel', locationModel)
+  }
+  const onDrawEnd = () => {
+    ;(wreqr as any).vent.trigger('search:drawend', locationModel)
+  }
   const setColor = (color: string) => {
     locationModel.set('color', color)
-    ;(wreqr as any).vent.trigger('search:drawend', [locationModel])
+    onDrawEnd()
   }
-  listenTo((wreqr as any).vent, 'location:doubleClick', (locationId: any) => {
-    if (locationModel.attributes.locationId === locationId) {
-      ;(wreqr as any).vent.trigger('search:draw' + state.mode, locationModel)
-    }
-  })
   React.useEffect(() => {
     return () => {
       setTimeout(() => {
         // This is to facilitate clearing out the map, it isn't about the value, but we don't want the changeCallback to fire!
         locationModel.set(locationModel.defaults())
-        ;(wreqr as any).vent.trigger('search:drawend', [locationModel])
+        onDrawEnd()
       }, 0)
     }
   }, [])
@@ -164,7 +168,19 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
       stopListening(locationModel, 'change', onChangeCallback)
     }
   }, [onChange])
-
+  React.useEffect(() => {
+    const onDoubleClickCallback = (locationId: any) => {
+      if (locationModel.attributes.locationId === locationId) onDraw()
+    }
+    listenTo((wreqr as any).vent, 'location:doubleClick', onDoubleClickCallback)
+    return () => {
+      stopListening(
+        (wreqr as any).vent,
+        'location:doubleClick',
+        onDoubleClickCallback
+      )
+    }
+  }, [locationModel, state])
   const ComponentToRender = inputs[state.mode]
     ? inputs[state.mode].Component
     : () => null
@@ -240,12 +256,7 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
               {isDrawing && locationModel === Drawing.getDrawModel() ? (
                 <Button
                   className="location-draw mt-2"
-                  onClick={() => {
-                    ;(wreqr as any).vent.trigger(
-                      'search:drawcancel',
-                      locationModel
-                    )
-                  }}
+                  onClick={onDrawCancel}
                   color="secondary"
                   fullWidth
                 >
@@ -254,12 +265,7 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
               ) : (
                 <Button
                   className="location-draw mt-2"
-                  onClick={() => {
-                    ;(wreqr as any).vent.trigger(
-                      'search:draw' + state.mode,
-                      locationModel
-                    )
-                  }}
+                  onClick={onDraw}
                   color="primary"
                   fullWidth
                 >

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/location/location.tsx
@@ -139,6 +139,11 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
     locationModel.set('color', color)
     ;(wreqr as any).vent.trigger('search:drawend', [locationModel])
   }
+  listenTo((wreqr as any).vent, 'location:doubleClick', (locationId: any) => {
+    if (locationModel.attributes.locationId === locationId) {
+      ;(wreqr as any).vent.trigger('search:draw' + state.mode, locationModel)
+    }
+  })
   React.useEffect(() => {
     return () => {
       setTimeout(() => {
@@ -159,6 +164,7 @@ const LocationInput = ({ onChange, value, errorListener }: any) => {
       stopListening(locationModel, 'change', onChangeCallback)
     }
   }, [onChange])
+
   const ComponentToRender = inputs[state.mode]
     ? inputs[state.mode].Component
     : () => null


### PR DESCRIPTION
* Double click on geo to go into edit mode
* press enter to apply changes
* press escape to cancel
* when hovering over a filter geo show the "grab" cursor
* when overing over a geo puled in from an area, show the "not-allowed" cursor

To make it so the drawn Locations (the ones you double click on) could reference the original filter Location (the ones that actually get edited), created a locationID and applied this to all location generated from the original filter location. Only set this locationID on filter Locations (not locations populated from areas) and used the existence of locationID to determine the hover cursor (editablilty).


https://github.com/codice/ddf-ui/assets/14789712/4d353e7f-7d69-4706-92c9-7038f2a717de

