### PR TITLE
Fix timeline for empty data values

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
@@ -163,9 +163,11 @@ const TimelineVisualization = (props: Props) => {
       } = {}
       possibleDateAttributes.forEach((dateAttribute: string) => {
         const val = metacard[dateAttribute]
-        resultDateAttributes[dateAttribute] = Array.isArray(val)
-          ? val.map((v) => moment(v) as Moment)
-          : [moment(val) as Moment]
+        if (val) {
+          resultDateAttributes[dateAttribute] = Array.isArray(val)
+            ? val.map((v) => moment(v) as Moment)
+            : [moment(val) as Moment]
+        }
       })
       const id = metacard.id
       const resultDataPoint: TimelineItem = {


### PR DESCRIPTION
Fixes an issue with the timeline display when results do not have the selected date attribute populated. 


https://github.com/codice/ddf-ui/assets/8962302/7f66f6d6-db8a-4221-8af5-ea68f9fb63af

