### PR TITLE
Adds the ability to override download handling downstream

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/download/download.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/download/download.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
+import { useDialog } from '../dialog'
+import { Overridable } from '../../js/model/Base/base-classes'
+import { useOverridable } from '../../js/model/Base/base-classes.hooks'
+
+export const normalDownload = ({ result }: { result: LazyQueryResult }) => {
+  const downloadUrl = result.getDownloadUrl()
+  downloadUrl && window.open(downloadUrl)
+}
+
+// in ddf-ui, we just open the download url and immediately close the dialog, so it should act as before
+export const BaseDownload = ({
+  lazyResults,
+}: {
+  lazyResults: LazyQueryResult[]
+}) => {
+  const { setProps } = useDialog()
+
+  React.useEffect(() => {
+    lazyResults.forEach((lazyResult) => {
+      normalDownload({ result: lazyResult })
+    })
+    setProps({ open: false })
+  }, [])
+
+  return <></>
+}
+
+export const OverridableDownload = new Overridable(BaseDownload)
+
+export const useDownloadComponent = () => {
+  return useOverridable(OverridableDownload)
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/snack/snack.provider.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/snack/snack.provider.tsx
@@ -6,7 +6,7 @@ import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import Portal from '@mui/material/Portal'
 
-export type AddSnack = (message: string, props?: SnackProps) => void
+export type AddSnack = (message: string, props?: SnackProps) => () => void
 
 type Snack = {
   message?: string
@@ -32,7 +32,8 @@ export function SnackProvider({ children }: any) {
   const [snacks, setSnacks] = useState([] as Snack[])
   const [currentSnack, setCurrentSnack] = useState({} as Snack)
 
-  const addSnack = (message: string, props: SnackProps = {}) => {
+  const addSnack: AddSnack = (message, props = {}) => {
+    const newSnack = { message, ...props }
     setSnacks((snacks) => {
       if (props.id) {
         const snackIndex = snacks.findIndex((s) => s.id === props.id)
@@ -40,8 +41,14 @@ export function SnackProvider({ children }: any) {
           snacks.splice(snackIndex, 1)
         }
       }
-      return [{ message, ...props }, ...snacks]
+      return [newSnack, ...snacks]
     })
+
+    const closeSnack = () => {
+      setSnacks((snacks) => snacks.filter((snack) => snack !== newSnack))
+    }
+
+    return closeSnack
   }
 
   // Set current snack to be displayed

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -50,6 +50,8 @@ import ExtensionPoints from '../../../extension-points/extension-points'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import wreqr from '../../../js/wreqr'
+import { useDialog } from '../../dialog'
+import { useDownloadComponent } from '../../download/download'
 const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
   return (
     <div
@@ -149,11 +151,9 @@ const MultiSelectActions = ({
 }
 const dynamicActionClasses = 'h-full'
 const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
-  const triggerDownload = (e: any) => {
-    e.stopPropagation()
-    window.open(lazyResult.getDownloadUrl())
-  }
+  const { setProps } = useDialog()
   const metacardInteractionMenuState = useMenuState()
+  const DownloadComponent = useDownloadComponent()
   return (
     <Grid container direction="column" wrap="nowrap" alignItems="center">
       <Grid item className="h-full">
@@ -235,7 +235,10 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
             data-id="download-button"
             onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
               e.stopPropagation()
-              triggerDownload(e)
+              setProps({
+                open: true,
+                children: <DownloadComponent lazyResults={[lazyResult]} />,
+              })
             }}
             style={{ height: '100%' }}
             size="small"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Base/base-classes.hooks.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Base/base-classes.hooks.tsx
@@ -12,8 +12,17 @@ export function useSubscribable<T extends { thing: string; args?: any }>(
   }, [subscribable, thing, callback])
 }
 
+/**
+ * Notice that we are passing a function to useState. This is because useState will call functions
+ * that are passed to it to compute the initial state. Since overridable.get() could return a function,
+ * we need to encapsulate the call to it within another function to ensure that useState handles it correctly.
+ * Similar with setValue, when passed a function it assumes you're trying to access the previous state, so we
+ * need to encapsulate that call as well.
+ */
 export function useOverridable<T>(overridable: Overridable<T>) {
-  const [value, setValue] = React.useState(overridable.get())
-  useSubscribable(overridable, 'override', setValue)
+  const [value, setValue] = React.useState(() => overridable.get())
+  useSubscribable(overridable, 'override', () => {
+    setValue(() => overridable.get())
+  })
   return value
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/download-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/download-interaction.tsx
@@ -18,21 +18,16 @@ import { MetacardInteraction } from './metacard-interactions'
 import { hot } from 'react-hot-loader'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
 import { StartupDataStore } from '../../js/model/Startup/startup'
-
-const openValidUrl = (result: LazyQueryResult) => {
-  const downloadUrl = result.getDownloadUrl()
-  downloadUrl && window.open(downloadUrl)
-}
+import { useDialog } from '../../component/dialog'
+import { useDownloadComponent } from '../../component/download/download'
 
 const isDownloadable = (model: LazyQueryResult[]): boolean => {
   return model.some((result) => result.getDownloadUrl())
 }
 
-const handleDownload = (model: LazyQueryResult[]) => {
-  model.forEach(openValidUrl)
-}
-
 const DownloadProduct = ({ model }: MetacardInteractionProps) => {
+  const { setProps } = useDialog()
+  const DownloadComponent = useDownloadComponent()
   if (!model || model.length === 0) {
     return null
   }
@@ -44,7 +39,12 @@ const DownloadProduct = ({ model }: MetacardInteractionProps) => {
       text="Download"
       help="Downloads the result's associated product directly to your machine."
       icon="fa fa-download"
-      onClick={() => handleDownload(model)}
+      onClick={() => {
+        setProps({
+          open: true,
+          children: <DownloadComponent lazyResults={model} />,
+        })
+      }}
     >
       {isRemoteResourceCached(model) && (
         <span


### PR DESCRIPTION
 - Downstream projects can now provide their own components to handle downloads.
 - The snack function now returns a function to remove the snack if the component calling it desires.
 - Small update to the useOverridable hook to allow function based overrides (in this case, a download component aka function).