### PR TITLE
Multi-Valued date attributes can now be properly edited

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -365,10 +365,16 @@ export const Editor = ({
             setMode(Mode.Saving)
             let transformedValues = values
             try {
-              transformedValues =
-                attrType === 'BINARY'
-                  ? values.map((subval: any) => subval.split(',')[1])
-                  : values
+                switch (attrType) {
+                    case 'BINARY':
+                        transformedValues = values.map((subval: any) => subval.split(',')[1])
+                        break;
+                    case 'DATE':
+                        transformedValues = values.map((subval: any) => moment(subval).toISOString())
+                        break;
+                    default:
+                        transformedValues = values
+                }
             } catch (err) {
               console.error(err)
             }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -40,6 +40,7 @@ import { useConfiguration } from '../../../js/model/Startup/configuration.hooks'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import Common from '../../../js/Common'
 import SummaryManageAttributes from '../../../react-component/summary-manage-attributes/summary-manage-attributes'
+import moment from 'moment-timezone'
 
 type Props = {
   result: LazyQueryResult


### PR DESCRIPTION
Unedited date attribute strings are now properly transformed to the correct ISO format before being sent to the backend.

To test:
Upload a product and edit datetime.start to add multiple dates.
After you save the metacard, try to add additional dates.
Ensure there are no errors after saving the metacard a second time.