### PR TITLE
Update measure function to listen for active tab changes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -425,6 +425,9 @@ function handleGoldenLayoutStackCreated(stack: any) {
     try {
       const renderRoot = createRoot(stack.header.controlsContainer[0])
       renderRoot.render(<StackToolbar stack={stack} />)
+      stack.on('activeContentItemChanged', function (contentItem: any) {
+        wreqr.vent.trigger('activeContentItemChanged', contentItem)
+      })
       stack.on('destroy', () => {
         renderRoot.unmount()
       })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -32,6 +32,8 @@ import useCoordinateFormat from '../../tabs/metacard/useCoordinateFormat'
 import Common from '../../../js/Common'
 import Extensions from '../../../extension-points'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import wreqr from '../../../js/wreqr'
+
 type ResultItemFullProps = {
   lazyResult: LazyQueryResult
   measure: () => void
@@ -85,7 +87,7 @@ const CheckboxCell = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
 }
 const RowComponent = ({
   lazyResult,
-  measure,
+  measure: originalMeasure,
   index,
   results,
   selectionInterface,
@@ -139,9 +141,21 @@ const RowComponent = ({
     )
   }, [])
   const imgsrc = Common.getImageSrc(thumbnail)
+  const measure = () => {
+    // ignore clientHeight 0 measures since those are typically when the element is hidden and not useful
+    if (
+      containerRef.current?.clientHeight &&
+      containerRef.current?.clientHeight > 0
+    ) {
+      originalMeasure()
+    }
+  }
   React.useEffect(() => {
     measure()
   }, [shownAttributes, convertToFormat])
+  listenTo(wreqr.vent, 'activeContentItemChanged', () => {
+    measure()
+  })
   const getDisplayValue = (value: any, property: string) => {
     if (value && MetacardDefinitions.getAttributeMap()[property]) {
       switch (MetacardDefinitions.getAttributeMap()[property].type) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -49,6 +49,8 @@ import Common from '../../../js/Common'
 import ExtensionPoints from '../../../extension-points/extension-points'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import wreqr from '../../../js/wreqr'
+
 const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
   return (
     <div
@@ -385,7 +387,7 @@ const fakeEvent = {
 } as any
 export const ResultItem = ({
   lazyResult,
-  measure,
+  measure: originalMeasure,
   selectionInterface,
 }: ResultItemFullProps) => {
   const MetacardDefinitions = useMetacardDefinitions()
@@ -425,9 +427,21 @@ export const ResultItem = ({
       }
     )
   }, [])
+  const measure = () => {
+    // ignore clientHeight 0 measures since those are typically when the element is hidden and not useful
+    if (
+      buttonRef.current?.clientHeight &&
+      buttonRef.current?.clientHeight > 0
+    ) {
+      originalMeasure()
+    }
+  }
   React.useEffect(() => {
     measure()
   }, [shownAttributes, convertToFormat])
+  listenTo(wreqr.vent, 'activeContentItemChanged', () => {
+    measure()
+  })
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
   const imgsrc = Common.getImageSrc(thumbnail)
   const buttonRef = React.useRef<HTMLButtonElement>(null)


### PR DESCRIPTION
 - Update the virtual result lists to respond to active tab changes and to ignore events when the measure would be 0.
 - This fixes an issue where when the tab with a virtual list is currently hidden experiences an attribute update, the next time the user shows that tab it would have the wrong measurements (0) and be unreadable.