### PR TITLE
Add Extension Point for Additional Sidebar Buttons

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
@@ -627,9 +627,11 @@ const SideBar = () => {
           <SideBarBackground />
           <Divider />
           <Grid item className="mt-auto overflow-hidden w-full shrink-0 grow-0">
+            {Extensions.extraSidebarButtons && (
+              <Extensions.extraSidebarButtons />
+            )}
             <HelpButton />
             <SettingsButton />
-
             <NotificationsButton />
             <UserButton />
           </Grid>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -120,6 +120,7 @@ export type ExtensionPointsType = {
     results: LazyQueryResult[]
     isSingleItem: boolean
   }) => JSX.Element | null
+  extraSidebarButtons?: PermissiveComponentType
 }
 
 const ExtensionPoints: ExtensionPointsType = {
@@ -151,6 +152,7 @@ const ExtensionPoints: ExtensionPointsType = {
   attributeEditor: () => null,
   customHistogramHover: undefined,
   timelineItemAddOn: () => null,
+  extraSidebarButtons: () => null,
 }
 
 export default ExtensionPoints


### PR DESCRIPTION
This PR adds the options for downstream projects to include additional buttons (not routes) in the lower half of the sidebar (pictured below).

![Screenshot 2024-04-12 at 08 48 43](https://github.com/codice/ddf-ui/assets/12192559/03d46ec6-1cd8-4d2b-9439-0f1e40c5016d)
