### PR TITLE
Fix geo attribute editor

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/location-new.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/location-new/location-new.view.tsx
@@ -22,21 +22,26 @@ import LocationNewModel from './location-new'
 type LocationInputReactPropsType = {
   value: string
   onChange: (val: string) => void
+  isStateDirty?: boolean
+  resetIsStateDirty?: () => void
 }
 
 export const LocationInputReact = ({
   value,
   onChange,
+  isStateDirty = false,
+  resetIsStateDirty = () => {},
 }: LocationInputReactPropsType) => {
   const [state, setState] = React.useState<LocationInputPropsType>(
     new LocationNewModel({ wkt: value, mode: 'wkt' }).toJSON()
   )
 
   React.useEffect(() => {
-    if (value && value !== state.wkt && value !== 'INVALID') {
-      setState(new LocationNewModel({ wkt: value, mode: 'wkt' }).toJSON())
+    if (isStateDirty) {
+      setState(new LocationNewModel({ wkt: value, mode: state.mode }).toJSON())
+      resetIsStateDirty()
     }
-  }, [value])
+  }, [isStateDirty])
 
   React.useEffect(() => {
     if (state.valid) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -168,6 +168,7 @@ export const Editor = ({
       ? lazyResult.plain.metacard.properties[attr].slice(0)
       : [lazyResult.plain.metacard.properties[attr]]
   )
+  const [dirtyIndex, setDirtyIndex] = React.useState(-1)
   const { getAlias, isMulti, getType, getEnum } = useMetacardDefinitions()
   const label = getAlias(attr)
   const isMultiValued = isMulti(attr)
@@ -287,6 +288,8 @@ export const Editor = ({
                             values[index] = location
                             setValues([...values])
                           }}
+                          isStateDirty={dirtyIndex === index}
+                          resetIsStateDirty={() => setDirtyIndex(-1)}
                           value={val}
                         />
                       )
@@ -314,6 +317,7 @@ export const Editor = ({
                     disabled={mode === Mode.Saving}
                     onClick={() => {
                       values.splice(index, 1)
+                      setDirtyIndex(index)
                       setValues([...values])
                     }}
                   >
@@ -382,6 +386,11 @@ export const Editor = ({
                 case 'DATE':
                   transformedValues = transformedValues.map((subval: any) =>
                     moment(subval).toISOString()
+                  )
+                  break
+                case 'GEOMETRY':
+                  transformedValues = values.filter(
+                    (val: any) => val != null && val !== ''
                   )
                   break
               }


### PR DESCRIPTION
* Fixes an issue where input validation was preventing any geo format other than WKT to be entered in the location editor

Testing:
1. Verify for both single and multi valued geo attributes that you can edit locations using different formats. 
2. For multi valued attributes, verify that deleting individual values works as expected.

https://github.com/codice/ddf-ui/assets/8962302/a2e17b0a-26b6-45d1-abff-2adec3e4b6ff