### PR TITLE
Fix "+X other results" count in timeline hover

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/timeline/timeline.tsx
@@ -90,9 +90,9 @@ const renderTooltip = (timelineItems: TimelineItem[]) => {
   })
 
   let OtherItemsAddOn = null
-  if (timelineItems.length > itemsToExpand) {
+  if (uniqueMetacards.length > itemsToExpand) {
     OtherItemsAddOn = Extensions.timelineItemAddOn({
-      results: timelineItems
+      results: uniqueMetacards
         .slice(itemsToExpand)
         .map((item) => item.data as LazyQueryResult),
       isSingleItem: false,
@@ -102,7 +102,7 @@ const renderTooltip = (timelineItems: TimelineItem[]) => {
   const otherResults = (
     <React.Fragment>
       <br />
-      {`+${timelineItems.length - itemsToExpand} other results`}
+      {`+${uniqueMetacards.length - itemsToExpand} other results`}
       {OtherItemsAddOn && (
         <>
           &nbsp;
@@ -114,7 +114,7 @@ const renderTooltip = (timelineItems: TimelineItem[]) => {
   return (
     <React.Fragment>
       {results}
-      {timelineItems.length > itemsToExpand && otherResults}
+      {uniqueMetacards.length > itemsToExpand && otherResults}
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Fix the `+X other results` counter in the timeline visual to be accurate in the case of multi valued date attributes. This number represents the number of additional metacard results and does not indicate the number of total date values.

https://github.com/codice/ddf-ui/assets/8962302/23ead43c-f96f-4e05-9500-5b5e61be475f

Testing:
1. Upload more than 5 files
2. Populate at least one value for `datetime.start` on each metacard
3. Open the timeline visual, select `datetime.start`, and verify the tooltip shows the correct number of "other results". For example, if you have 8 total metacards with non-empty `datetime.start`, you should see `+3 other results`

