### PR TITLE
Fix issues with shape drawing on initialize

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/drawing-and-display.tsx
@@ -199,7 +199,7 @@ export const useDrawingAndDisplayModels = ({
   const { listenTo, stopListening } = useBackbone()
   useListenTo(
     (wreqr as any).vent,
-    'search:linedisplay search:polydisplay search:bboxdisplay search:circledisplay search:keyworddisplay',
+    'search:linedisplay search:polydisplay search:bboxdisplay search:circledisplay search:keyworddisplay search:areadisplay',
     (model: any) => {
       setModels((currentModels) => {
         let newModels = currentModels
@@ -228,7 +228,7 @@ export const useDrawingAndDisplayModels = ({
   React.useEffect(() => {
     ;(wreqr as any).vent.trigger('search:requestlocationmodels')
   }, [])
-  const updateFilterModels = () => {
+  const updateFilterModels = React.useCallback(() => {
     for (const model of filterModels) {
       stopListening(model)
     }
@@ -270,10 +270,10 @@ export const useDrawingAndDisplayModels = ({
       (m) => !locationIds.has(m.get('locationId'))
     )
     setFilterModels(dedupedModels)
-  }
+  }, [filterTree, models])
   React.useEffect(() => {
     updateFilterModels()
-  }, [filterTree, models])
+  }, [updateFilterModels])
   useListenTo(selectionInterface, 'change:currentQuery', updateFilterModels)
   useListenTo(
     TypedUserInstance.getPreferences(),
@@ -315,14 +315,6 @@ export const useDrawingAndDisplayModels = ({
       setDrawingModels([])
     }
   }, [isDrawing])
-  React.useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      updateFilterModels()
-    }, 1000)
-    return () => {
-      window.clearTimeout(timeoutId)
-    }
-  }, [])
   const callback = React.useMemo(() => {
     return () => {
       if (map) {


### PR DESCRIPTION
 - Updates the Query model to set the correct cql / filterTree on both itself and the LazyResult object right at construction time, preventing weirdness that could arise from the slight delay we have today
 - Removes a timeout effect that would inadvertantly use old data and possible cause shapes to disappear from the map.
 - Updates the drawing / display component to useCallback