### PR TITLE
Fix click-enter-to-save-geo race condition

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -75,6 +75,22 @@ const ensurePolygonIsClosed = (polygon: any) => {
   }
 }
 
+const pickLocation = (model?: any) => {
+  const mode = getDrawModeFromModel({ model })
+  switch (mode) {
+    case 'bbox':
+      return _.pick(model.attributes, 'north', 'south', 'east', 'west')
+    case 'circle':
+      return _.pick(model.attributes, 'lat', 'lon')
+    case 'line':
+      return _.pick(model.attributes, 'line')
+    case 'poly':
+      return _.pick(model.attributes, 'polygon')
+    default:
+      return {}
+  }
+}
+
 export const CesiumDrawings = ({
   map,
   selectionInterface,
@@ -97,7 +113,7 @@ export const CesiumDrawings = ({
     (e: any) => {
       if (e.key === 'Enter') {
         e.preventDefault()
-        finishDrawing()
+        if (drawingLocation) finishDrawing()
       }
       if (e.key === 'Escape') {
         cancelDrawing()
@@ -144,22 +160,6 @@ export const CesiumDrawings = ({
     drawingModel.set({ ...drawingLocation, drawing: false })
     setIsDrawing(false)
     drawingLocation = null
-  }
-
-  const pickLocation = (model?: any) => {
-    const mode = getDrawModeFromModel({ model })
-    switch (mode) {
-      case 'bbox':
-        return _.pick(model.attributes, 'north', 'south', 'east', 'west')
-      case 'circle':
-        return _.pick(model.attributes, 'lat', 'lon')
-      case 'line':
-        return _.pick(model.attributes, 'line')
-      case 'poly':
-        return _.pick(model.attributes, 'polygon')
-      default:
-        return {}
-    }
   }
 
   const isNotBeingEdited = (model: any) =>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/drawing-and-display.tsx
@@ -270,11 +270,22 @@ export const getDrawingGeometryFromModel = (
 }
 
 export const convertToModel = (geo: GeometryJSON, shape: Shape) => {
+  // geo.properties?.color will have a value when in drawing mode,
+  // but we dont want to render the drawing's contrastingColor after saving.
+  // So, we only want to set the default if no color is already set
+  if (geo.properties?.color === contrastingColor) {
+    return {
+      ...createGeoModel(geo),
+      type: getGeoType(geo),
+      mode: getDrawModeFromShape(shape),
+    }
+  }
+
   return {
     ...createGeoModel(geo),
     type: getGeoType(geo),
     mode: getDrawModeFromShape(shape),
-    color: geo.properties?.color || Object.values(locationColors)[0],
+    color: Object.values(locationColors)[0],
   }
 }
 
@@ -309,7 +320,7 @@ export const OpenlayersDrawings = ({
     (e: any) => {
       if (e.key === 'Enter') {
         e.preventDefault()
-        finishDrawing()
+        if (drawingLocation) finishDrawing()
       }
       if (e.key === 'Escape') {
         cancelDrawing()


### PR DESCRIPTION
The cesium and openlayers maps manage their location/drawing models separately. If both maps are open, hitting "enter" would cause both maps to save their locations which would be a race condition and sometimes the map without changes would overwrite the changes drawn on the other map. Its obvious that the changes should only be applied if the  there are changes on to the drawn geo, and that is what this PR fixes. Now, if both maps are open and only one map has been edited, the changes will be applied for the edited map.

Issues we will need to address:
- If the geo was edited on both maps, the race condition will still be an issue.
- If no changes happen, the UI doesnt do anything because it cant know what changes to apply.

Another issue this fixes:
Now that downstream projects are utilizes the drawing-and-display for openlayere (specifically the set color), the convertToModel only needs to specify the "color" attribute if it is not already set