### PR TITLE
fix unreadable search results when attribute is updated

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -425,6 +425,9 @@ function handleGoldenLayoutStackCreated(stack: any) {
     try {
       const renderRoot = createRoot(stack.header.controlsContainer[0])
       renderRoot.render(<StackToolbar stack={stack} />)
+      stack.on('activeContentItemChanged', function (contentItem: any) {
+        wreqr.vent.trigger('activeContentItemChanged', contentItem)
+      })
       stack.on('destroy', () => {
         renderRoot.unmount()
       })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -32,6 +32,7 @@ import useCoordinateFormat from '../../tabs/metacard/useCoordinateFormat'
 import Common from '../../../js/Common'
 import Extensions from '../../../extension-points'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import wreqr from '../../../js/wreqr'
 type ResultItemFullProps = {
   lazyResult: LazyQueryResult
   measure: () => void
@@ -85,7 +86,7 @@ const CheckboxCell = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
 }
 const RowComponent = ({
   lazyResult,
-  measure,
+  measure: originalMeasure,
   index,
   results,
   selectionInterface,
@@ -139,6 +140,14 @@ const RowComponent = ({
     )
   }, [])
   const imgsrc = Common.getImageSrc(thumbnail)
+  const measure = () => {
+    if (
+      containerRef.current?.clientHeight &&
+      containerRef.current?.clientHeight > 0
+    ) {
+      originalMeasure()
+    }
+  }
   React.useEffect(() => {
     measure()
   }, [shownAttributes, convertToFormat])
@@ -155,7 +164,9 @@ const RowComponent = ({
     }
     return value
   }
-
+  listenTo(wreqr.vent, 'activeContentItemChanged', () => {
+    measure()
+  })
   const containerRef = React.useRef<HTMLDivElement>(null)
   const ResultItemActionInstance = Extensions.resultItemAction({
     lazyResult,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -49,6 +49,7 @@ import Common from '../../../js/Common'
 import ExtensionPoints from '../../../extension-points/extension-points'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import wreqr from '../../../js/wreqr'
 const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
   return (
     <div
@@ -385,7 +386,7 @@ const fakeEvent = {
 } as any
 export const ResultItem = ({
   lazyResult,
-  measure,
+  measure: originalMeasure,
   selectionInterface,
 }: ResultItemFullProps) => {
   const MetacardDefinitions = useMetacardDefinitions()
@@ -425,9 +426,24 @@ export const ResultItem = ({
       }
     )
   }, [])
+  /**
+   * Unfocused (hidden) tab sets the container height to 0
+   * Run the measure function when the height is 0 could cause items inside the tab to be unreadable
+   */
+  const measure = () => {
+    if (
+      buttonRef.current?.clientHeight &&
+      buttonRef.current?.clientHeight > 0
+    ) {
+      originalMeasure()
+    }
+  }
   React.useEffect(() => {
     measure()
   }, [shownAttributes, convertToFormat])
+  listenTo(wreqr.vent, 'activeContentItemChanged', () => {
+    measure()
+  })
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
   const imgsrc = Common.getImageSrc(thumbnail)
   const buttonRef = React.useRef<HTMLButtonElement>(null)


### PR DESCRIPTION
**What does this PR do, and why?**
The purpose of this PR is to fix a bug. When a user updates a result attribute and clicks on the unfocused (hidden) results tab, the items in the tab become unreadable. The PR addresses the issue.

**How should this be tested?**
Use the drop a Jar method to test the PR on an MIO

In the frontend application, upload two files in the Create section in the left menu bar
Make sure Results and Inspector windows are together as tabs in one window
Go to the Search function in the left side menu bar
Search for Fast data source
Click on one of the files you uploaded, then go to Inspector
Modify releasability and click save
Go back to the Results tab
You should see the results are unreadable then they appear readable (before, the results would remain unreadable)

**PR Definition of Done**
See that results are readable when the result attribute is changed.
