### PR TITLE
Move determination of hidden to be in central area within compose, fix sorting regression

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-leaf.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-leaf.spec.tsx
@@ -13,6 +13,7 @@ import {
 import moment from 'moment'
 import user from '../singletons/user-instance'
 import { StartupDataStore } from '../../js/model/Startup/startup'
+import { BasicDataTypePropertyName } from './reserved.properties'
 function addTestDefs() {
   StartupDataStore.MetacardDefinitions.addDynamicallyFoundMetacardDefinitions({
     testing: {
@@ -69,12 +70,14 @@ function addTestDefs() {
         id: 'xmlType',
         multivalued: false,
         isInjected: false,
+        hidden: true,
       },
       binaryType: {
         type: 'BINARY',
         id: 'binaryType',
         multivalued: false,
         isInjected: false,
+        hidden: true,
       },
       'location.country-code': {
         type: 'STRING',
@@ -93,6 +96,14 @@ function addTestDefs() {
         id: 'anyText',
         multivalued: false,
         isInjected: false,
+        hidden: true,
+      },
+      [BasicDataTypePropertyName]: {
+        type: 'STRING',
+        id: BasicDataTypePropertyName,
+        multivalued: false,
+        isInjected: false,
+        hidden: true,
       },
     },
   })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -69,10 +69,7 @@ export const TypedUserInstance = {
       return (
         !currentAttributesShown.includes(attr.id) &&
         !searchOnlyAttributes.includes(attr.id) &&
-        !StartupDataStore.MetacardDefinitions.isHiddenTypeExceptThumbnail(
-          attr.id
-        ) &&
-        !StartupDataStore.Configuration.isHiddenAttribute(attr.id)
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(attr.id)
       )
     })
     return attributesPossible.map((attr) => attr.id)
@@ -88,10 +85,7 @@ export const TypedUserInstance = {
       return (
         !currentAttributesShown.includes(attr.id) &&
         !searchOnlyAttributes.includes(attr.id) &&
-        !StartupDataStore.MetacardDefinitions.isHiddenTypeExceptThumbnail(
-          attr.id
-        ) &&
-        !StartupDataStore.Configuration.isHiddenAttribute(attr.id)
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(attr.id)
       )
     })
     return attributesPossible.map((attr) => attr.id)
@@ -108,10 +102,7 @@ export const TypedUserInstance = {
       return (
         !currentAttributesShown.includes(attr.id) &&
         !searchOnlyAttributes.includes(attr.id) &&
-        !StartupDataStore.MetacardDefinitions.isHiddenTypeExceptThumbnail(
-          attr.id
-        ) &&
-        !StartupDataStore.Configuration.isHiddenAttribute(attr.id)
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(attr.id)
       )
     })
     return attributesPossible.map((attr) => attr.id)

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -36,7 +36,6 @@ import ExtensionPoints from '../../../extension-points'
 import LocationInputReact from '../../location-new/location-new.view'
 import { TypedUserInstance } from '../../singletons/TypedUser'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
-import { useConfiguration } from '../../../js/model/Startup/configuration.hooks'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import Common from '../../../js/Common'
 import SummaryManageAttributes from '../../../react-component/summary-manage-attributes/summary-manage-attributes'
@@ -704,12 +703,7 @@ const getHiddenAttributes = (
       return true
     })
     .filter((val) => {
-      return !StartupDataStore.Configuration.isHiddenAttribute(val.id)
-    })
-    .filter((val) => {
-      return !StartupDataStore.MetacardDefinitions.isHiddenTypeExceptThumbnail(
-        val.id
-      )
+      return !StartupDataStore.MetacardDefinitions.isHiddenAttribute(val.id)
     })
 }
 let globalExpanded = false // globally track if users want this since they may be clicking between results
@@ -728,9 +722,7 @@ const Summary = ({ result: selection }: Props) => {
   )
   useRerenderOnBackboneSync({ lazyResult: selection })
   const { listenTo } = useBackbone()
