### PR TITLE
Save results visual settings as part of golden layout container state

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -47,6 +47,7 @@ import {
   GoldenLayoutWindowCommunicationEvents,
 } from './cross-window-communication'
 import { useVerifyMapExistsWhenDrawing } from './verify-map'
+import { VisualSettingsProvider } from './visual-settings.provider'
 
 const treeMap = (obj: any, fn: any, path = []): any => {
   if (Array.isArray(obj)) {
@@ -168,17 +169,20 @@ const GoldenLayoutComponent = ({
 }) => {
   const { height } = useContainerSize(container)
   const isMinimized = height && height <= MinimizedHeight
+
   return (
     <ExtensionPoints.providers>
-      <UseSubwindowConsumeNavigationChange goldenLayout={goldenLayout} />
-      <UseMissingParentWindow goldenLayout={goldenLayout} />
-      <Paper
-        elevation={Elevations.panels}
-        className={`w-full h-full ${isMinimized ? 'hidden' : ''}`}
-        square
-      >
-        <ComponentView selectionInterface={options.selectionInterface} />
-      </Paper>
+      <VisualSettingsProvider container={container} goldenLayout={goldenLayout}>
+        <UseSubwindowConsumeNavigationChange goldenLayout={goldenLayout} />
+        <UseMissingParentWindow goldenLayout={goldenLayout} />
+        <Paper
+          elevation={Elevations.panels}
+          className={`w-full h-full ${isMinimized ? 'hidden' : ''}`}
+          square
+        >
+          <ComponentView selectionInterface={options.selectionInterface} />
+        </Paper>
+      </VisualSettingsProvider>
     </ExtensionPoints.providers>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-settings.provider.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-settings.provider.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import React from 'react'
+
+type LayoutContextType = {
+  getValue: (key: string, defaultValue?: any) => any
+  setValue: (key: string, value: any) => void
+  onStateChanged: (callback: () => void) => void
+  visualTitle: string
+}
+
+export const LayoutContext = React.createContext<LayoutContextType>({
+  getValue: () => {},
+  setValue: () => {},
+  onStateChanged: (callback: () => void) => callback(),
+  visualTitle: '',
+})
+
+type VisualSettingsProviderProps = {
+  container: any
+  goldenLayout: any
+  children: React.ReactNode
+}
+
+export const VisualSettingsProvider = (props: VisualSettingsProviderProps) => {
+  const { container, goldenLayout, children } = props
+
+  const getVisualSettingValue = (key: string, defaultValue?: any) => {
+    let settingsVal = container.getState()?.[key]
+
+    if ((!settingsVal || settingsVal.length === 0) && defaultValue) {
+      settingsVal = defaultValue
+    }
+    return settingsVal
+  }
+
+  const setVisualSettingValue = (key: string, value: any) => {
+    container.setState({ ...(container.getState() || {}), [key]: value })
+  }
+
+  const onVisualSettingChangedListener = (callback: () => void) => {
+    goldenLayout.on('stateChanged', () => callback())
+  }
+
+  return (
+    <LayoutContext.Provider
+      value={{
+        getValue: getVisualSettingValue,
+        setValue: setVisualSettingValue,
+        onStateChanged: onVisualSettingChangedListener,
+        visualTitle: container.title,
+      }}
+    >
+      {children}
+    </LayoutContext.Provider>
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -74,9 +74,11 @@ export const TypedUserInstance = {
     })
     return attributesPossible.map((attr) => attr.id)
   },
-  getResultsAttributesPossibleTable: (): string[] => {
+  getResultsAttributesPossibleTable: (
+    currentAttributes?: string[]
+  ): string[] => {
     const currentAttributesShown =
-      TypedUserInstance.getResultsAttributesShownTable()
+      currentAttributes ?? TypedUserInstance.getResultsAttributesShownTable()
     const allKnownAttributes =
       StartupDataStore.MetacardDefinitions.getSortedAttributes()
     const searchOnlyAttributes =
@@ -91,9 +93,11 @@ export const TypedUserInstance = {
     return attributesPossible.map((attr) => attr.id)
   },
   // basically, what could be shown that currently isn't
-  getResultsAttributesPossibleList: (): string[] => {
+  getResultsAttributesPossibleList: (
+    currentAttributes?: string[]
+  ): string[] => {
     const currentAttributesShown =
-      TypedUserInstance.getResultsAttributesShownList()
+      currentAttributes ?? TypedUserInstance.getResultsAttributesShownList()
     const allKnownAttributes =
       StartupDataStore.MetacardDefinitions.getSortedAttributes()
     const searchOnlyAttributes =

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -33,6 +33,8 @@ import Common from '../../../js/Common'
 import Extensions from '../../../extension-points'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import wreqr from '../../../js/wreqr'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
+import { getDefaultResultsShownTable } from './settings-helper'
 type ResultItemFullProps = {
   lazyResult: LazyQueryResult
   measure: () => void
@@ -96,13 +98,17 @@ const RowComponent = ({
   addOnWidth,
   setMaxAddOnWidth,
 }: ResultItemFullProps) => {
+  const { getValue, onStateChanged } = React.useContext(LayoutContext)
   const MetacardDefinitions = useMetacardDefinitions()
   const thumbnail = lazyResult.plain.metacard.properties.thumbnail
   const [decimalPrecision, setDecimalPrecision] = React.useState(
     TypedUserInstance.getDecimalPrecision()
   )
   const [shownAttributes, setShownAttributes] = React.useState(
-    TypedUserInstance.getResultsAttributesShownTable()
+    getValue(
+      'results-attributesShownTable',
+      getDefaultResultsShownTable()
+    ) as string[]
   )
   const isLast = index === results.length - 1
   const { listenTo } = useBackbone()
@@ -126,18 +132,18 @@ const RowComponent = ({
   React.useEffect(() => {
     listenTo(
       user.get('user').get('preferences'),
-      'change:results-attributesShownTable',
-      () => {
-        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-      }
-    )
-    listenTo(
-      user.get('user').get('preferences'),
       'change:decimalPrecision',
       () => {
         setDecimalPrecision(TypedUserInstance.getDecimalPrecision())
       }
     )
+    onStateChanged(() => {
+      const shownList = getValue(
+        'results-attributesShownTable',
+        getDefaultResultsShownTable()
+      )
+      setShownAttributes(shownList)
+    })
   }, [])
   const imgsrc = Common.getImageSrc(thumbnail)
   const measure = () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.collection.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.collection.tsx
@@ -34,9 +34,10 @@ import { HeaderCheckbox } from './table-header'
 import { DarkDivider } from '../../dark-divider/dark-divider'
 import { ResultsCommonControls } from './table'
 import { TypedUserInstance } from '../../singletons/TypedUser'
-import user from '../../singletons/user-instance'
 import { VariableSizeList } from 'react-window'
 import { Memo } from '../../memo/memo'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
+import { getDefaultResultsShownList } from './settings-helper'
 
 type Props = {
   mode: any
@@ -145,6 +146,7 @@ export const useScrollToItemOnSelection = ({
 }
 
 const ResultCards = ({ mode, setMode, selectionInterface }: Props) => {
+  const { setValue, getValue } = React.useContext(LayoutContext)
   const lazyResults = useLazyResultsFromSelectionInterface({
     selectionInterface,
   })
@@ -192,19 +194,18 @@ const ResultCards = ({ mode, setMode, selectionInterface }: Props) => {
             />
           </Grid>
           <ResultsCommonControls
-            getStartingLeft={() => {
-              return TypedUserInstance.getResultsAttributesShownList()
-            }}
+            getStartingLeft={() =>
+              getValue(
+                'results-attributesShownList',
+                getDefaultResultsShownList()
+              )
+            }
             getStartingRight={() => {
-              return TypedUserInstance.getResultsAttributesPossibleList()
+              return TypedUserInstance.getResultsAttributesPossibleList(
+                getValue('results-attributesShownList')
+              )
             }}
-            onSave={(active) => {
-              user
-                .get('user')
-                .get('preferences')
-                .set('results-attributesShownList', active)
-              user.savePreferences()
-            }}
+            onSave={(active) => setValue('results-attributesShownList', active)}
           />
           <Grid item className="pr-2">
             <Button

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -52,6 +52,9 @@ import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-defin
 import wreqr from '../../../js/wreqr'
 import { useDialog } from '../../dialog'
 import { useDownloadComponent } from '../../download/download'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
+import { getDefaultResultsShownList } from './settings-helper'
+
 const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
   return (
     <div
@@ -392,6 +395,7 @@ export const ResultItem = ({
   measure: originalMeasure,
   selectionInterface,
 }: ResultItemFullProps) => {
+  const { getValue, onStateChanged } = React.useContext(LayoutContext)
   const MetacardDefinitions = useMetacardDefinitions()
   const rippleRef = React.useRef<{
     pulsate: () => void
@@ -410,17 +414,14 @@ export const ResultItem = ({
     TypedUserInstance.getDecimalPrecision()
   )
   const [shownAttributes, setShownAttributes] = React.useState(
-    TypedUserInstance.getResultsAttributesShownList()
+    getValue(
+      'results-attributesShownList',
+      getDefaultResultsShownList()
+    ) as string[]
   )
   useRerenderOnBackboneSync({ lazyResult })
+
   React.useEffect(() => {
-    listenTo(
-      user.get('user').get('preferences'),
-      'change:results-attributesShownList',
-      () => {
-        setShownAttributes(TypedUserInstance.getResultsAttributesShownList())
-      }
-    )
     listenTo(
       user.get('user').get('preferences'),
       'change:decimalPrecision',
@@ -428,7 +429,15 @@ export const ResultItem = ({
         setDecimalPrecision(TypedUserInstance.getDecimalPrecision())
       }
     )
+    onStateChanged(() => {
+      const shownList = getValue(
+        'results-attributesShownList',
+        getDefaultResultsShownList()
+      )
+      setShownAttributes(shownList)
+    })
   }, [])
+
   /**
    * Unfocused (hidden) tab sets the container height to 0
    * Run the measure function when the height is 0 could cause items inside the tab to be unreadable

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/results-visual.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/results-visual.tsx
@@ -12,6 +12,7 @@ import { useStatusOfLazyResults } from '../../../js/model/LazyQueryResult/hooks'
 import { LazyQueryResult } from '../../../js/model/LazyQueryResult/LazyQueryResult'
 import Button from '@mui/material/Button'
 import BackgroundInheritingDiv from '../../theme/background-inheriting-div'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
 type Props = {
   selectionInterface: any
 }
@@ -24,8 +25,18 @@ export const ResultsViewContext = React.createContext({
 })
 
 const ResultsView = ({ selectionInterface }: Props) => {
-  const [mode, setMode] = React.useState('card' as ModeType)
+  const { getValue, setValue } = React.useContext(LayoutContext)
+  const [mode, setMode] = React.useState(null)
   const [edit, setEdit] = React.useState(null as null | LazyQueryResult)
+
+  React.useEffect(() => {
+    setMode(getValue('results-mode') || ('card' as ModeType))
+  }, [])
+
+  React.useEffect(() => {
+    mode && setValue('results-mode', mode)
+  }, [mode])
+
   return (
     <ResultsViewContext.Provider value={{ edit, setEdit }}>
       <Grid

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/settings-helper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/settings-helper.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import { StartupDataStore } from '../../../js/model/Startup/startup'
+
+export const getDefaultResultsShownList = () => {
+  if (StartupDataStore.Configuration.getResultShow().length > 0) {
+    return StartupDataStore.Configuration.getResultShow()
+  }
+  return ['title', 'thumbnail']
+}
+
+export const getDefaultResultsShownTable = () => {
+  if (StartupDataStore.Configuration.getDefaultTableColumns().length > 0) {
+    return StartupDataStore.Configuration.getDefaultTableColumns()
+  }
+  return ['title', 'thumbnail']
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table-header.tsx
@@ -22,9 +22,9 @@ import { useSelectionOfLazyResults } from '../../../js/model/LazyQueryResult/hoo
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import IndeterminateCheckBoxIcon from '@mui/icons-material/IndeterminateCheckBox'
-import { TypedUserInstance } from '../../singletons/TypedUser'
-import { useBackbone } from '../../selection-checkbox/useBackbone.hook'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
+import { getDefaultResultsShownTable } from './settings-helper'
 export type Header = {
   hidden: boolean
   id: string
@@ -178,12 +178,15 @@ export const Header = ({
   actionWidth,
   addOnWidth,
 }: HeaderProps) => {
+  const { getValue, onStateChanged } = React.useContext(LayoutContext)
   const MetacardDefinitions = useMetacardDefinitions()
   const handleSortClick = _.debounce(updateSort, 500, true)
   const [shownAttributes, setShownAttributes] = React.useState(
-    TypedUserInstance.getResultsAttributesShownTable()
+    getValue(
+      'results-attributesShownTable',
+      getDefaultResultsShownTable()
+    ) as string[]
   )
-  const { listenTo } = useBackbone()
 
   const [activeIndex, setActiveIndex] = React.useState(null)
 
@@ -255,18 +258,18 @@ export const Header = ({
   }, [activeIndex, mouseMove, mouseUp, removeListeners])
 
   React.useEffect(() => {
-    listenTo(
-      user.get('user').get('preferences'),
-      'change:results-attributesShownTable',
-      () => {
-        setShownAttributes(TypedUserInstance.getResultsAttributesShownTable())
-        columnRefs.current =
-          TypedUserInstance.getResultsAttributesShownTable().map(() =>
-            React.createRef<HTMLDivElement>()
-          )
-      }
-    )
+    onStateChanged(() => {
+      const shownList = getValue(
+        'results-attributesShownTable',
+        getDefaultResultsShownTable()
+      )
+      setShownAttributes(shownList)
+      columnRefs.current = shownList.map(() =>
+        React.createRef<HTMLDivElement>()
+      )
+    })
   }, [])
+
   return (
     <React.Fragment>
       <div

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -37,6 +37,8 @@ import { TypedUserInstance } from '../../singletons/TypedUser'
 import useTimePrefs from '../../fields/useTimePrefs'
 import { useScrollToItemOnSelection } from './result-item.collection'
 import { Memo } from '../../memo/memo'
+import { LayoutContext } from '../../golden-layout/visual-settings.provider'
+import { getDefaultResultsShownTable } from './settings-helper'
 type Props = {
   selectionInterface: any
   mode: any
@@ -94,6 +96,7 @@ export const ResultsCommonControls = ({
   )
 }
 const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
+  const { getValue, setValue } = React.useContext(LayoutContext)
   const lazyResults = useLazyResultsFromSelectionInterface({
     selectionInterface,
   })
@@ -148,18 +151,19 @@ const TableVisual = ({ selectionInterface, mode, setMode }: Props) => {
         >
           <ResultsCommonControls
             getStartingLeft={() => {
-              return TypedUserInstance.getResultsAttributesShownTable()
+              return getValue(
+                'results-attributesShownTable',
+                getDefaultResultsShownTable()
+              )
             }}
             getStartingRight={() => {
-              return TypedUserInstance.getResultsAttributesPossibleTable()
+              return TypedUserInstance.getResultsAttributesPossibleTable(
+                getValue('results-attributesShownTable')
+              )
             }}
-            onSave={(active) => {
-              user
-                .get('user')
-                .get('preferences')
-                .set('results-attributesShownTable', active)
-              user.savePreferences()
-            }}
+            onSave={(active) =>
+              setValue('results-attributesShownTable', active)
+            }
           />
           <Grid item className="pr-2">
             <Button


### PR DESCRIPTION
Saves the settings for the results visual (table vs list, table attributes list, and list attributes list) as a part of the golden layout container state.