### PR TITLE
Support complex geometries for cql to filter tree translation

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.ts
@@ -40,7 +40,7 @@ const mockMetacardDefinitionsObject = {
   getAttributeMap: () => mockMetacardDefinitions,
 } as any
 
-function assertPolygon(actual: any, expected: any) {
+function assertCoordinateArray(actual: any, expected: any) {
   expect(actual.length).equals(expected.length)
   actual.forEach((point: any, i: any) => {
     let expectedPoint = expected[i]
@@ -49,10 +49,10 @@ function assertPolygon(actual: any, expected: any) {
   })
 }
 
-function assertMultiPolygon(actual: any, expected: any) {
+function assertMultiCoordinateArray(actual: any, expected: any) {
   expect(actual.length).equals(expected.length)
-  actual.forEach((polygon: any, i: any) => {
-    assertPolygon(polygon, expected[i])
+  actual.forEach((shape: any, i: any) => {
+    assertCoordinateArray(shape, expected[i])
   })
 }
 
@@ -442,7 +442,7 @@ describe('CQL Utils', () => {
       const polygon = CQLUtils.arrayFromPolygonWkt(
         'POLYGON((3 50, 4 49, 4 50, 3 50))'
       )
-      assertPolygon(polygon, [
+      assertCoordinateArray(polygon, [
         [3.0, 50.0],
         [4.0, 49.0],
         [4.0, 50.0],
@@ -454,7 +454,7 @@ describe('CQL Utils', () => {
       const multipolygon = CQLUtils.arrayFromPolygonWkt(
         'MULTIPOLYGON(((3 50, 4 49, 4 50, 3 50)))'
       )
-      assertMultiPolygon(multipolygon, [
+      assertMultiCoordinateArray(multipolygon, [
         [
           [3.0, 50.0],
           [4.0, 49.0],
@@ -468,7 +468,7 @@ describe('CQL Utils', () => {
       const multipolygon = CQLUtils.arrayFromPolygonWkt(
         'MULTIPOLYGON(((3 50, 4 49, 4 50, 3 50)), ((8 55, 9 54, 9 55, 8 55)))'
       )
-      assertMultiPolygon(multipolygon, [
+      assertMultiCoordinateArray(multipolygon, [
         [
           [3.0, 50.0],
           [4.0, 49.0],
@@ -481,6 +481,74 @@ describe('CQL Utils', () => {
           [9.0, 55.0],
           [8.0, 55.0],
         ],
+      ])
+    })
+
+    it('correctly parses a LINESTRING into an array', () => {
+      const linestring = CQLUtils.arrayFromLinestringWkt(
+        'LINESTRING(3 50, 4 49, 4 50, 3 50)'
+      )
+      assertCoordinateArray(linestring, [
+        [3.0, 50.0],
+        [4.0, 49.0],
+        [4.0, 50.0],
+        [3.0, 50.0],
+      ])
+    })
+
+    it('correctly parses a MULTILINESTRING with one LINESTRING into an array', () => {
+      const multilinestring = CQLUtils.arrayFromMultilinestringWkt(
+        'MULTILINESTRING((3 50, 4 49, 4 50, 3 50))'
+      )
+      assertMultiCoordinateArray(multilinestring, [
+        [
+          [3.0, 50.0],
+          [4.0, 49.0],
+          [4.0, 50.0],
+          [3.0, 50.0],
+        ],
+      ])
+    })
+
+    it('correctly parses a MULTILINESTRING with multiple LINESTRINGs into an array', () => {
+      const multilinestring = CQLUtils.arrayFromMultilinestringWkt(
+        'MULTILINESTRING((3 50, 4 49, 4 50, 3 50), (8 55, 9 54, 9 55, 8 55))'
+      )
+      assertMultiCoordinateArray(multilinestring, [
+        [
+          [3.0, 50.0],
+          [4.0, 49.0],
+          [4.0, 50.0],
+          [3.0, 50.0],
+        ],
+        [
+          [8.0, 55.0],
+          [9.0, 54.0],
+          [9.0, 55.0],
+          [8.0, 55.0],
+        ],
+      ])
+    })
+
+    it('correctly parses a POINT into an array', () => {
+      const point = CQLUtils.arrayFromPointWkt('POINT(3 50)')
+      assertCoordinateArray(point, [[3.0, 50.0]])
+    })
+
+    it('correctly parses a MULTIPOINT with one POINT into an array', () => {
+      const multipoint = CQLUtils.arrayFromPointWkt('MULTIPOINT(3 50)')
+      assertCoordinateArray(multipoint, [[3.0, 50.0]])
+    })
+
+    it('correctly parses a MULTIPOINT with multiple POINTs into an array', () => {
+      const multipoint = CQLUtils.arrayFromPointWkt(
+        'MULTIPOINT(3 50, 4 49, 4 50, 3 50)'
+      )
+      assertCoordinateArray(multipoint, [
+        [3.0, 50.0],
+        [4.0, 49.0],
+        [4.0, 50.0],
+        [3.0, 50.0],
       ])
     })
   })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.ts
@@ -159,8 +159,11 @@ function buildIntersectOrCQL(this: any, shapes: any) {
   return locationFilter
 }
 function arrayFromPartialWkt(partialWkt: any) {
-  // remove the leading and trailing parentheses
-  let result = partialWkt.replace(/^\(/, '').replace(/\)$/, '')
+  let result = partialWkt
+  if (partialWkt.startsWith('((')) {
+    // remove the leading and trailing parentheses
+    result = partialWkt.replace(/^\(/, '').replace(/\)$/, '')
+  }
   // change parentheses to array brackets
   result = result.replace(/\(/g, '[').replace(/\)/g, ']')
   // change each space-separated coordinate pair to a two-element array
@@ -348,6 +351,29 @@ function arrayFromPolygonWkt(wkt: any) {
   }
   return []
 }
+const arrayFromLinestringWkt = (wkt: string): Array<[number, number]> => {
+  const lines = wkt.match(/\([^()]+\)/g)
+  if (lines && lines.length > 0) {
+    return arrayFromPartialWkt(lines[0])
+  }
+  return []
+}
+const arrayFromMultilinestringWkt = (
+  wkt: string
+): Array<Array<[number, number]>> => {
+  const lines = wkt.match(/\([^()]+\)/g)
+  if (lines && lines.length > 0) {
+    return lines.map((line) => arrayFromPartialWkt(line))
+  }
+  return []
+}
+const arrayFromPointWkt = (wkt: string): Array<[number, number]> => {
+  const points = wkt.match(/\([^()]+\)/g)
+  if (points && points.length > 0) {
+    return arrayFromPartialWkt(points[0])
+  }
+  return []
+}
 export default {
   sanitizeGeometryCql,
   getProperty,
@@ -361,4 +387,7 @@ export default {
   isPointRadiusFilter,
   buildIntersectCQL,
   arrayFromPolygonWkt,
+  arrayFromLinestringWkt,
+  arrayFromMultilinestringWkt,
+  arrayFromPointWkt,
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.spec.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/cql.spec.ts
@@ -177,6 +177,7 @@ const cqlMultipolygonStrings = {
                 [-5.041638, -1.100891],
                 [-0.580634, 10.295094],
               ],
+              polygonBufferWidth: '500',
               type: 'POLYGON',
             },
           },
@@ -218,6 +219,422 @@ const cqlMultipolygonStrings = {
                 [37.62219839763307, 22.095010254397405],
               ],
               type: 'POLYGON',
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+  ],
+}
+
+const cqlPointStrings = {
+  geometries: [
+    {
+      input: `(INTERSECTS("anyGeo", POINT(10 20)))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 20,
+              lon: 10,
+              type: 'POINTRADIUS',
+            },
+          },
+        ],
+        negated: false,
+        type: 'AND',
+      },
+    },
+    {
+      input: `(INTERSECTS("anyGeo", MULTIPOINT(10 20, 5 5)))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 20,
+              lon: 10,
+              type: 'POINTRADIUS',
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 5,
+              lon: 5,
+              type: 'POINTRADIUS',
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", POINT(10 20), 100, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 20,
+              lon: 10,
+              radius: '100',
+              type: 'POINTRADIUS',
+            },
+          },
+        ],
+        negated: false,
+        type: 'AND',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", MULTIPOINT(10 20), 100, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 20,
+              lon: 10,
+              radius: '100',
+              type: 'POINTRADIUS',
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", MULTIPOINT(10 20, 5 5), 100, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 20,
+              lon: 10,
+              radius: '100',
+              type: 'POINTRADIUS',
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              lat: 5,
+              lon: 5,
+              radius: '100',
+              type: 'POINTRADIUS',
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+  ],
+}
+
+const cqlLinestrings = {
+  geometries: [
+    {
+      input: `(INTERSECTS("anyGeo", LINESTRING(10 20, 30 30, 40 20)))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              line: [
+                [10, 20],
+                [30, 30],
+                [40, 20],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'AND',
+      },
+    },
+    {
+      input: `(INTERSECTS("anyGeo", MULTILINESTRING((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              line: [
+                [10, 10],
+                [20, 20],
+                [10, 40],
+              ],
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              line: [
+                [40, 40],
+                [30, 30],
+                [40, 20],
+                [30, 10],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", LINESTRING(10 20, 30 30, 40 20), 1000, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              lineWidth: '1000',
+              line: [
+                [10, 20],
+                [30, 30],
+                [40, 20],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'AND',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", MULTILINESTRING((10 10, 20 20, 10 40)), 1000, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              lineWidth: '1000',
+              line: [
+                [10, 10],
+                [20, 20],
+                [10, 40],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", MULTILINESTRING((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)), 1000, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              lineWidth: '1000',
+              line: [
+                [10, 10],
+                [20, 20],
+                [10, 40],
+              ],
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              lineWidth: '1000',
+              line: [
+                [40, 40],
+                [30, 30],
+                [40, 20],
+                [30, 10],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+  ],
+}
+
+const cqlGeometryCollections = {
+  geometries: [
+    {
+      input: `(INTERSECTS("anyGeo", GEOMETRYCOLLECTION(POINT(10 20), LINESTRING(30 30, 40 20))))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              type: 'POINTRADIUS',
+              lat: 20,
+              lon: 10,
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              line: [
+                [30, 30],
+                [40, 20],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(INTERSECTS("anyGeo", GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(10 20)), LINESTRING(30 30, 40 20))))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              type: 'POINTRADIUS',
+              lat: 20,
+              lon: 10,
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              line: [
+                [30, 30],
+                [40, 20],
+              ],
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", GEOMETRYCOLLECTION(POINT(10 20)), 1000, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'circle',
+              type: 'POINTRADIUS',
+              lat: 20,
+              lon: 10,
+              radius: '1000',
+            },
+          },
+        ],
+        negated: false,
+        type: 'OR',
+      },
+    },
+    {
+      input: `(DWITHIN("anyGeo", GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POLYGON((10 20, 15 18, 5 9, 10 20))), LINESTRING(30 30, 40 20)), 1000, meters))`,
+      output: {
+        filters: [
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'poly',
+              type: 'POLYGON',
+              polygonBufferWidth: '1000',
+              polygon: [
+                [10, 20],
+                [15, 18],
+                [5, 9],
+                [10, 20],
+              ],
+            },
+          },
+          {
+            negated: false,
+            property: 'anyGeo',
+            type: 'GEOMETRY',
+            value: {
+              mode: 'line',
+              type: 'LINE',
+              lineWidth: '1000',
+              line: [
+                [30, 30],
+                [40, 20],
+              ],
             },
           },
         ],
@@ -282,6 +699,18 @@ const cqlBooleanLogicStrings = {
 }
 
 describe('read & write parity for capabilities, as well as boolean logic', () => {
+  it('TEST GET GEO FILTERS', () => {
+    const wkt = 'GEOMETRYCOLLECTION(POINT(50 40), LINESTRING(10 20, 40 50))'
+    cql.getGeoFilters(wkt, 'anyGeo', '100')
+    expect('test-value', 'Adding bogus expectation.').to.equal('test-value')
+  })
+
+  it('TEST LINESTRING FILTERS', () => {
+    const wkt = 'LINESTRING(10 20, 40 50)'
+    cql.getGeoFilters(wkt, 'anyGeo', '100')
+    expect('test-value', 'Adding bogus expectation.').to.equal('test-value')
+  })
+
   describe('test all capabilities', () => {
     for (const type in cqlCapabilityStrings) {
       cqlCapabilityStrings[type as CapabilityCategoriesType].forEach(
@@ -695,6 +1124,7 @@ describe('read & write parity for capabilities, as well as boolean logic', () =>
       )
     })
   })
+
   describe('multipolygon cql string read test', () => {
     cqlMultipolygonStrings.geometries.forEach((capability) => {
       it(`${capability}`, () => {
@@ -706,6 +1136,63 @@ describe('read & write parity for capabilities, as well as boolean logic', () =>
             const { id, ...newFilter } = filter
             filtersArray.push(newFilter)
           }
+        })
+        const { id, ...expectedOutput } = filterBuilderClassOutput
+        expectedOutput.filters = filtersArray
+        expect(expectedOutput, 'Unexpected filter value.').to.deep.equal(
+          capability.output
+        )
+      })
+    })
+  })
+
+  describe('point and multipoint cql string read test', () => {
+    cqlPointStrings.geometries.forEach((capability) => {
+      it(`${capability}`, () => {
+        const filterBuilderClassOutput = cql.read(capability.input)
+        const filtersArray: any[] = []
+
+        filterBuilderClassOutput.filters.forEach((filter) => {
+          const { id, ...newFilter } = filter
+          filtersArray.push(newFilter)
+        })
+        const { id, ...expectedOutput } = filterBuilderClassOutput
+        expectedOutput.filters = filtersArray
+        expect(expectedOutput, 'Unexpected filter value.').to.deep.equal(
+          capability.output
+        )
+      })
+    })
+  })
+
+  describe('linestring and multilinestring cql string read test', () => {
+    cqlLinestrings.geometries.forEach((capability) => {
+      it(`${capability}`, () => {
+        const filterBuilderClassOutput = cql.read(capability.input)
+        const filtersArray: any[] = []
+
+        filterBuilderClassOutput.filters.forEach((filter) => {
+          const { id, ...newFilter } = filter
+          filtersArray.push(newFilter)
+        })
+        const { id, ...expectedOutput } = filterBuilderClassOutput
+        expectedOutput.filters = filtersArray
+        expect(expectedOutput, 'Unexpected filter value.').to.deep.equal(
+          capability.output
+        )
+      })
+    })
+  })
+
+  describe('geometry collection cql string read test', () => {
+    cqlGeometryCollections.geometries.forEach((capability) => {
+      it(`${capability}`, () => {
+        const filterBuilderClassOutput = cql.read(capability.input)
+        const filtersArray: any[] = []
+
+        filterBuilderClassOutput.filters.forEach((filter) => {
+          const { id, ...newFilter } = filter
+          filtersArray.push(newFilter)
         })
         const { id, ...expectedOutput } = filterBuilderClassOutput
         expectedOutput.filters = filtersArray


### PR DESCRIPTION
Cql to filter tree translation for spatial filters now supports all valid wkt geometries. Previously, the supported geometries were polygon, multipolygon, linestring, and point. The translation code has been improved to support the additional geometries: multilinestring, multipoint, and geometry collection.

Unit tests were added so a manual hero is probably not necessary.