### PR TITLE
Add configuration for required export attributes

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -152,6 +152,9 @@ public class ConfigurationApplication implements SparkApplication {
 
   private Integer exportResultLimit = 1000;
 
+  private List<String> requiredExportAttributes =
+      ImmutableList.of("title", "security.classification", "security.releasability");
+
   private Set<String> exportMetacardFormatOptions = new HashSet<>();
 
   private Set<String> exportMetacardsFormatOptions = new HashSet<>();
@@ -512,6 +515,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("timeout", timeout);
     config.put("resultCount", resultCount);
     config.put("exportResultLimit", exportResultLimit);
+    config.put("requiredExportAttributes", requiredExportAttributes);
     config.put("exportMetacardFormatOptions", exportMetacardFormatOptions);
     config.put("exportMetacardsFormatOptions", exportMetacardsFormatOptions);
     config.put("typeNameMapping", typeNameMapping);
@@ -873,6 +877,14 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setExportResultLimit(Integer exportResultLimit) {
     this.exportResultLimit = exportResultLimit;
+  }
+
+  public List<String> getRequiredExportAttributes() {
+    return requiredExportAttributes;
+  }
+
+  public void setRequiredExportAttributes(List<String> requiredExportAttributes) {
+    this.requiredExportAttributes = requiredExportAttributes;
   }
 
   public Set<String> getExportMetacardFormatOptions() {

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -152,8 +152,7 @@ public class ConfigurationApplication implements SparkApplication {
 
   private Integer exportResultLimit = 1000;
 
-  private List<String> requiredExportAttributes =
-      ImmutableList.of("title", "security.classification", "security.releasability");
+  private List<String> requiredExportAttributes = Collections.emptyList();
 
   private Set<String> exportMetacardFormatOptions = new HashSet<>();
 

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -27,6 +27,12 @@
             type="Integer"
             default="1000"/>
 
+        <AD id="requiredExportAttributes"
+            name="Required Export Attributes"
+            description="Specifies the attributes that must be included in exports. These attributes will always by displayed in the inspector (summary shown) as well."
+            type="String"
+            cardinality="10000"
+            default="title,security.classification,security.releasability"/>
 
         <AD id="exportMetacardFormatOptions"
             name="Export Metacard Format Options"
@@ -240,8 +246,8 @@
             required="false"/>
 
         <AD id="summaryShow"
-            name="Summary Metacard Attributes"
-            description="List of metacard attributes to display in the summary view."
+            name="Summary Metacard Attributes (Inspector)"
+            description="List of metacard attributes to display in the summary (inspector) view by default."
             type="String"
             cardinality="10000"
             default="created,modified,thumbnail"

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -32,7 +32,7 @@
             description="Specifies the attributes that must be included in exports. These attributes will always by displayed in the inspector (summary shown) as well."
             type="String"
             cardinality="10000"
-            default="title,security.classification,security.releasability"/>
+            default=""/>
 
         <AD id="exportMetacardFormatOptions"
             name="Export Metacard Format Options"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -20,8 +20,11 @@ export const TypedUserInstance = {
     if (userchoices.length > 0) {
       return userchoices
     }
-    if (StartupDataStore.Configuration.getSummaryShow().length > 0) {
-      return StartupDataStore.Configuration.getSummaryShow()
+    const config = StartupDataStore.Configuration
+    const summary = config.getSummaryShow()
+    const required = config.getRequiredExportAttributes()
+    if (summary.length > 0 || required.length > 0) {
+      return [...new Set([...required, ...summary])]
     }
     return ['title', 'created', 'thumbnail']
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
@@ -61,6 +61,9 @@ class Configuration extends Subscribable<{ thing: 'configuration-update' }> {
   getSummaryShow = () => {
     return this.config?.summaryShow || []
   }
+  getRequiredExportAttributes = () => {
+    return this.config?.requiredExportAttributes || []
+  }
   getExportMetacardFormatOptions = () => {
     return this.config?.exportMetacardFormatOptions || []
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -112,6 +112,7 @@ export interface UIConfigType {
   basicSearchMatchType: string
   onlineGazetteer: boolean
   imageryProviders: ImageryProvider[]
+  requiredExportAttributes: string[]
   exportMetacardFormatOptions: string[]
   exportMetacardsFormatOptions: string[]
   isCacheDisabled: boolean

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
@@ -19,8 +19,11 @@ import TransferList from '../../component//tabs/metacard/transfer-list'
 import { Elevations } from '../../component//theme/theme'
 import { useDialog } from '../../component//dialog'
 import { TypedUserInstance } from '../../component/singletons/TypedUser'
+import { StartupDataStore } from '../../js/model/Startup/startup'
 
 export default ({ isExport = false }: { isExport?: boolean }) => {
+  const requiredAttributes =
+    StartupDataStore.Configuration.getRequiredExportAttributes()
   const dialogContext = useDialog()
   return (
     <Button
@@ -43,6 +46,7 @@ export default ({ isExport = false }: { isExport?: boolean }) => {
             >
               <TransferList
                 startingLeft={TypedUserInstance.getResultsAttributesSummaryShown()}
+                requiredAttributes={requiredAttributes}
                 startingRight={TypedUserInstance.getResultsAttributesPossibleSummaryShown()}
                 startingHideEmpty={user
                   .get('user')

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
@@ -59,6 +59,7 @@ const mockStartupPayload: StartupPayloadType = {
     isVersioningEnabled: true,
     isSpellcheckEnabled: true,
     attributeSuggestionList: [],
+    requiredExportAttributes: [],
     exportMetacardFormatOptions: [],
     exportMetacardsFormatOptions: [],
     summaryShow: ['name', 'age'],


### PR DESCRIPTION
Adds a new configuration for required export attributes. These attributes will always be displayed in the inspector. When managing the inspector attributes, the user will be able to change the order of attributes, but not be able to select the attribute to be moved to "hidden"

https://github.com/codice/ddf-ui/assets/14789712/de53bcd1-d974-4ef8-a362-383e758a9e9e

