### PR TITLE
Verbiage updates & Switch 3D buffered line to dashes

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -882,7 +882,7 @@ public class ConfigurationApplication implements SparkApplication {
   public void setExportMetacardFormatOptions(String exportMetacardFormatOptions) {
     this.exportMetacardFormatOptions =
         Arrays.stream(exportMetacardFormatOptions.replaceAll("\\s+", "").split(","))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   public Set<String> getExportMetacardsFormatOptions() {
@@ -892,7 +892,7 @@ public class ConfigurationApplication implements SparkApplication {
   public void setExportMetacardsFormatOptions(String exportMetacardsFormatOptions) {
     this.exportMetacardsFormatOptions =
         Arrays.stream(exportMetacardsFormatOptions.replaceAll("\\s+", "").split(","))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   public Boolean getSignInEnabled() {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -310,7 +310,7 @@ const TableExports = ({ selectionInterface }: Props) => {
         />
       </div>
       {['csv', 'rtf', 'xlsx'].includes(exportFormat) ? (
-        <SummaryManageAttributes />
+        <SummaryManageAttributes isExport={true} />
       ) : null}
       {warning && (
         <div className="warning text-center pt-1">

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
@@ -129,13 +129,13 @@ export const constructDottedLinePrimitive = ({
   const color = model.get('color')
 
   return {
-    width: 4,
+    width: 2,
     material: Cesium.Material.fromType('PolylineDash', {
       color: color
         ? Cesium.Color.fromCssColorString(color)
         : Cesium.Color.KHAKI,
-      dashLength: 16.0,
-      dashPattern: 7.0,
+      dashLength: 20,
+      dashPattern: 255,
     }),
     id: 'userDrawing',
     positions: Cesium.Cartesian3.fromDegreesArray(_.flatten(coordinates)),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/attribute-settings/attribute-settings.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/attribute-settings/attribute-settings.tsx
@@ -31,7 +31,7 @@ type PrecisionOption = {
 
 const Options = [
   {
-    label: 'None',
+    label: 'Default',
     value: undefined,
   },
   {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
@@ -72,7 +72,7 @@ const ResultsExportComponent = (props: Props) => {
         />
       </div>
       {['CSV', 'RTF', 'XLSX'].includes(selectedFormat) ? (
-        <SummaryManageAttributes />
+        <SummaryManageAttributes isExport={true} />
       ) : null}
       <Button
         variant="contained"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
@@ -20,7 +20,7 @@ import { Elevations } from '../../component//theme/theme'
 import { useDialog } from '../../component//dialog'
 import { TypedUserInstance } from '../../component/singletons/TypedUser'
 
-export default () => {
+export default ({ isExport = false }: { isExport?: boolean }) => {
   const dialogContext = useDialog()
   return (
     <Button
@@ -64,7 +64,7 @@ export default () => {
       size="small"
       style={{ height: 'auto' }}
     >
-      Manage Attributes
+      {isExport ? 'Select Attributes to Export' : 'Manage Attributes'}
     </Button>
   )
 }


### PR DESCRIPTION
* see that search areas dashed buffer lines are consistent between 3D and 2D maps
<img width="1904" alt="image" src="https://github.com/codice/ddf-ui/assets/14789712/6e0279aa-11d1-406b-9254-ac1407991b7b">
* Verbiage update from "Manage Attributes" to "Select attributes to export"
<img width="1904" alt="Pasted Graphic" src="https://github.com/codice/ddf-ui/assets/14789712/5a7f216c-9453-4e1f-a9d6-ce93b9aa042b">
* verbiage updated from "None" to "Default"
<img width="1904" alt="Pasted Graphic 1" src="https://github.com/codice/ddf-ui/assets/14789712/f473d520-fa51-46b1-a0e0-f42ac5f37d1d">
