### PR TITLE
Allow  2D/OpenLayers map to specify drawing/display locations without a selectionInterface

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
@@ -122,6 +122,9 @@ const extractModelsFromFilter = ({
         })
       } else {
         const newLocationModel = new LocationModel(filter.value)
+        if (newLocationModel.get('hasKeyword')) {
+          newLocationModel.set('locationId', undefined)
+        }
         extractedModels.push(newLocationModel)
       }
     }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
@@ -276,6 +276,18 @@ const handleMapHover = ({
   setIsHoveringResult: (val: boolean) => void
   setEditableGeo: (val: EditableGeo) => void
 }) => {
+  const isHoveringOverGeo = Boolean(
+    mapEvent.mapTarget &&
+      mapEvent.mapTarget.constructor === String &&
+      (mapEvent.mapTarget as string).startsWith(SHAPE_ID_PREFIX)
+  )
+
+  if (isHoveringOverGeo) setEditableGeo(Boolean(mapEvent.mapLocationId))
+  else setEditableGeo(undefined)
+
+  if (!selectionInterface) {
+    return
+  }
   const currentQuery = selectionInterface.get('currentQuery')
   if (!currentQuery) {
     return
@@ -296,15 +308,6 @@ const handleMapHover = ({
             !(mapEvent.mapTarget as string).startsWith(SHAPE_ID_PREFIX)))
     )
   )
-
-  const isHoveringOverGeo = Boolean(
-    mapEvent.mapTarget &&
-      mapEvent.mapTarget.constructor === String &&
-      (mapEvent.mapTarget as string).startsWith(SHAPE_ID_PREFIX)
-  )
-
-  if (isHoveringOverGeo) setEditableGeo(Boolean(mapEvent.mapLocationId))
-  else setEditableGeo(undefined)
 }
 
 const useMapListeners = ({
@@ -320,7 +323,7 @@ const useMapListeners = ({
   const [editableGeo, setEditableGeo] = React.useState<EditableGeo>(undefined)
 
   React.useEffect(() => {
-    if (map && mapModel && selectionInterface) {
+    if (map && mapModel) {
       map.onMouseMove((_event: any, mapEvent: any) => {
         handleMapHover({
           map,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
@@ -17,7 +17,6 @@ import { useState, useEffect } from 'react'
 import { v4 } from 'uuid'
 import {
   getDrawModeFromModel,
-  useDrawingAndDisplayModels,
   getShapeFromDrawMode,
   getDrawModeFromShape,
 } from '../drawing-and-display'
@@ -45,7 +44,10 @@ import { validateGeo } from '../../../../react-component/utils/validation'
 import ShapeUtils from '../../../../js/ShapeUtils'
 import _ from 'lodash'
 import utility from './utility'
-import { contrastingColor } from '../../../../react-component/location/location-color-selector'
+import {
+  locationColors,
+  contrastingColor,
+} from '../../../../react-component/location/location-color-selector'
 
 const DrawingMenu = menu.DrawingMenu
 const makeEmptyGeometry = geometry.makeEmptyGeometry
@@ -272,6 +274,7 @@ export const convertToModel = (geo: GeometryJSON, shape: Shape) => {
     ...createGeoModel(geo),
     type: getGeoType(geo),
     mode: getDrawModeFromShape(shape),
+    color: geo.properties?.color || Object.values(locationColors)[0],
   }
 }
 
@@ -286,15 +289,12 @@ let drawingLocation: GeometryJSON | null = makeEmptyGeometry(
 
 export const OpenlayersDrawings = ({
   map,
-  selectionInterface,
+  drawingAndDisplayModels,
 }: {
   map: any
-  selectionInterface: any
+  drawingAndDisplayModels: any
 }) => {
-  const { models, filterModels, drawingModels } = useDrawingAndDisplayModels({
-    selectionInterface,
-    map,
-  })
+  const { models, filterModels, drawingModels } = drawingAndDisplayModels
 
   const [drawingModel] =
     drawingModels.length > 0 ? drawingModels.slice(-1) : [undefined]
@@ -367,7 +367,7 @@ export const OpenlayersDrawings = ({
 
   return (
     <>
-      {filterModels.map((model) => {
+      {filterModels.map((model: any) => {
         const drawMode = getDrawModeFromModel({ model })
         switch (drawMode) {
           case 'bbox':
@@ -404,7 +404,7 @@ export const OpenlayersDrawings = ({
             )
         }
       })}
-      {models.map((model) => {
+      {models.map((model: any) => {
         const drawMode = getDrawModeFromModel({ model })
         switch (drawMode) {
           case 'bbox':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -214,7 +214,7 @@ export default function (
       })
     },
     onDoubleClick() {
-      $(map.getTargetElement()).one('dblclick', (e) => {
+      $(map.getTargetElement()).on('dblclick', (e) => {
         const boundingRect = map.getTargetElement().getBoundingClientRect()
         const id = determineLocationIdFromPosition(
           [e.clientX - boundingRect.left, e.clientY - boundingRect.top],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -214,7 +214,7 @@ export default function (
       })
     },
     onDoubleClick() {
-      $(map.getTargetElement()).on('dblclick', (e) => {
+      $(map.getTargetElement()).one('dblclick', (e) => {
         const boundingRect = map.getTargetElement().getBoundingClientRect()
         const id = determineLocationIdFromPosition(
           [e.clientX - boundingRect.left, e.clientY - boundingRect.top],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/openlayers.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/openlayers.view.tsx
@@ -16,6 +16,7 @@ import React from 'react'
 import { Memo } from '../../../memo/memo'
 import { MapViewReact } from '../map.view'
 import { OpenlayersDrawings } from './drawing-and-display'
+import { useDrawingAndDisplayModels } from '../drawing-and-display'
 import $ from 'jquery'
 
 const loadOpenLayersCode = () => {
@@ -30,11 +31,11 @@ const loadOpenLayersCode = () => {
 export const OpenlayersMapViewReact = ({
   selectionInterface,
   setMap: outerSetMap,
-  includeDrawings = true,
+  drawingAndDisplayModels,
 }: {
   selectionInterface: any
   setMap?: (map: any) => void
-  includeDrawings?: boolean
+  drawingAndDisplayModels?: any
 }) => {
   const [map, setMap] = React.useState<any>(null)
   React.useEffect(() => {
@@ -42,6 +43,14 @@ export const OpenlayersMapViewReact = ({
       outerSetMap(map)
     }
   }, [map])
+
+  if (!drawingAndDisplayModels) {
+    drawingAndDisplayModels = useDrawingAndDisplayModels({
+      selectionInterface,
+      map,
+    })
+  }
+
   return (
     <>
       <Memo>
@@ -51,9 +60,10 @@ export const OpenlayersMapViewReact = ({
           setMap={setMap}
         />
       </Memo>
-      {includeDrawings && (
-        <OpenlayersDrawings selectionInterface={selectionInterface} map={map} />
-      )}
+      <OpenlayersDrawings
+        drawingAndDisplayModels={drawingAndDisplayModels}
+        map={map}
+      />
     </>
   )
 }


### PR DESCRIPTION
This will allow downstream projects to utilize the 2D map's drawing-and-display - search/selectionInterface no longer required to generate geos, can pass Locations directly to the OpenLayers Map instead.

To test this - try to break 2D map in the search area view by adding/updating various geos