### PR TITLE
Update to DDF 2.26.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <errorprone.version>2.2.0</errorprone.version>
 
     <!--Backend properties-->
-    <ddf.version>2.26.37</ddf.version>
+    <ddf.version>2.26.38</ddf.version>
     <ddf-jsonrpc.version>0.6</ddf-jsonrpc.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <antlr.version>4.3</antlr.version>


### PR DESCRIPTION
Update from DDF 2.26.37 -> 38 pulls in the following change:
[[2.26.x] Ensure SortedQueryMonitor uses query ThreadContext (](https://github.com/codice/ddf/commit/e275dbbc94e427adf83946ce69b4a1e219c6a254)https://github.com/codice/ddf/pull/6784[)](https://github.com/codice/ddf/commit/e275dbbc94e427adf83946ce69b4a1e219c6a254)
