### PR TITLE
ISR-15627 increase debounce for saving preferences

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -193,7 +193,7 @@ const Theme = Backbone.Model.extend({
     },
   ],
   initialize() {
-    this.savePreferences = _debounce(this.savePreferences, 1000)
+    this.savePreferences = _debounce(this.savePreferences, 1200)
     this.handleAlertPersistence()
     this.handleResultCount()
     this.listenTo((wreqr as any).vent, 'alerts:add', this.addAlert)


### PR DESCRIPTION
Duplicate preferences can be created with the current frequency this request can execute.

To Hero:
Login to the isri-app.
Open the network tab and filter to preferences. 
<img width="2056" alt="Screenshot 2024-01-08 at 3 34 43 PM" src="https://github.com/codice/ddf-ui/assets/17283825/35c28712-e4e3-4935-9950-223e0dafcd06">
Access the time settings: https://localhost:8993/search/catalog/#/search/adhoc?global-settings=Time
Filter through changes rapidly. We're trying to verify that request will not be sent out within 1.2 seconds of one another. 
[ ] Verify that no two requests were made to the preferences endpoint within 1.2 seconds of one another. 
