### PR TITLE
Fix issue where map layers sometimes did not validate against configuration changes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
@@ -26,7 +26,6 @@ import {
   CesiumLayers,
 } from '../../../../js/controllers/cesium.layers'
 import user from '../../../singletons/user-instance'
-import User from '../../../../js/model/User'
 import { Drawing } from '../../../singletons/drawing'
 import { LazyQueryResult } from '../../../../js/model/LazyQueryResult/LazyQueryResult'
 import { ClusterType } from '../react/geometries'
@@ -70,7 +69,6 @@ function setupTerrainProvider(viewer: any, terrainProvider: any) {
 }
 function createMap(insertionElement: any) {
   const layerPrefs = user.get('user>preferences>mapLayers')
-  ;(User as any).updateMapLayers(layerPrefs)
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
   const layerCollectionController = new CesiumLayers({
     collection: layerPrefs,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -22,7 +22,6 @@ import DrawingUtility from '../DrawingUtility'
 import Openlayers from 'openlayers'
 import { OpenlayersLayers } from '../../../../js/controllers/openlayers.layers'
 import user from '../../../singletons/user-instance'
-import User from '../../../../js/model/User'
 import wreqr from '../../../../js/wreqr'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { ClusterType } from '../react/geometries'
@@ -33,7 +32,6 @@ const defaultColor = '#3c6dd5'
 const rulerColor = '#506f85'
 function createMap(insertionElement: any) {
   const layerPrefs = user.get('user>preferences>mapLayers')
-  ;(User as any).updateMapLayers(layerPrefs)
   // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
   const layerCollectionController = new OpenlayersLayers({
     collection: layerPrefs,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layers.tsx
@@ -37,7 +37,6 @@ export const CesiumImageryProviderTypes = {
 }
 import { Layers } from './layers'
 import user from '../../component/singletons/user-instance'
-import User from '../../js/model/User'
 import Backbone from 'backbone'
 import { StartupDataStore } from '../model/Startup/startup'
 type MakeMapType = {
@@ -57,7 +56,6 @@ export class CesiumLayers {
     this.layerOrder = []
     this.layerForCid = {}
     const layerPrefs = user.get('user>preferences>mapLayers')
-    ;(User as any).updateMapLayers(layerPrefs)
     this.layers = new Layers(layerPrefs)
     this.backboneModel.listenTo(
       layerPrefs,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
@@ -2,7 +2,6 @@ import { Layers } from './layers'
 import _ from 'underscore'
 import ol from 'openlayers'
 import user from '../../component/singletons/user-instance'
-import User from '../../js/model/User'
 import Backbone from 'backbone'
 import { StartupDataStore } from '../model/Startup/startup'
 const createTile = (
@@ -130,7 +129,6 @@ export class OpenlayersLayers {
     this.isMapCreated = false
     this.layerForCid = {}
     const layerPrefs = user.get('user>preferences>mapLayers')
-    ;(User as any).updateMapLayers(layerPrefs)
     this.layers = new Layers(layerPrefs)
     this.backboneModel.listenTo(
       layerPrefs,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -69,7 +69,9 @@ export interface ImageryProvider {
   type: string
   url: string
   parameters: {
-    imageSize: number[]
+    format?: string
+    transparent?: boolean
+    imageSize?: number[]
   }
   alpha: number
   name: string
@@ -279,7 +281,9 @@ interface PreferencesType {
     type: string
     url: string
     parameters: {
-      imageSize: number[]
+      format?: string
+      transparent?: boolean
+      imageSize?: number[]
     }
     alpha: number
     name: string

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.spec.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { expect } from 'chai'
+import user from '../../component/singletons/user-instance'
+import { StartupDataStore } from './Startup/startup'
+import _ from 'underscore'
+import { userModifiableLayerProperties } from './User'
+
+const exampleProviders1 = [
+  {
+    proxyEnabled: true,
+    withCredentials: false,
+    alpha: 1,
+    name: 'World Topo Map - 1',
+    show: true,
+    type: 'AGM',
+    parameters: {
+      transparent: true,
+      format: 'image/png',
+    },
+    url: './proxy/catalog20',
+    order: 0,
+  },
+  {
+    proxyEnabled: true,
+    withCredentials: false,
+    alpha: 1,
+    name: 'World Imagery - 3',
+    show: true,
+    type: 'AGM',
+    parameters: {
+      transparent: true,
+      format: 'image/png',
+    },
+    url: './proxy/catalog21',
+    order: 1,
+  },
+]
+
+// same as one, but with user modifiable properties changed (order, alpha, show)
+const exampleProviders2 = [
+  {
+    proxyEnabled: true,
+    withCredentials: false,
+    alpha: 0.7,
+    name: 'World Imagery - 3',
+    show: false,
+    type: 'AGM',
+    parameters: {
+      transparent: true,
+      format: 'image/png',
+    },
+    url: './proxy/catalog21',
+    order: 0,
+  },
+  {
+    proxyEnabled: true,
+    withCredentials: false,
+    alpha: 0.7,
+    name: 'World Topo Map - 1',
+    show: true,
+    type: 'AGM',
+    parameters: {
+      transparent: true,
+      format: 'image/png',
+    },
+    url: './proxy/catalog20',
+    order: 1,
+  },
+]
+
+// same as one, but with one layer removed
+const exampleProviders3 = [
+  {
+    proxyEnabled: true,
+    withCredentials: false,
+    alpha: 1,
+    name: 'World Topo Map - 1',
+    show: true,
+    type: 'AGM',
+    parameters: {
+      transparent: true,
+      format: 'image/png',
+    },
+    url: './proxy/catalog20',
+    order: 0,
+  },
+]
+
+describe('user preferences and such are handled correctly', () => {
+  it('should overwrite user layers if none exist', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.imageryProviders = exampleProviders1
+    }
+    const userLayers = user.get('user>preferences>mapLayers')
+    userLayers.reset([])
+
+    expect(
+      userLayers
+        .toJSON()
+        .map((layer: any) => _.omit(layer, userModifiableLayerProperties))
+    ).to.deep.equal(
+      exampleProviders1.map((layer) =>
+        _.omit(layer, userModifiableLayerProperties)
+      )
+    )
+  })
+
+  it('should leave user layers alone if the configuration has not updated', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.imageryProviders = exampleProviders1
+    }
+    const userLayers = user.get('user>preferences>mapLayers')
+    userLayers.reset(exampleProviders2)
+
+    expect(
+      userLayers
+        .toJSON()
+        .map((layer: any) => _.omit(layer, userModifiableLayerProperties))
+    ).to.deep.equal(
+      exampleProviders2.map((layer) =>
+        _.omit(layer, userModifiableLayerProperties)
+      )
+    )
+  })
+
+  it('should remove layers that have been removed', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.imageryProviders = exampleProviders3
+    }
+    const userLayers = user.get('user>preferences>mapLayers')
+    userLayers.reset(exampleProviders1)
+
+    expect(
+      userLayers
+        .toJSON()
+        .map((layer: any) => _.omit(layer, userModifiableLayerProperties))
+    ).to.deep.equal(
+      exampleProviders3.map((layer) =>
+        _.omit(layer, userModifiableLayerProperties)
+      )
+    )
+  })
+
+  it('should add layers that have been added', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.imageryProviders = exampleProviders1
+    }
+    const userLayers = user.get('user>preferences>mapLayers')
+    userLayers.reset(exampleProviders3)
+
+    expect(
+      userLayers
+        .toJSON()
+        .map((layer: any) => _.omit(layer, userModifiableLayerProperties))
+    ).to.deep.equal(
+      exampleProviders1.map((layer) =>
+        _.omit(layer, userModifiableLayerProperties)
+      )
+    )
+  })
+
+  it('should handle empty imagery providers', () => {
+    if (StartupDataStore.Configuration.config) {
+      StartupDataStore.Configuration.config.imageryProviders = []
+    }
+    const userLayers = user.get('user>preferences>mapLayers')
+    userLayers.reset(exampleProviders3)
+
+    expect(
+      userLayers
+        .toJSON()
+        .map((layer: any) => _.omit(layer, userModifiableLayerProperties))
+    ).to.deep.equal(
+      [].map((layer) => _.omit(layer, userModifiableLayerProperties))
+    )
+  })
+})


### PR DESCRIPTION
 - The validation of map layers was being done in a few different places as opposed to when the layers are initialized / added.  Now this is done in a central spot.
 - The sidebar now shows layers as they are updated in the config appropriately.