### PR TITLE
Move overwrite to metacard interactions

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.tsx
@@ -13,7 +13,6 @@
  *
  **/
 import React from 'react'
-import { MetacardOverwrite } from '../../metacard-overwrite/metacard-overwrite.view'
 import MetacardActions from '../../../react-component/metacard-actions'
 import MetacardQuality from '../../../react-component/metacard-quality'
 import MetacardHistory from '../../../react-component/metacard-history'
@@ -39,7 +38,6 @@ export const TabNames = {
   History: 'History',
   Quality: 'Quality',
   Actions: 'Actions',
-  Overwrite: 'Overwrite',
 }
 
 const Tabs = {
@@ -52,11 +50,6 @@ const Tabs = {
   History: { content: MetacardHistory },
   Quality: { content: MetacardQuality },
   Actions: { content: MetacardActions },
-  Overwrite: {
-    content: ({ result }) => {
-      return <MetacardOverwrite lazyResult={result} />
-    },
-  },
 } as {
   [key: string]: TabDefinition
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
@@ -31,7 +31,6 @@ import OverflowTooltip from '../../overflow-tooltip/overflow-tooltip'
 import Tabs from '@mui/material/Tabs'
 import MaterialTab from '@mui/material/Tab'
 import MetacardTabs, { TabNames } from '../../tabs/metacard/tabs-metacard'
-import { TypedUserInstance } from '../../singletons/TypedUser'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
 import Extensions from '../../../extension-points'
 
@@ -114,23 +113,17 @@ const usePossibleMetacardTabs = ({ result }: { result: LazyQueryResult }) => {
       if (result.isRevision()) {
         delete copyOfMetacardTabs[TabNames.History]
         delete copyOfMetacardTabs[TabNames.Actions]
-        delete copyOfMetacardTabs[TabNames.Overwrite]
       }
       if (result.isDeleted()) {
         delete copyOfMetacardTabs[TabNames.History]
         delete copyOfMetacardTabs[TabNames.Actions]
-        delete copyOfMetacardTabs[TabNames.Overwrite]
       }
       if (result.isRemote()) {
         delete copyOfMetacardTabs[TabNames.History]
-        delete copyOfMetacardTabs[TabNames.Overwrite]
         delete copyOfMetacardTabs[TabNames.Quality]
       }
       if (!result.hasPreview()) {
         delete copyOfMetacardTabs[TabNames.Preview]
-      }
-      if (!TypedUserInstance.canWrite(result)) {
-        delete copyOfMetacardTabs[TabNames.Overwrite]
       }
       setPossibleMetacardTabs(copyOfMetacardTabs)
     } else {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/metacard-interactions/metacard-interactions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/metacard-interactions/metacard-interactions.tsx
@@ -15,12 +15,14 @@
 import ExpandMetacard from '../../react-component/metacard-interactions/expand-interaction'
 import DownloadProduct from '../../react-component/metacard-interactions/download-interaction'
 import ExportActions from '../../react-component/metacard-interactions/export-interaction'
+import OverwriteAction from '../../react-component/metacard-interactions/overwrite-interaction'
 import ArchiveAction from '../../react-component/metacard-interactions/archive-interaction'
 
 const DefaultItems = [
   ExpandMetacard,
   DownloadProduct,
   ExportActions,
+  OverwriteAction,
   ArchiveAction,
 ]
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/overwrite-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/overwrite-interaction.tsx
@@ -38,24 +38,22 @@ export const OverwriteAction = (props: MetacardInteractionProps) => {
 
   const dialogContext = useDialog()
   return (
-    <>
-      <MetacardInteraction
-        onClick={() => {
-          props.onClose()
-          if (props.model) {
-            dialogContext.setProps({
-              children: (
-                <MetacardOverwrite title={'Overwrite'} lazyResult={result} />
-              ),
-              open: true,
-            })
-          }
-        }}
-        icon="fa fa-files-o"
-        text={'Overwrite'}
-        help="This will overwrite the item content. To restore a previous content, you can click on 'File' in the toolbar, and then click 'Restore Archived Items'."
-      />
-    </>
+    <MetacardInteraction
+      onClick={() => {
+        props.onClose()
+        if (props.model) {
+          dialogContext.setProps({
+            children: (
+              <MetacardOverwrite title={'Overwrite'} lazyResult={result} />
+            ),
+            open: true,
+          })
+        }
+      }}
+      icon="fa fa-files-o"
+      text={'Overwrite'}
+      help="This will overwrite the item content. To restore a previous content, you can click on 'File' in the toolbar, and then click 'Restore Archived Items'."
+    />
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/overwrite-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/overwrite-interaction.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { MetacardInteractionProps } from '.'
+import { MetacardInteraction } from './metacard-interactions'
+import { hot } from 'react-hot-loader'
+import { useDialog } from '../../component/dialog'
+import { TypedUserInstance } from '../../component/singletons/TypedUser'
+import { MetacardOverwrite } from '../../component/metacard-overwrite/metacard-overwrite.view'
+
+export const OverwriteAction = (props: MetacardInteractionProps) => {
+  if (!props.model || props.model.length !== 1) {
+    return null
+  }
+
+  const result = props.model[0]
+
+  if (
+    result.isDeleted() ||
+    result.isRevision() ||
+    result.isRemote() ||
+    !TypedUserInstance.canWrite(result)
+  ) {
+    return null
+  }
+
+  const dialogContext = useDialog()
+  return (
+    <>
+      <MetacardInteraction
+        onClick={() => {
+          props.onClose()
+          if (props.model) {
+            dialogContext.setProps({
+              children: (
+                <MetacardOverwrite title={'Overwrite'} lazyResult={result} />
+              ),
+              open: true,
+            })
+          }
+        }}
+        icon="fa fa-files-o"
+        text={'Overwrite'}
+        help="This will overwrite the item content. To restore a previous content, you can click on 'File' in the toolbar, and then click 'Restore Archived Items'."
+      />
+    </>
+  )
+}
+
+export default hot(module)(OverwriteAction)


### PR DESCRIPTION
The archive/delete was moved from tabs to the interactions a few months ago too. This changes make it so that a confirmation modal pops up first, then after confirming, the user can select the file, and the modal will tell them the upload progress. 

https://github.com/codice/ddf-ui/assets/14789712/55ace1f1-e0ea-451d-b457-0c429b856fd3

