### PR TITLE
Update layer component save calls to use the custom savePreferences rather than the backbone default

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layers/layers.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/layers/layers.view.tsx
@@ -69,7 +69,7 @@ const LayersViewReact = () => {
   const containerElementRef = React.useRef<HTMLDivElement>(null)
   const saveCallback = React.useMemo(() => {
     return debounce(() => {
-      user.get('user>preferences').save()
+      user.get('user>preferences').savePreferences()
     }, 100)
   }, [])
   useListenTo(
@@ -97,7 +97,7 @@ const LayersViewReact = () => {
               }
             )
             user.get('user>preferences').get('mapLayers').sort()
-            // user.get('user>preferences').save()
+            user.get('user>preferences').savePreferences()
           }}
           focusModel={focusModel}
         />
@@ -119,7 +119,7 @@ const LayersViewReact = () => {
                 viewLayer.set(defaultConfig)
               })
             user.get('user>preferences').get('mapLayers').sort()
-            user.get('user>preferences').save()
+            user.get('user>preferences').savePreferences()
           }}
         >
           <span>Reset to Defaults</span>


### PR DESCRIPTION
 - Our custom savePreferences passes certain options like withoutSet that were not being used since this component used the backbone default save instead.  This led to issues with flickering if the user changed layer settings too quickly.
 - Updated the ordering callback to call savePreferences, as previously this wasn't being done.  As a result, if the user only reordered layers and didn't adjust the alpha or show, the reorder wouldn't be saved.