### PR TITLE
Adds a new component to make type searching more ergonomic for users

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/compose/ComposeApplication.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/compose/ComposeApplication.java
@@ -174,6 +174,13 @@ public class ComposeApplication implements SparkApplication {
     anyDate.put("multivalued", false);
     anyDate.put("hidden", true);
 
+    Map<String, Object> reservedBasicDatatype = new HashMap<>();
+    reservedBasicDatatype.put("id", "reserved.basic-datatype");
+    reservedBasicDatatype.put("type", "STRING");
+    reservedBasicDatatype.put("multivalued", false);
+    reservedBasicDatatype.put("hidden", true);
+    reservedBasicDatatype.put("alias", "Types");
+
     Map<String, Object> metacardType = new HashMap<>();
     metacardType.put("id", "metacard-type");
     metacardType.put("type", "STRING");
@@ -199,6 +206,7 @@ public class ComposeApplication implements SparkApplication {
     attributeMap.put("anyText", anyText);
     attributeMap.put("anyGeo", anyGeo);
     attributeMap.put("anyDate", anyDate);
+    attributeMap.put("reserved.basic-datatype", reservedBasicDatatype);
     attributeMap.put("metacard-type", metacardType);
     attributeMap.put("source-id", sourceId);
     attributeMap.put("cached", cached);

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/datatypes/datatypes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/datatypes/datatypes.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+export interface FontAwesomeIconConfig {
+  // FontAwesome classes, e.g., 'fa fa-file-text'
+  class: string
+}
+
+export interface ValueInformation {
+  attributes: {
+    [key: string]: string[] // the values to use when filtering on this attribute
+  }
+  // Optional in case some data types might not have an associated icon, eg
+  iconConfig?: FontAwesomeIconConfig
+}
+
+export interface DataTypesConfiguration {
+  groups: {
+    [key: string]: {
+      values: {
+        [key: string]: ValueInformation
+      }
+      iconConfig?: FontAwesomeIconConfig
+    }
+  }
+}
+
+// this is a structure to make it easier to go from value to group, which we'll make by transforming the DataTypesConfiguration
+export interface ReverseDataTypesConfiguration {
+  [key: string]: {
+    group: {
+      name: string
+      iconConfig?: FontAwesomeIconConfig
+    }
+  } & ValueInformation
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/reserved.properties.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/reserved.properties.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+// keep this file import free to avoid circular dependencies
+
+export const BasicDataTypePropertyName = 'reserved.basic-datatype'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.spec.tsx
@@ -1,0 +1,548 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { expect } from 'chai'
+import {
+  constructFilterFromBasicFilter,
+  translateFilterToBasicMap,
+} from './query-basic.view'
+import {
+  FilterBuilderClass,
+  FilterClass,
+} from '../filter-builder/filter.structure'
+import { StartupDataStore } from '../../js/model/Startup/startup'
+
+// function to remove any key with id from an arbitrarily nested object
+function removeId(obj: any) {
+  if (obj && typeof obj === 'object') {
+    Object.keys(obj).forEach((key) => {
+      if (key === 'id') {
+        delete obj[key]
+      } else {
+        removeId(obj[key])
+      }
+    })
+  }
+  return obj
+}
+
+function removeCustomClasses(obj: any) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+describe('verify going back and forth from filter to state in query basic is not lossy or "wrong"', () => {
+  it('handles just keyword ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    expect(
+      removeCustomClasses(
+        removeId(
+          constructFilterFromBasicFilter({
+            basicFilter:
+              translateFilterToBasicMap(startingFilter).propertyValueMap,
+          })
+        )
+      )
+    ).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+
+  it('handles just time ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+        created: {
+          type: 'DATE',
+          id: 'created',
+          multivalued: false,
+          isInjected: false,
+        },
+        effective: {
+          type: 'DATE',
+          id: 'effective',
+          multivalued: false,
+          isInjected: false,
+        },
+        modified: {
+          type: 'DATE',
+          id: 'modified',
+          multivalued: false,
+          isInjected: false,
+        },
+        'metacard.created': {
+          type: 'DATE',
+          id: 'metacard.created',
+          multivalued: false,
+          isInjected: false,
+        },
+        'metacard.modified': {
+          type: 'DATE',
+          id: 'metacard.modified',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+        }),
+        new FilterBuilderClass({
+          type: 'OR',
+          filters: [
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'created',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'effective',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'modified',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'metacard.created',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'metacard.modified',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+          ],
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    expect(
+      removeCustomClasses(
+        removeId(
+          constructFilterFromBasicFilter({
+            basicFilter:
+              translateFilterToBasicMap(startingFilter).propertyValueMap,
+          })
+        )
+      )
+    ).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+
+  it('handles just location ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+        anyGeo: {
+          type: 'LOCATION',
+          id: 'anyGeo',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+          id: '0.04416459837101705',
+        }),
+        new FilterClass({
+          type: 'GEOMETRY',
+          property: 'anyGeo',
+          value: {
+            // @ts-ignore
+            locationId: 1713480576078,
+            color: '#8E79DD',
+            drawing: false,
+            dmsNorthDirection: 'N',
+            dmsSouthDirection: 'N',
+            dmsEastDirection: 'E',
+            dmsWestDirection: 'E',
+            radiusUnits: 'meters',
+            radius: 955.1713897900735,
+            locationType: 'dd',
+            prevLocationType: 'dd',
+            lat: 44.352567,
+            lon: -108.13405,
+            dmsLat: '44°21\'09.241"',
+            dmsLon: '108°08\'02.58"',
+            dmsLatDirection: 'N',
+            dmsLonDirection: 'W',
+            usng: '12T YQ 28412 15028',
+            lineWidth: '',
+            lineUnits: 'meters',
+            polygonBufferWidth: '',
+            polygonBufferUnits: 'meters',
+            hasKeyword: false,
+            utmUpsUpperLeftHemisphere: 'Northern',
+            utmUpsUpperLeftZone: 1,
+            utmUpsLowerRightHemisphere: 'Northern',
+            utmUpsLowerRightZone: 1,
+            utmUpsEasting: 728412.2560937542,
+            utmUpsNorthing: 4915028.120213763,
+            utmUpsZone: 12,
+            utmUpsHemisphere: 'Northern',
+            mode: 'circle',
+            type: 'POINTRADIUS',
+          },
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    expect(
+      removeCustomClasses(
+        removeId(
+          constructFilterFromBasicFilter({
+            basicFilter:
+              translateFilterToBasicMap(startingFilter).propertyValueMap,
+          })
+        )
+      )
+    ).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+
+  it('handles just types but when blank ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+        'reserved.basic-datatype': {
+          type: 'STRING',
+          id: 'reserved.basic-datatype',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+        }),
+        new FilterClass({
+          type: 'ILIKE',
+          property: 'reserved.basic-datatype',
+          value: [],
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    expect(
+      removeCustomClasses(
+        removeId(
+          constructFilterFromBasicFilter({
+            basicFilter:
+              translateFilterToBasicMap(startingFilter).propertyValueMap,
+          })
+        )
+      )
+    ).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+
+  it('handles just types when types are filled out ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+        'reserved.basic-datatype': {
+          type: 'STRING',
+          id: 'reserved.basic-datatype',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+        }),
+        new FilterClass({
+          type: 'ILIKE',
+          property: 'reserved.basic-datatype',
+          value: ['Equipment'],
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    expect(
+      removeCustomClasses(
+        removeId(
+          constructFilterFromBasicFilter({
+            basicFilter:
+              translateFilterToBasicMap(startingFilter).propertyValueMap,
+          })
+        )
+      )
+    ).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+
+  it('handles just types when everything is filled out ', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap = {
+        anyText: {
+          type: 'STRING',
+          id: 'anyText',
+          multivalued: false,
+          isInjected: false,
+        },
+        anyGeo: {
+          type: 'LOCATION',
+          id: 'anyGeo',
+          multivalued: false,
+          isInjected: false,
+        },
+        created: {
+          type: 'DATE',
+          id: 'created',
+          multivalued: false,
+          isInjected: false,
+        },
+        effective: {
+          type: 'DATE',
+          id: 'effective',
+          multivalued: false,
+          isInjected: false,
+        },
+        modified: {
+          type: 'DATE',
+          id: 'modified',
+          multivalued: false,
+          isInjected: false,
+        },
+        'metacard.created': {
+          type: 'DATE',
+          id: 'metacard.created',
+          multivalued: false,
+          isInjected: false,
+        },
+        'metacard.modified': {
+          type: 'DATE',
+          id: 'metacard.modified',
+          multivalued: false,
+          isInjected: false,
+        },
+        'reserved.basic-datatype': {
+          type: 'STRING',
+          id: 'reserved.basic-datatype',
+          multivalued: false,
+          isInjected: false,
+        },
+      }
+    }
+    const startingFilter = new FilterBuilderClass({
+      type: 'AND',
+      filters: [
+        new FilterClass({
+          type: 'BOOLEAN_TEXT_SEARCH',
+          property: 'anyText',
+          value: {
+            text: 't',
+            cql: "(anyText ILIKE 't')",
+            error: false,
+          },
+          negated: false,
+        }),
+        new FilterBuilderClass({
+          type: 'OR',
+          filters: [
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'created',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'effective',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'modified',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'metacard.created',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+            new FilterClass({
+              type: 'BEFORE',
+              property: 'metacard.modified',
+              value: '2024-04-18T22:39:05.946Z',
+              negated: false,
+            }),
+          ],
+          negated: false,
+        }),
+        new FilterClass({
+          type: 'GEOMETRY',
+          property: 'anyGeo',
+          value: {
+            // @ts-ignore
+            locationId: 1713480576078,
+            color: '#8E79DD',
+            drawing: false,
+            dmsNorthDirection: 'N',
+            dmsSouthDirection: 'N',
+            dmsEastDirection: 'E',
+            dmsWestDirection: 'E',
+            radiusUnits: 'meters',
+            radius: 955.1713897900735,
+            locationType: 'dd',
+            prevLocationType: 'dd',
+            lat: 44.352567,
+            lon: -108.13405,
+            dmsLat: '44°21\'09.241"',
+            dmsLon: '108°08\'02.58"',
+            dmsLatDirection: 'N',
+            dmsLonDirection: 'W',
+            usng: '12T YQ 28412 15028',
+            lineWidth: '',
+            lineUnits: 'meters',
+            polygonBufferWidth: '',
+            polygonBufferUnits: 'meters',
+            hasKeyword: false,
+            utmUpsUpperLeftHemisphere: 'Northern',
+            utmUpsUpperLeftZone: 1,
+            utmUpsLowerRightHemisphere: 'Northern',
+            utmUpsLowerRightZone: 1,
+            utmUpsEasting: 728412.2560937542,
+            utmUpsNorthing: 4915028.120213763,
+            utmUpsZone: 12,
+            utmUpsHemisphere: 'Northern',
+            mode: 'circle',
+            type: 'POINTRADIUS',
+          },
+          negated: false,
+        }),
+        new FilterClass({
+          type: 'ILIKE',
+          property: 'reserved.basic-datatype',
+          value: ['Equipment'],
+          negated: false,
+        }),
+      ],
+      negated: false,
+    })
+
+    const result = removeCustomClasses(
+      removeId(
+        constructFilterFromBasicFilter({
+          basicFilter:
+            translateFilterToBasicMap(startingFilter).propertyValueMap,
+        })
+      )
+    )
+
+    expect(result).to.deep.equal(removeCustomClasses(removeId(startingFilter)))
+  })
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.tsx
@@ -17,8 +17,6 @@ import * as React from 'react'
 import TextField from '@mui/material/TextField'
 import MenuItem from '@mui/material/MenuItem'
 import { hot } from 'react-hot-loader'
-import { FilterClass } from '../filter-builder/filter.structure'
-import { Omit } from '../../typescript'
 import Autocomplete from '@mui/material/Autocomplete'
 import Chip from '@mui/material/Chip'
 import Grid from '@mui/material/Grid'
@@ -27,9 +25,7 @@ import FilterInput from '../../react-component/filter/filter-input'
 import Checkbox from '@mui/material/Checkbox'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import { StartupDataStore } from '../../js/model/Startup/startup'
-export interface BasicFilterClass extends Omit<FilterClass, 'property'> {
-  property: string[]
-}
+import { BasicFilterClass } from '../filter-builder/filter.structure'
 
 type QueryTimeProps = {
   value: undefined | BasicFilterClass

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.spec.tsx
@@ -1,0 +1,554 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { expect } from 'chai'
+import { DataTypesConfiguration } from '../datatypes/datatypes'
+import { StartupDataStore } from '../../js/model/Startup/startup'
+import {
+  generateGroupsToValues,
+  generateKnownGroups,
+  generateSortedValues,
+  getDataTypesConfiguration,
+} from './reserved.basic-datatype'
+
+const DatatypesJSONConfig = {
+  groups: {
+    Object: {
+      iconConfig: {
+        class: 'fa fa-file-text-o',
+      },
+      values: {
+        Person: {
+          attributes: {
+            description: ['person'],
+          },
+          iconConfig: {
+            class: 'fa fa-user',
+          },
+        },
+        Group: {
+          attributes: {
+            description: ['group'],
+          },
+          iconConfig: {
+            class: 'fa fa-users',
+          },
+        },
+        Equipment: {
+          attributes: {
+            description: ['equipment'],
+          },
+          iconConfig: {
+            class: 'fa fa-wrench',
+          },
+        },
+        Platform: {
+          attributes: {
+            description: ['platform'],
+          },
+          iconConfig: {
+            class: 'fa fa-industry',
+          },
+        },
+        Facility: {
+          attributes: {
+            description: ['facility'],
+          },
+          iconConfig: {
+            class: 'fa fa-building',
+          },
+        },
+      },
+    },
+    Happenings: {
+      iconConfig: {
+        class: 'fa fa-bolt',
+      },
+      values: {
+        Civil: {
+          attributes: {
+            description: ['civil'],
+          },
+          iconConfig: {
+            class: 'fa fa-university',
+          },
+        },
+        Military: {
+          attributes: {
+            description: ['military'],
+          },
+          iconConfig: {
+            class: 'fa fa-shield',
+          },
+        },
+        Political: {
+          attributes: {
+            description: ['political'],
+          },
+          iconConfig: {
+            class: 'fa fa-balance-scale',
+          },
+        },
+        Natural: {
+          attributes: {
+            description: ['natural'],
+          },
+          iconConfig: {
+            class: 'fa fa-leaf',
+          },
+        },
+        Other: {
+          attributes: {
+            description: ['other'],
+          },
+        },
+      },
+    },
+    'Visual Media': {
+      iconConfig: {
+        class: 'fa fa-camera-retro',
+      },
+      values: {
+        Image: {
+          attributes: {
+            datatype: ['Image'],
+          },
+          iconConfig: {
+            class: 'fa fa-picture-o',
+          },
+        },
+        'Moving Image': {
+          attributes: {
+            datatype: ['Moving Image'],
+          },
+          iconConfig: {
+            class: 'fa fa-film',
+          },
+        },
+        'Still Image': {
+          attributes: {
+            datatype: ['Still Image'],
+          },
+          iconConfig: {
+            class: 'fa fa-camera-retro',
+          },
+        },
+      },
+    },
+  },
+} as DataTypesConfiguration
+
+describe('Reserved Basic Datatype', () => {
+  it('should use defaults when extra json is not defined', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap['datatype'] = {
+        id: 'datatype',
+        multivalued: false,
+        type: 'STRING',
+        enumerations: ['Image'],
+        isInjected: true,
+      }
+    }
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {}
+    }
+
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    expect(resolvedConfiguration.groupMap).to.deep.equal({
+      groups: {
+        Other: {
+          values: {
+            Image: {
+              attributes: {
+                datatype: ['Image'],
+                'metadata-content-type': ['Image'],
+              },
+              iconConfig: {
+                class: undefined,
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+  it('should use defaults when extra json is not defined p2', () => {
+    if (StartupDataStore.MetacardDefinitions.attributeMap) {
+      StartupDataStore.MetacardDefinitions.attributeMap['datatype'] = {
+        id: 'datatype',
+        multivalued: false,
+        type: 'STRING',
+        enumerations: ['Image', 'Moving Image'],
+        isInjected: true,
+      }
+    }
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {}
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    expect(resolvedConfiguration.groupMap).to.deep.equal({
+      groups: {
+        Other: {
+          values: {
+            Image: {
+              attributes: {
+                datatype: ['Image'],
+                'metadata-content-type': ['Image'],
+              },
+              iconConfig: {
+                class: undefined,
+              },
+            },
+            'Moving Image': {
+              attributes: {
+                datatype: ['Moving Image'],
+                'metadata-content-type': ['Moving Image'],
+              },
+              iconConfig: {
+                class: undefined,
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+  it('should use extra json when defined', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {
+        datatypes: DatatypesJSONConfig,
+      }
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    expect(resolvedConfiguration.groupMap).to.deep.equal(DatatypesJSONConfig)
+  })
+  it('should generate a proper value mapping', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {
+        datatypes: DatatypesJSONConfig,
+      }
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    expect(resolvedConfiguration.valueMap).to.deep.equal({
+      Person: {
+        group: {
+          name: 'Object',
+          iconConfig: {
+            class: 'fa fa-file-text-o',
+          },
+        },
+        attributes: {
+          description: ['person'],
+        },
+        iconConfig: {
+          class: 'fa fa-user',
+        },
+      },
+      Group: {
+        group: {
+          name: 'Object',
+          iconConfig: {
+            class: 'fa fa-file-text-o',
+          },
+        },
+        attributes: {
+          description: ['group'],
+        },
+        iconConfig: {
+          class: 'fa fa-users',
+        },
+      },
+      Equipment: {
+        group: {
+          name: 'Object',
+          iconConfig: {
+            class: 'fa fa-file-text-o',
+          },
+        },
+        attributes: {
+          description: ['equipment'],
+        },
+        iconConfig: {
+          class: 'fa fa-wrench',
+        },
+      },
+      Platform: {
+        group: {
+          name: 'Object',
+          iconConfig: {
+            class: 'fa fa-file-text-o',
+          },
+        },
+        attributes: {
+          description: ['platform'],
+        },
+        iconConfig: {
+          class: 'fa fa-industry',
+        },
+      },
+      Facility: {
+        group: {
+          name: 'Object',
+          iconConfig: {
+            class: 'fa fa-file-text-o',
+          },
+        },
+        attributes: {
+          description: ['facility'],
+        },
+        iconConfig: {
+          class: 'fa fa-building',
+        },
+      },
+      Civil: {
+        group: {
+          name: 'Happenings',
+          iconConfig: {
+            class: 'fa fa-bolt',
+          },
+        },
+        attributes: {
+          description: ['civil'],
+        },
+        iconConfig: {
+          class: 'fa fa-university',
+        },
+      },
+      Military: {
+        group: {
+          name: 'Happenings',
+          iconConfig: {
+            class: 'fa fa-bolt',
+          },
+        },
+        attributes: {
+          description: ['military'],
+        },
+        iconConfig: {
+          class: 'fa fa-shield',
+        },
+      },
+      Political: {
+        group: {
+          name: 'Happenings',
+          iconConfig: {
+            class: 'fa fa-bolt',
+          },
+        },
+        attributes: {
+          description: ['political'],
+        },
+        iconConfig: {
+          class: 'fa fa-balance-scale',
+        },
+      },
+      Natural: {
+        group: {
+          name: 'Happenings',
+          iconConfig: {
+            class: 'fa fa-bolt',
+          },
+        },
+        attributes: {
+          description: ['natural'],
+        },
+        iconConfig: {
+          class: 'fa fa-leaf',
+        },
+      },
+      Other: {
+        group: {
+          name: 'Happenings',
+          iconConfig: {
+            class: 'fa fa-bolt',
+          },
+        },
+        attributes: {
+          description: ['other'],
+        },
+      },
+      Image: {
+        group: {
+          name: 'Visual Media',
+          iconConfig: {
+            class: 'fa fa-camera-retro',
+          },
+        },
+        attributes: {
+          datatype: ['Image'],
+        },
+        iconConfig: {
+          class: 'fa fa-picture-o',
+        },
+      },
+      'Moving Image': {
+        group: {
+          name: 'Visual Media',
+          iconConfig: {
+            class: 'fa fa-camera-retro',
+          },
+        },
+        attributes: {
+          datatype: ['Moving Image'],
+        },
+        iconConfig: {
+          class: 'fa fa-film',
+        },
+      },
+      'Still Image': {
+        group: {
+          name: 'Visual Media',
+          iconConfig: {
+            class: 'fa fa-camera-retro',
+          },
+        },
+        attributes: {
+          datatype: ['Still Image'],
+        },
+        iconConfig: {
+          class: 'fa fa-camera-retro',
+        },
+      },
+    })
+  })
+
+  it('should sort values appropriately, according to the key order in the json config, and alphabetically otherwise', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {
+        datatypes: DatatypesJSONConfig,
+      }
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    const sortedValues = generateSortedValues({
+      dataTypesConfiguration: resolvedConfiguration,
+    })
+    expect(sortedValues).to.deep.equal([
+      {
+        label: 'Object',
+        value: 'Object',
+      },
+      {
+        label: 'Equipment',
+        value: 'Equipment',
+      },
+      {
+        label: 'Facility',
+        value: 'Facility',
+      },
+      {
+        label: 'Group',
+        value: 'Group',
+      },
+      {
+        label: 'Person',
+        value: 'Person',
+      },
+      {
+        label: 'Platform',
+        value: 'Platform',
+      },
+      {
+        label: 'Happenings',
+        value: 'Happenings',
+      },
+      {
+        label: 'Civil',
+        value: 'Civil',
+      },
+      {
+        label: 'Military',
+        value: 'Military',
+      },
+      {
+        label: 'Natural',
+        value: 'Natural',
+      },
+      {
+        label: 'Other',
+        value: 'Other',
+      },
+      {
+        label: 'Political',
+        value: 'Political',
+      },
+      {
+        label: 'Visual Media',
+        value: 'Visual Media',
+      },
+      {
+        label: 'Image',
+        value: 'Image',
+      },
+      {
+        label: 'Moving Image',
+        value: 'Moving Image',
+      },
+      {
+        label: 'Still Image',
+        value: 'Still Image',
+      },
+    ])
+  })
+
+  it('should use generate groups to values appropriately', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {
+        datatypes: DatatypesJSONConfig,
+      }
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    const groupsToValues = generateGroupsToValues({
+      dataTypesConfiguration: resolvedConfiguration,
+    })
+    expect(groupsToValues).to.deep.equal({
+      Object: ['Person', 'Group', 'Equipment', 'Platform', 'Facility'],
+      Happenings: ['Civil', 'Military', 'Political', 'Natural', 'Other'],
+      'Visual Media': ['Image', 'Moving Image', 'Still Image'],
+    })
+  })
+
+  it('should use generate known groups appropriately', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.extra = {
+        datatypes: DatatypesJSONConfig,
+      }
+    }
+    const resolvedConfiguration = getDataTypesConfiguration({
+      Configuration: StartupDataStore.Configuration,
+      MetacardDefinitions: StartupDataStore.MetacardDefinitions,
+    })
+    const knownGroups = generateKnownGroups({
+      dataTypesConfiguration: resolvedConfiguration,
+    })
+    expect(knownGroups).to.deep.equal(['Object', 'Happenings', 'Visual Media'])
+  })
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.tsx
@@ -1,0 +1,423 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import * as React from 'react'
+import IconHelper from '../../js/IconHelper'
+import TextField from '@mui/material/TextField'
+import CheckBoxIcon from '@mui/icons-material/CheckBox'
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
+import IndeterminateCheckBoxIcon from '@mui/icons-material/IndeterminateCheckBox'
+
+import Chip from '@mui/material/Chip'
+import Autocomplete from '@mui/material/Autocomplete'
+import { useConfiguration } from '../../js/model/Startup/configuration.hooks'
+import { StartupDataStore } from '../../js/model/Startup/startup'
+import { useMetacardDefinitions } from '../../js/model/Startup/metacard-definitions.hooks'
+import { BasicDatatypeFilter } from '../filter-builder/filter.structure'
+
+import Swath from '../swath/swath'
+import {
+  DataTypesConfiguration,
+  ReverseDataTypesConfiguration,
+} from '../datatypes/datatypes'
+
+function getMatchTypeAttribute() {
+  return StartupDataStore.MetacardDefinitions.getAttributeMap()[
+    StartupDataStore.Configuration.getBasicSearchMatchType()
+  ]
+    ? StartupDataStore.Configuration.getBasicSearchMatchType()
+    : 'datatype'
+}
+
+/**
+ *  If the configuration is empty, we generate a configuration based off the enum instead
+ */
+function getTypesMapping({
+  Configuration,
+  MetacardDefinitions,
+}: {
+  Configuration: ReturnType<typeof useConfiguration>
+  MetacardDefinitions: ReturnType<typeof useMetacardDefinitions>
+}): DataTypesConfiguration {
+  const customTypesConfig = Configuration.getDataTypes()
+  if (Object.keys(customTypesConfig.groups).length > 0) {
+    return customTypesConfig
+  }
+  const matchTypeAttr = getMatchTypeAttribute()
+  const validTypes = MetacardDefinitions.getEnum(matchTypeAttr)
+  const defaultTypesMapping = validTypes.reduce(
+    (blob, value: any) => {
+      const iconClass = IconHelper.getClassByName(value)
+      blob.groups['Other'] = blob.groups['Other'] || {}
+      blob.groups['Other'].values = blob.groups['Other'].values || {}
+
+      blob.groups['Other'].values[value] = {
+        attributes: {
+          datatype: [value],
+          'metadata-content-type': [value],
+        },
+        iconConfig: {
+          class: iconClass,
+        },
+      }
+      return blob
+    },
+    {
+      groups: {},
+    } as ReturnType<typeof Configuration.getDataTypes>
+  )
+  return defaultTypesMapping
+}
+
+export function getDataTypesConfiguration({
+  Configuration,
+  MetacardDefinitions,
+}: {
+  Configuration: ReturnType<typeof useConfiguration>
+  MetacardDefinitions: ReturnType<typeof useMetacardDefinitions>
+}): {
+  groupMap: DataTypesConfiguration
+  valueMap: ReverseDataTypesConfiguration
+} {
+  const typesMapping = getTypesMapping({ Configuration, MetacardDefinitions })
+  const reverseMapping = Object.entries(typesMapping.groups).reduce(
+    (blob, [groupName, groupInfo]) => {
+      Object.entries(groupInfo.values).forEach(([valueName, valueInfo]) => {
+        blob[valueName] = {
+          group: {
+            name: groupName,
+            iconConfig: groupInfo.iconConfig,
+          },
+          ...valueInfo,
+        }
+      })
+      return blob
+    },
+    {} as ReverseDataTypesConfiguration
+  )
+
+  return {
+    groupMap: typesMapping,
+    valueMap: reverseMapping,
+  }
+}
+
+function getGroupFromValue({
+  dataTypesConfiguration,
+  value,
+  orderedGroups,
+}: {
+  dataTypesConfiguration: ReturnType<typeof getDataTypesConfiguration>
+  value: string
+  orderedGroups: string[]
+}) {
+  const groupName = dataTypesConfiguration.valueMap[value]?.group.name
+  return orderedGroups.includes(groupName)
+    ? groupName
+    : orderedGroups.includes(value)
+    ? value
+    : null
+}
+
+export function generateSortedValues({
+  dataTypesConfiguration,
+}: {
+  dataTypesConfiguration: ReturnType<typeof getDataTypesConfiguration>
+}) {
+  const orderedGroups = Object.keys(dataTypesConfiguration.groupMap.groups)
+  return Object.keys(dataTypesConfiguration.valueMap)
+    .concat(orderedGroups)
+    .sort((a, b) => {
+      const groupA = getGroupFromValue({
+        dataTypesConfiguration,
+        value: a,
+        orderedGroups,
+      })
+      const groupB = getGroupFromValue({
+        dataTypesConfiguration,
+        value: b,
+        orderedGroups,
+      })
+
+      // Handle cases where one value has a group and the other doesn't (grouped comes first)
+      if (groupA && !groupB) return -1
+      if (!groupA && groupB) return 1
+
+      // Sort by group if both values have different groups (group order matters)
+      if (groupA && groupB && groupA !== groupB) {
+        return orderedGroups.indexOf(groupA) - orderedGroups.indexOf(groupB)
+      }
+
+      // If they are in the same group, sort by whether the value itself is the group (if it's the group, it comes first)
+      if (groupA === groupB) {
+        if (a === groupA) return -1
+        if (b === groupB) return 1
+        return a.localeCompare(b) // Sub-sort alphabetically if not the group itself
+      }
+
+      // If no groups are involved, sort alphabetically
+      return a.localeCompare(b)
+    })
+    .map((value) => {
+      return {
+        label: value,
+        value,
+      }
+    })
+}
+
+export function generateGroupsToValues({
+  dataTypesConfiguration,
+}: {
+  dataTypesConfiguration: ReturnType<typeof getDataTypesConfiguration>
+}) {
+  return Object.keys(dataTypesConfiguration.groupMap.groups).reduce(
+    (groupsToValuesMapping, groupName) => {
+      groupsToValuesMapping[groupName] = Object.keys(
+        dataTypesConfiguration.groupMap.groups[groupName].values
+      )
+      return groupsToValuesMapping
+    },
+    {} as { [key: string]: string[] }
+  )
+}
+
+export function generateKnownGroups({
+  dataTypesConfiguration,
+}: {
+  dataTypesConfiguration: ReturnType<typeof getDataTypesConfiguration>
+}) {
+  return Object.keys(dataTypesConfiguration.groupMap.groups)
+}
+
+function useDataTypesConfiguration(): {
+  configuration: ReturnType<typeof getDataTypesConfiguration>
+  sortedValues: { label: string; value: string }[]
+  groupsToValues: {
+    [key: string]: string[]
+  }
+  knownGroups: string[]
+} {
+  const Configuration = useConfiguration()
+  const MetacardDefinitions = useMetacardDefinitions()
+
+  const dataTypesConfiguration = React.useMemo(() => {
+    return getDataTypesConfiguration({ Configuration, MetacardDefinitions })
+  }, [Configuration.getDataTypes(), MetacardDefinitions])
+
+  const sortedValues = React.useMemo(() => {
+    return generateSortedValues({ dataTypesConfiguration })
+  }, [dataTypesConfiguration])
+
+  const groupsToValues = React.useMemo(() => {
+    return generateGroupsToValues({ dataTypesConfiguration })
+  }, [dataTypesConfiguration])
+
+  const knownGroups = React.useMemo(() => {
+    return generateKnownGroups({ dataTypesConfiguration })
+  }, [dataTypesConfiguration])
+
+  return {
+    configuration: dataTypesConfiguration,
+    sortedValues,
+    groupsToValues,
+    knownGroups,
+  }
+}
+
+function validateShape({
+  value,
+  onChange,
+}: {
+  value: BasicDatatypeFilter['value']
+  onChange: (value: BasicDatatypeFilter['value']) => void
+}) {
+  if (!hasValidShape({ value })) {
+    onChange([])
+  }
+}
+
+function hasValidShape({
+  value,
+}: {
+  value: BasicDatatypeFilter['value']
+}): boolean {
+  if (value === undefined || value === null || value.constructor !== Array) {
+    return false
+  } else {
+    return (
+      value.find((subvalue) => {
+        return typeof subvalue !== 'string'
+      }) === undefined
+    )
+  }
+}
+
+function getIconForValue({
+  value,
+  configuration,
+}: {
+  value: string
+  configuration: ReturnType<typeof getDataTypesConfiguration>
+}) {
+  return (
+    configuration.valueMap[value]?.iconConfig?.class ||
+    configuration.groupMap.groups[value]?.iconConfig?.class
+  )
+}
+
+export const ReservedBasicDatatype = ({
+  value = [],
+  onChange,
+}: {
+  value: BasicDatatypeFilter['value']
+  onChange: (value: BasicDatatypeFilter['value']) => void
+}) => {
+  const datatypesConfiguration = useDataTypesConfiguration()
+  React.useEffect(() => {
+    validateShape({ value, onChange })
+  }, [])
+
+  if (!hasValidShape({ value })) {
+    return null
+  }
+  return (
+    <Autocomplete
+      fullWidth
+      multiple
+      options={datatypesConfiguration.sortedValues}
+      disableCloseOnSelect
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(option, value) => option.value === value.value}
+      onChange={(_e, newValue) => {
+        // should technically only ever be one value, since we filter these out at the end
+        const includedGroup = newValue.find((val) => {
+          return datatypesConfiguration.knownGroups.includes(val.value)
+        })?.value
+
+        // determine if we need to deselect or select all values in a group
+        if (includedGroup) {
+          // determine if everything in a group is selected
+          const groupValues =
+            datatypesConfiguration.groupsToValues[includedGroup]
+          const isGroupSelected = groupValues.every((val) => {
+            return value.includes(val)
+          })
+          if (isGroupSelected) {
+            newValue = newValue.filter((val) => {
+              return !groupValues.includes(val.value)
+            })
+          } else {
+            groupValues.forEach((val) => {
+              if (!newValue.find((value) => value.value === val)) {
+                newValue.push({ label: val, value: val })
+              }
+            })
+          }
+        }
+
+        // remove any groups, as we don't actually want these in the value or we can't remove other chips in that category once it gets added
+        newValue = newValue.filter((val) => {
+          return !datatypesConfiguration.knownGroups.includes(val.value)
+        })
+        onChange(newValue.map((val) => val.value))
+      }}
+      size="small"
+      renderOption={(props, option) => {
+        const isGroup = datatypesConfiguration.knownGroups.includes(
+          option.value
+        )
+        // determine if everything in a group is selected
+        const isGroupSelected = isGroup
+          ? datatypesConfiguration.groupsToValues[option.value].every((val) => {
+              return value.includes(val)
+            })
+          : false
+        // determine if anything in a group is selected but not everything
+        const isGroupPartiallySelected =
+          isGroup && !isGroupSelected
+            ? datatypesConfiguration.groupsToValues[option.value].some(
+                (val) => {
+                  return value.includes(val)
+                }
+              )
+            : false
+
+        const isSelected = props['aria-selected'] || isGroupSelected
+
+        return (
+          <li
+            {...props}
+            className={`${props.className} ${isGroup ? '!pl-2' : '!pl-8'} ${
+              isGroupSelected ? '' : ''
+            }`}
+            aria-selected={isSelected}
+          >
+            {isGroup ? <></> : <Swath className="w-1 h-6" />}
+            <div className="px-2">
+              {isGroup ? (
+                isGroupSelected ? (
+                  <CheckBoxIcon />
+                ) : isGroupPartiallySelected ? (
+                  <IndeterminateCheckBoxIcon />
+                ) : (
+                  <CheckBoxOutlineBlankIcon />
+                )
+              ) : isSelected ? (
+                <CheckBoxIcon />
+              ) : (
+                <CheckBoxOutlineBlankIcon />
+              )}
+            </div>
+            <div
+              className={`pr-2 icon ${getIconForValue({
+                value: option.value,
+                configuration: datatypesConfiguration.configuration,
+              })}`}
+            />
+            <div className="pt-[3px]"> {option.label}</div>
+          </li>
+        )
+      }}
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            variant="outlined"
+            color="default"
+            label={
+              <>
+                <div
+                  className={`pr-2 icon ${getIconForValue({
+                    value: option.value,
+                    configuration: datatypesConfiguration.configuration,
+                  })}`}
+                />
+                {option.label}
+              </>
+            }
+            {...getTagProps({ index })}
+          />
+        ))
+      }
+      value={value.map((val) => {
+        return {
+          label: val,
+          value: val,
+        }
+      })}
+      renderInput={(params) => <TextField {...params} variant="outlined" />}
+    />
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/IconHelper.tsx
@@ -149,15 +149,6 @@ export default {
     const i = _deriveIconByMetacardObject(metacard)
     return _get(i, 'class', _default.class)
   },
-  getUnicode() {
-    return _get(_map, 'style.code', _default.style.code)
-  },
-  getFont() {
-    return _get(_map, 'style.font', _default.style.font)
-  },
-  getSize() {
-    return _get(_map, 'style.size', _default.style.size)
-  },
   getFullByMetacardObject(metacard: LazyQueryResult['plain']) {
     const i = _deriveIconByMetacardObject(metacard)
     return i !== undefined ? i : _default

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.spec.tsx
@@ -794,7 +794,6 @@ describe('calculation of next index', () => {
   ]
   it('passes snapshot test cases', (done) => {
     Examples.forEach((example) => {
-      console.log(example)
       expect(
         JSON.stringify(
           calculateNextIndexForSourceGroupNextPage({
@@ -1417,7 +1416,6 @@ describe('calculation of max index', () => {
 
   it('passes snapshot test cases', (done) => {
     Examples.forEach((example) => {
-      console.log(example)
       expect(
         JSON.stringify(
           getMaxIndexForSourceGroup({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
@@ -2,6 +2,7 @@ import { Subscribable } from '../Base/base-classes'
 import { StartupPayloadType } from './startup.types'
 import { StartupData } from './startup'
 import _ from 'underscore'
+import { DataTypesConfiguration } from '../../../component/datatypes/datatypes'
 
 function match(regexList: any, attribute: any) {
   return (
@@ -179,7 +180,12 @@ class Configuration extends Subscribable<{ thing: 'configuration-update' }> {
     return this.config?.disableUnknownErrorBox || false
   }
   getExtra = () => {
-    return this.config?.extra || []
+    return this.config?.extra
+  }
+  getDataTypes = (): DataTypesConfiguration => {
+    return {
+      groups: this.getExtra()?.datatypes?.groups || {},
+    }
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/metacard-definitions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/metacard-definitions.tsx
@@ -1,3 +1,4 @@
+import { BasicDataTypePropertyName } from '../../../component/filter-builder/reserved.properties'
 import { Subscribable } from '../Base/base-classes'
 import { StartupData } from './startup'
 import {
@@ -195,7 +196,7 @@ class MetacardDefinitions extends Subscribable<{
     return this.attributeMap?.[attributeName]?.enumerations || []
   }
   getSearchOnlyAttributes = () => {
-    return ['anyText', 'anyGeo', 'anyDate']
+    return ['anyText', 'anyGeo', 'anyDate', BasicDataTypePropertyName]
   }
   getSortedAttributes = () => {
     return this.sortedAttributes || []

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -13,6 +13,8 @@
  *
  **/
 
+import { DataTypesConfiguration } from '../../../component/datatypes/datatypes'
+
 export type AttributeTypes =
   | 'BINARY'
   | 'DATE'
@@ -141,7 +143,10 @@ export interface UIConfigType {
   attributeAliases: Record<string, string>
   iconConfig: IconConfig
   enums: Record<string, any>
-  extra: any
+  extra: {
+    [key: string]: any
+    datatypes?: DataTypesConfiguration
+  }
   editorAttributes: string[]
   resultShow: string[]
   disableUnknownErrorBox: boolean

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/filter-comparator.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/filter-comparator.tsx
@@ -16,7 +16,10 @@ import React, { useEffect } from 'react'
 import { getComparators } from './comparatorUtils'
 import MenuItem from '@mui/material/MenuItem'
 import TextField, { TextFieldProps } from '@mui/material/TextField'
-import { FilterClass } from '../../../component/filter-builder/filter.structure'
+import {
+  FilterClass,
+  isBasicDatatypeClass,
+} from '../../../component/filter-builder/filter.structure'
 
 type Props = {
   filter: FilterClass
@@ -38,6 +41,10 @@ const FilterComparator = ({ filter, setFilter, textFieldProps }: Props) => {
       )
     }
   }, [filter, setFilter])
+
+  if (isBasicDatatypeClass(filter)) {
+    return null
+  }
 
   const comparators = getComparators(filter.property)
   return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -22,6 +22,7 @@ import { NumberRangeField } from '../../../component/fields/number-range'
 import { DateRangeField } from '../../../component/fields/date-range'
 import { DateRelativeField } from '../../../component/fields/date-relative'
 import {
+  BasicDatatypeFilter,
   FilterClass,
   ValueTypes,
 } from '../../../component/filter-builder/filter.structure'
@@ -35,6 +36,8 @@ import { EnterKeySubmitProps } from '../../../component/custom-events/enter-key-
 import { EnumInput } from './enum-input'
 import { ValidationResult } from '../../location/validators'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import { ReservedBasicDatatype } from '../../../component/reserved-basic-datatype/reserved.basic-datatype'
+import { BasicDataTypePropertyName } from '../../../component/filter-builder/reserved.properties'
 export type Props = {
   filter: FilterClass
   setFilter: (filter: FilterClass) => void
@@ -55,6 +58,16 @@ const FilterInput = ({ filter, setFilter, errorListener }: Props) => {
       })
     )
   }
+
+  if (filter.property === BasicDataTypePropertyName) {
+    return (
+      <ReservedBasicDatatype
+        onChange={onChange}
+        value={value as BasicDatatypeFilter['value']}
+      />
+    )
+  }
+
   switch (filter.type) {
     case 'IS NULL':
       return null

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+import { BasicDataTypePropertyName } from '../../component/filter-builder/reserved.properties'
 import { StartupDataStore } from '../../js/model/Startup/startup'
 import {
   AttributeDefinitionType,
@@ -61,10 +62,16 @@ export const getGroupedFilteredAttributes = (): {
   const groupedFilteredAttributes = validCommonAttributes.concat(
     getFilteredAttributeList('All Attributes')
   )
+  const reservedDatatypeAttr = groupedFilteredAttributes.find((thing) => {
+    return thing.value === BasicDataTypePropertyName
+  })
+  if (reservedDatatypeAttr) {
+    reservedDatatypeAttr.group = 'Special Attributes'
+  }
   const groups =
     validCommonAttributes.length > 0
-      ? ['Commonly Used Attributes', 'All Attributes']
-      : []
+      ? ['Commonly Used Attributes', 'Special Attributes', 'All Attributes']
+      : ['Special Attributes', 'All Attributes']
   return {
     groups,
     attributes: groupedFilteredAttributes,


### PR DESCRIPTION
 - We now use a special type component that is based on the extra json config being set.  See the datatypes.tsx file for details on the json structure.
 - The structure allows grouping values, assigning icons to groups, ordering of groups (through their order in the json), custom values for each group that map to custom attributes / values for those attributes, and a custom icon for each value within a group.
 - If the extra json has no group specified, it will fall back to the previous datatype / type selection behavior, albiet with the new custom component.
 - The custom component is also utilized in advance search.  We do this by keeping the details of the component within the filter tree structure itself, and only mapping to proper cql when we have to.
 - This allows users to search on multiple type values, while also using advanced boolean logic like negation, without having to wrap their head around what those types expand to.  Previously a basic type search could look overwhelming, and unusable when changed into the advanced form.
 - The new property is inserted as an actual metacard attribute type on the backend when sending the config to the UI, called reserved.basic-datatype.  The goal is to avoid clashing with real attribute types.  We set it to be hidden, so that it doesn't show up anywhere unless we want it to.
 - By doing this, we can also take advantage of the alias config, which we do to set a custom label on this selector in the UI.  By default it has the old label of Types (see the alias set in ComposeApplication).
 - The cql parser has been updated to handle expansion of this new filter type before the actual writing.
 - Reserved properties file is here to ensure no circular dependencies between files that need to know the names of these reserved properties.
 - Various tests have been added to the cql parser to make sure it can handle the new structure, even when values are present that haven't been configured.  For now, it drops those values (but includes any valid ones).
 - Tests have also been added to exercise that the new type dropdown is able to properly transform the configuration values into forms it can understand.
 - Tests have been added to the query basic view to try and prevent regressions.  For the most part these are converting to the component state and back to filter to ensure there isn't a loss of information.  The actual component state doesn't get tested, only that it can handle going back to the filter as expected, so we should be able to flexibly update the component and catch any regressions.
 - The new property that shows the dropdown in the advanced form gets slotted under "Special Attributes" which will appear under "Common" for now.