### PR TITLE
Respected configured inspector attributes before adding the requird attributes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -21,12 +21,12 @@ export const TypedUserInstance = {
       .get('preferences')
       .get('inspector-summaryShown')
     if (userchoices.length > 0) {
-      return [...new Set([...required, ...userchoices])]
+      return [...new Set([...userchoices, ...required])]
     }
 
     const summary = config.getSummaryShow()
     if (summary.length > 0 || required.length > 0) {
-      return [...new Set([...required, ...summary])]
+      return [...new Set([...summary, ...required])]
     }
 
     return ['title', 'created', 'thumbnail']

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
@@ -14,10 +14,10 @@
  **/
 import * as React from 'react'
 import Button from '@mui/material/Button'
-import user from '../../component//singletons/user-instance'
-import TransferList from '../../component//tabs/metacard/transfer-list'
-import { Elevations } from '../../component//theme/theme'
-import { useDialog } from '../../component//dialog'
+import user from '../../component/singletons/user-instance'
+import TransferList from '../../component/tabs/metacard/transfer-list'
+import { Elevations } from '../../component/theme/theme'
+import { useDialog } from '../../component/dialog'
 import { TypedUserInstance } from '../../component/singletons/TypedUser'
 import { StartupDataStore } from '../../js/model/Startup/startup'
 


### PR DESCRIPTION
Previously we weren't able to sort the required attributes because they would always be at the beginning of the list. Now we take the configured attributes and append and required attributes to the end of the list.

https://github.com/codice/ddf-ui/assets/14789712/3e118c2e-6939-454c-8180-972e05448346

