### PR TITLE
Update preference syncing across windows

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/cross-window-communication.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/cross-window-communication.tsx
@@ -11,6 +11,9 @@ import wreqr from '../../js/wreqr'
 import GoldenLayout from 'golden-layout'
 import { getRootColumnContent, rootIsNotAColumn } from './stack-toolbar'
 import { unMaximize } from '../../react-component/visualization-selector/visualization-selector'
+import { v4 as uuid } from 'uuid'
+
+const windowId = uuid()
 
 /**
  *  The popin function in golden layout has issues, particularly when there is a single stack in the main window at root.
@@ -293,6 +296,7 @@ const useConsumePreferencesChange = ({
         GoldenLayoutWindowCommunicationEvents.consumePreferencesChange,
         {
           preferences: TypedUserInstance.getPreferences().toJSON(),
+          fromWindowId: windowId,
         }
       )
     }
@@ -301,8 +305,16 @@ const useConsumePreferencesChange = ({
     if (goldenLayout && isInitialized) {
       goldenLayout.eventHub.on(
         GoldenLayoutWindowCommunicationEvents.consumePreferencesChange,
-        ({ preferences }: { preferences: any }) => {
-          TypedUserInstance.sync(preferences)
+        ({
+          preferences,
+          fromWindowId,
+        }: {
+          preferences: any
+          fromWindowId: string
+        }) => {
+          if (windowId !== fromWindowId) {
+            TypedUserInstance.sync(preferences)
+          }
         }
       )
       return () => {}


### PR DESCRIPTION
 - If golden layout happened to be open during uploads, weirdness would occur as uploads would be replaced during preferences syncs.
 - This updates our consumption of preference events to be particular about ignoring events from the window emitting them.  Might be worth doing the same for other events we have in this file, if only for performance purposes.