### PR TITLE
Filter Invalid Colors In Theme Settings

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -365,16 +365,20 @@ export const Editor = ({
             setMode(Mode.Saving)
             let transformedValues = values
             try {
-                switch (attrType) {
-                    case 'BINARY':
-                        transformedValues = values.map((subval: any) => subval.split(',')[1])
-                        break;
-                    case 'DATE':
-                        transformedValues = values.map((subval: any) => moment(subval).toISOString())
-                        break;
-                    default:
-                        transformedValues = values
-                }
+              switch (attrType) {
+                case 'BINARY':
+                  transformedValues = values.map(
+                    (subval: any) => subval.split(',')[1]
+                  )
+                  break
+                case 'DATE':
+                  transformedValues = values.map((subval: any) =>
+                    moment(subval).toISOString()
+                  )
+                  break
+                default:
+                  transformedValues = values
+              }
             } catch (err) {
               console.error(err)
             }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/color-tool.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/theme-settings/color-tool.tsx
@@ -14,7 +14,9 @@ import Button from '@mui/material/Button'
 import _ from 'lodash'
 import CheckIcon from '@mui/icons-material/Check'
 import Slider from '@mui/material/Slider'
-const hues = Object.keys(colors).slice(1, 17)
+import user from '../../component/singletons/user-instance'
+import { capitalize } from '@mui/material/utils'
+
 const shades = [
   900,
   800,
@@ -31,9 +33,20 @@ const shades = [
   'A200',
   'A100',
 ]
-import user from '../../component/singletons/user-instance'
+const containsShades = (
+  color: any,
+  shades: Array<string | number>
+): boolean => {
+  return shades.every((shade) => Object.keys(color).includes(shade.toString()))
+}
+const getHues = () => {
+  const hues = Object.keys(colors).filter((hue) =>
+    containsShades(colors[hue], shades)
+  )
+  return hues.slice(1, 17)
+}
 
-import { capitalize } from '@mui/material/utils'
+const hues = getHues()
 
 /**
  * Costly to update, so let them settle on a color first


### PR DESCRIPTION
Fixes theme settings bug that caused invalid colors to be available as a custom palette option.

Before:
![Screenshot 2024-01-18 at 14 55 59](https://github.com/codice/ddf-ui/assets/12192559/be76ab62-846a-495d-a38d-989dce4d0a5e)

![Screenshot 2024-01-18 at 14 56 15](https://github.com/codice/ddf-ui/assets/12192559/23db7dd5-75be-4f23-827c-5dbbc8244279)

After:
![Screenshot 2024-01-18 at 14 56 24](https://github.com/codice/ddf-ui/assets/12192559/8f7fbbdd-a8d3-4583-9c94-befe07954972)
![Screenshot 2024-01-18 at 14 56 31](https://github.com/codice/ddf-ui/assets/12192559/17b36ac6-416e-46b8-b236-8434e37ecc98)