-  const { isHiddenAttribute } = useConfiguration()
-  const { isHiddenTypeExceptThumbnail, getMetacardDefinition } =
-    useMetacardDefinitions()
+  const { isHiddenAttribute, getMetacardDefinition } = useMetacardDefinitions()
   React.useEffect(() => {
     listenTo(
       user.get('user').get('preferences'),
@@ -763,16 +755,13 @@ const Summary = ({ result: selection }: Props) => {
     return selection && expanded
       ? Object.keys(selection.plain.metacard.properties)
           .filter((attr) => {
-            return !isHiddenTypeExceptThumbnail(attr)
-          })
-          .filter((attr) => {
             return !isHiddenAttribute(attr)
           })
           .filter((attr) => {
             return !summaryShown.includes(attr)
           })
       : []
-  }, [expanded, summaryShown, isHiddenAttribute, isHiddenTypeExceptThumbnail])
+  }, [expanded, summaryShown, isHiddenAttribute])
   const blankEverythingElse = React.useMemo(() => {
     return selection
       ? Object.values(getMetacardDefinition(selection.plain.metacardType))
@@ -786,13 +775,10 @@ const Summary = ({ result: selection }: Props) => {
             return true
           })
           .filter((val) => {
-            return !isHiddenTypeExceptThumbnail(val.id)
-          })
-          .filter((val) => {
             return !isHiddenAttribute(val.id)
           })
       : []
-  }, [expanded, summaryShown, isHiddenAttribute, isHiddenTypeExceptThumbnail])
+  }, [expanded, summaryShown, isHiddenAttribute])
   React.useEffect(() => {
     globalExpanded = expanded
   }, [expanded])

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
@@ -39,16 +39,7 @@ function calculateAvailableAttributes(results: LazyQueryResult[]) {
   return availableAttributes
     .filter(
       (attribute) =>
-        StartupDataStore.MetacardDefinitions.getAttributeMap()[attribute] !==
-        undefined
-    )
-    .filter(
-      (attribute) =>
-        !StartupDataStore.MetacardDefinitions.isHiddenType(attribute)
-    )
-    .filter(
-      (attribute) =>
-        !StartupDataStore.Configuration.isHiddenAttribute(attribute)
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(attribute)
     )
     .map((attribute) => ({
       label: StartupDataStore.MetacardDefinitions.getAlias(attribute),

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -363,7 +363,7 @@ export class LazyQueryResult {
     return _.filter(
       this.plain.metacard.properties,
       (_value: any, key: string) =>
-        !StartupDataStore.Configuration.isHiddenAttribute(key) &&
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(key) &&
         (attribute === undefined || attribute === key) &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key] &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key].type ===

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.ts
@@ -61,7 +61,7 @@ export default Backbone.AssociatedModel.extend({
     return _.filter(
       this.toJSON(),
       (_value, key) =>
-        !StartupDataStore.Configuration.isHiddenAttribute(key) &&
+        !StartupDataStore.MetacardDefinitions.isHiddenAttribute(key) &&
         (attribute === undefined || attribute === key) &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key] &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key].type ===

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.tsx
@@ -28,16 +28,6 @@ class Configuration extends Subscribable<{ thing: 'configuration-update' }> {
       },
     })
   }
-  isHiddenAttribute = (attribute: any) => {
-    if (attribute === 'anyDate') {
-      // feels like we should consolidate all the attribute logic into the metacard definitions file, but for now don't want to risk circular dependency
-      return true
-    }
-    return match(this.getHiddenAttributes(), attribute)
-  }
-  getHiddenAttributes = () => {
-    return this.config?.hiddenAttributes || []
-  }
   getExportLimit = () => {
     return this.config?.exportResultLimit || 1000
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/metacard-definitions.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/metacard-definitions.tsx
@@ -159,26 +159,14 @@ class MetacardDefinitions extends Subscribable<{
     this.sortedAttributes = sortMetacardTypes(this.attributeMap)
     this._notifySubscribers({ thing: 'metacard-definitions-update' })
   }
-  isHiddenType = (id: string): boolean => {
+  isHiddenAttribute = (id: string): boolean => {
     if (!this.attributeMap) {
       return false
     }
     return (
       this.attributeMap[id] === undefined ||
-      this.attributeMap[id].type === 'XML' ||
-      this.attributeMap[id].type === 'BINARY' ||
-      this.attributeMap[id].type === 'OBJECT'
+      this.attributeMap[id].hidden === true
     )
-  }
-  /**
-   * We exclude thumbnail because although it is a type of attribute (BINARY) we don't usually support viewing in the UI, we handle it
-   */
-  isHiddenTypeExceptThumbnail = (attributeName: string) => {
-    if (attributeName === 'thumbnail') {
-      return false
-    } else {
-      return this.isHiddenType(attributeName)
-    }
   }
   getMetacardDefinition = (metacardTypeName: string) => {
     return this.metacardTypes?.[metacardTypeName] || {}
@@ -203,6 +191,9 @@ class MetacardDefinitions extends Subscribable<{
   }
   getAttributeMap = () => {
     return this.attributeMap || {}
+  }
+  getAttributeDefinition = (id: string) => {
+    return this.attributeMap?.[id]
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -38,6 +38,7 @@ export type AttributeDefinitionType = {
   alias?: string
   enumerations?: string[]
   deprecatedEnumerations?: string[]
+  hidden?: boolean
 }
 
 export type AttributeMapType = {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -59,15 +59,17 @@ export const getGroupedFilteredAttributes = (): {
       },
       []
     )
-  const groupedFilteredAttributes = validCommonAttributes.concat(
-    getFilteredAttributeList('All Attributes')
-  )
-  const reservedDatatypeAttr = groupedFilteredAttributes.find((thing) => {
-    return thing.value === BasicDataTypePropertyName
-  })
-  if (reservedDatatypeAttr) {
-    reservedDatatypeAttr.group = 'Special Attributes'
-  }
+
+  const basicDataTypeAttributeDefinition =
+    StartupDataStore.MetacardDefinitions.getAttributeDefinition(
+      BasicDataTypePropertyName
+    ) as AttributeDefinitionType
+
+  const groupedFilteredAttributes = validCommonAttributes
+    .concat([
+      toAttribute(basicDataTypeAttributeDefinition, 'Special Attributes'),
+    ])
+    .concat(getFilteredAttributeList('All Attributes'))
   const groups =
     validCommonAttributes.length > 0
       ? ['Commonly Used Attributes', 'Special Attributes', 'All Attributes']
@@ -81,8 +83,11 @@ export const getFilteredAttributeList = (group?: string): Attribute[] => {
   return StartupDataStore.MetacardDefinitions.getSortedAttributes()
     .filter(
       ({ id }: any) =>
-        !StartupDataStore.Configuration.isHiddenAttribute(id) &&
-        !StartupDataStore.MetacardDefinitions.isHiddenType(id)
+        id === 'anyText' ||
+        id === 'anyGeo' ||
+        id === BasicDataTypePropertyName ||
+        (!StartupDataStore.MetacardDefinitions.isHiddenAttribute(id) &&
+          id !== 'thumbnail')
     )
     .map((attr) => toAttribute(attr, group))
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/sort-selection-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/query-sort-selection/sort-selection-helpers.tsx
@@ -32,13 +32,7 @@ export const getSortAttributeOptions = (currentSelections: string[]) => {
   const attributes = StartupDataStore.MetacardDefinitions.getSortedAttributes()
   const options: Option[] = attributes
     .filter(
-      (type) => !StartupDataStore.Configuration.isHiddenAttribute(type.id)
-    )
-    .filter(
-      (type) =>
-        !StartupDataStore.MetacardDefinitions.isHiddenTypeExceptThumbnail(
-          type.id
-        )
+      (type) => !StartupDataStore.MetacardDefinitions.isHiddenAttribute(type.id)
     )
     .filter((type) => !blacklist.includes(type.id))
     .filter((type) => !currentAttributes.includes(type.id))


### PR DESCRIPTION
 - The previous move of sorting to the backend did not take into account casing.  Now we properly do a case insensitive sort.
 - The logic around hidden attributes was previously split between configuration / metacard definitions on the frontend.  This logic has been moved to be done upfront, similar to the sorting / alias mapping, on the backend instead.  Now we can check for the presence of hidden on the attribute definitions.
 - With this in mind, added hidden to the anyText, anyGeo definitions on the backend.  These are now manually included in the one attribute list we want them in rather than risking them leaking elsewhere like the metacard editor.  See getFilteredAttributeList in filterHelper.