### PR TITLE
update and add to the export table and metacard functionality

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/paging.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/paging.tsx
@@ -3,13 +3,16 @@ import { hot } from 'react-hot-loader'
 import Button from '@mui/material/Button'
 import { useBackbone } from '../selection-checkbox/useBackbone.hook'
 import { useLazyResultsStatusFromSelectionInterface } from '../selection-interface/hooks'
-import CloseIcon from '@mui/icons-material/Close'
 import TableExport from '../table-export/table-export'
 import { useDialogState } from '../../component/hooks/useDialogState'
 import Divider from '@mui/material/Divider'
+import { Dialog, DialogActions, DialogTitle } from '@mui/material'
 
 type Props = {
   selectionInterface: any
+  onClose?: any
+  exportSuccessful?: boolean
+  setExportSuccessful?: () => void
 }
 
 const determineIsOutdated = ({ selectionInterface }: Props) => {
@@ -25,6 +28,8 @@ const Paging = ({ selectionInterface }: Props) => {
     selectionInterface,
   })
   const exportDialogState = useDialogState()
+
+  const [exportSuccessful, setExportSuccessful] = React.useState(false)
 
   const [isOutdated, setIsOutdated] = React.useState(
     determineIsOutdated({ selectionInterface })
@@ -80,22 +85,27 @@ const Paging = ({ selectionInterface }: Props) => {
       </Button>
       <exportDialogState.MuiDialogComponents.Dialog
         {...exportDialogState.MuiDialogProps}
+        disableEscapeKeyDown
+        onClose={(event, reason) => {
+          if (reason === 'backdropClick') {
+            return
+          }
+          exportDialogState.MuiDialogProps.onClose(event, reason)
+        }}
       >
         <exportDialogState.MuiDialogComponents.DialogTitle>
           <div className="flex flex-row items-center justify-between flex-nowrap w-full">
             Export Results
-            <Button
-              className="ml-auto"
-              onClick={() => {
-                exportDialogState.handleClose()
-              }}
-            >
-              <CloseIcon />
-            </Button>
           </div>
         </exportDialogState.MuiDialogComponents.DialogTitle>
         <Divider />
-        <TableExport selectionInterface={selectionInterface} />
+        <TableExport
+          selectionInterface={selectionInterface}
+          setExportSuccessful={setExportSuccessful}
+          onClose={() => {
+            exportDialogState.handleClose()
+          }}
+        />
       </exportDialogState.MuiDialogComponents.Dialog>
       <Button
         data-id="export-table-button"
@@ -108,6 +118,29 @@ const Paging = ({ selectionInterface }: Props) => {
       >
         Export
       </Button>
+      {exportSuccessful && (
+        <Dialog open={exportSuccessful}>
+          <DialogTitle>
+            <div className="flex flex-row items-center justify-between flex-nowrap w-full">
+              Export Successful!
+            </div>
+          </DialogTitle>
+          <Divider />
+          <DialogActions>
+            <div
+              className="pt-2"
+              style={{ display: 'flex', justifyContent: 'flex-end' }}
+            >
+              <Button
+                color="primary"
+                onClick={() => setExportSuccessful(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </DialogActions>
+        </Dialog>
+      )}
     </>
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/paging.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/paging.tsx
@@ -102,6 +102,7 @@ const Paging = ({ selectionInterface }: Props) => {
         <TableExport
           selectionInterface={selectionInterface}
           setExportSuccessful={setExportSuccessful}
+          exportSuccessful={exportSuccessful}
           onClose={() => {
             exportDialogState.handleClose()
           }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/index.tsx
@@ -16,5 +16,5 @@ export {
   default as tableExport,
   Props,
   getWarning,
-  getDownloadBody,
+  getExportBody,
 } from './table-export'

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -185,6 +185,7 @@ const TableExports = ({
   selectionInterface,
   onClose,
   setExportSuccessful,
+  exportSuccessful,
 }: Props) => {
   const exportLimit = StartupDataStore.Configuration.getExportLimit()
   const [formats, setFormats] = useState<Option[]>([])
@@ -207,10 +208,7 @@ const TableExports = ({
           response.headers.get('content-disposition')
         ).parameters.filename
         OverridableSaveFile.get()(filename, 'data:' + contentType, data)
-        if (!loading) {
-          onClose()
-          setExportSuccessful(true)
-        }
+        setExportSuccessful(true)
       } else {
         setExportSuccessful(false)
         addSnack('Error: Could not export results.', {
@@ -223,6 +221,10 @@ const TableExports = ({
     } finally {
       setLoading(false)
     }
+  }
+
+  if (exportSuccessful) {
+    onClose()
   }
 
   const exportSizes: Option[] = [
@@ -368,16 +370,12 @@ const TableExports = ({
               customExportCount > exportLimit
             }
             onClick={() => {
-              try {
-                onExportClick(addSnack, {
-                  exportFormat,
-                  exportSize,
-                  customExportCount,
-                  selectionInterface,
-                })
-              } catch (error) {
-                console.error(error)
-              }
+              onExportClick(addSnack, {
+                exportFormat,
+                exportSize,
+                customExportCount,
+                selectionInterface,
+              })
             }}
           >
             Export

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -18,7 +18,6 @@ import { useEffect, useState } from 'react'
 import contentDisposition from 'content-disposition'
 import LinearProgress from '@mui/material/LinearProgress'
 import Button from '@mui/material/Button'
-import GetAppIcon from '@mui/icons-material/GetApp'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import useSnack from '../hooks/useSnack'
@@ -30,7 +29,7 @@ import {
   OverridableGetColumnOrder,
   exportResultSet,
   ExportCountInfo,
-  DownloadInfo,
+  ExportInfo,
   ExportFormat,
 } from '../../react-component/utils/export'
 import user from '../../component/singletons/user-instance'
@@ -39,9 +38,16 @@ import { DEFAULT_USER_QUERY_OPTIONS } from '../../js/model/TypedQuery'
 import { getResultSetCql } from '../../react-component/utils/cql'
 import SummaryManageAttributes from '../../react-component/summary-manage-attributes/summary-manage-attributes'
 import { OverridableSaveFile } from '../../react-component/utils/save-file/save-file'
+import ProgressButton from '../../react-component/progress-button/progress-button'
+import DialogContent from '@mui/material/DialogContent/DialogContent'
+import DialogActions from '@mui/material/DialogActions/DialogActions'
+import DialogContentText from '@mui/material/DialogContentText'
 
 export type Props = {
   selectionInterface: any
+  onClose?: any
+  exportSuccessful?: boolean
+  setExportSuccessful?: any
 }
 
 type Source = {
@@ -123,8 +129,8 @@ export const getWarning = (exportCountInfo: ExportCountInfo): string => {
   return warningMessage
 }
 
-export const getDownloadBody = async (downloadInfo: DownloadInfo) => {
-  const { exportSize, customExportCount, selectionInterface } = downloadInfo
+export const getExportBody = async (ExportInfo: ExportInfo) => {
+  const { exportSize, customExportCount, selectionInterface } = ExportInfo
   const exportResultLimit = StartupDataStore.Configuration.getExportLimit()
   const hiddenFields = getHiddenFields()
   const columnOrder = OverridableGetColumnOrder.get()()
@@ -151,7 +157,7 @@ export const getDownloadBody = async (downloadInfo: DownloadInfo) => {
     originalFilterTree: query.get('filterTree'),
     queryRef: query,
   })
-  if (downloadInfo.exportSize !== 'all') {
+  if (ExportInfo.exportSize !== 'all') {
     queryCount = pageSize
     cql = getResultSetCql(results)
   }
@@ -175,38 +181,49 @@ export const getDownloadBody = async (downloadInfo: DownloadInfo) => {
   }
 }
 
-const onDownloadClick = async (
-  addSnack: AddSnack,
-  downloadInfo: DownloadInfo
-) => {
-  const exportFormat = encodeURIComponent(downloadInfo.exportFormat)
-  try {
-    const body = await getDownloadBody(downloadInfo)
-    const response = await exportResultSet(exportFormat, body)
-    if (response.status === 200) {
-      const data = await response.blob()
-      const contentType = response.headers.get('content-type')
-      const filename = contentDisposition.parse(
-        response.headers.get('content-disposition')
-      ).parameters.filename
-      OverridableSaveFile.get()(filename, 'data:' + contentType, data)
-    } else {
-      addSnack('Error: Could not export results.', {
-        alertProps: { severity: 'error' },
-      })
-    }
-  } catch (error) {
-    console.error(error)
-  }
-}
-
-const TableExports = ({ selectionInterface }: Props) => {
+const TableExports = ({
+  selectionInterface,
+  onClose,
+  setExportSuccessful,
+}: Props) => {
   const exportLimit = StartupDataStore.Configuration.getExportLimit()
   const [formats, setFormats] = useState<Option[]>([])
   const [exportFormat, setExportFormat] = useState('')
   const [exportSize, setExportSize] = useState('all')
   const [warning, setWarning] = useState('')
   const [customExportCount, setCustomExportCount] = useState(exportLimit)
+  const [loading, setLoading] = useState(false)
+
+  const onExportClick = async (addSnack: AddSnack, ExportInfo: ExportInfo) => {
+    const exportFormat = encodeURIComponent(ExportInfo.exportFormat)
+    try {
+      setLoading(true)
+      const body = await getExportBody(ExportInfo)
+      const response = await exportResultSet(exportFormat, body)
+      if (response.status === 200) {
+        const data = await response.blob()
+        const contentType = response.headers.get('content-type')
+        const filename = contentDisposition.parse(
+          response.headers.get('content-disposition')
+        ).parameters.filename
+        OverridableSaveFile.get()(filename, 'data:' + contentType, data)
+        if (!loading) {
+          onClose()
+          setExportSuccessful(true)
+        }
+      } else {
+        setExportSuccessful(false)
+        addSnack('Error: Could not export results.', {
+          alertProps: { severity: 'error' },
+        })
+      }
+    } catch (error) {
+      console.error(error)
+      setExportSuccessful(false)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   const exportSizes: Option[] = [
     {
@@ -253,90 +270,121 @@ const TableExports = ({ selectionInterface }: Props) => {
   return formats.length === 0 ? (
     <LinearProgress className="w-full h-2" />
   ) : (
-    <div className="p-4" style={{ minWidth: '400px' }}>
-      <div className="pt-2">
-        <Autocomplete
-          size="small"
-          options={exportSizes}
-          onChange={(_e: any, newValue) => {
-            setExportSize(newValue.value)
-          }}
-          isOptionEqualToValue={(option) => option.value === exportSize}
-          getOptionLabel={(option) => {
-            return option.label
-          }}
-          disableClearable
-          value={exportSizes.find((choice) => choice.value === exportSize)}
-          renderInput={(params) => (
-            <TextField {...params} label="Export" variant="outlined" />
-          )}
-        />
-      </div>
-      {exportSize === 'custom' ? (
-        <div className="pt-2">
-          <TextField
-            fullWidth
-            size="small"
-            type="number"
-            label=""
-            placeholder="Enter number of results you would like to export"
-            name="customExport"
-            value={customExportCount}
-            onChange={(e) => {
-              setCustomExportCount(Number(e.target.value))
-            }}
-            variant="outlined"
-          />
-        </div>
-      ) : (
-        <div />
-      )}
-      <div className="pt-2 export-format">
-        <Autocomplete
-          size="small"
-          options={formats}
-          onChange={(_e: any, newValue) => {
-            setExportFormat(newValue.value)
-          }}
-          isOptionEqualToValue={(option) => option.value === exportFormat}
-          getOptionLabel={(option) => {
-            return option.label
-          }}
-          disableClearable
-          value={formats.find((choice) => choice.value === exportFormat)}
-          renderInput={(params) => (
-            <TextField {...params} label="as" variant="outlined" />
-          )}
-        />
-      </div>
-      {['csv', 'rtf', 'xlsx'].includes(exportFormat) ? (
-        <SummaryManageAttributes isExport={true} />
-      ) : null}
-      {warning && (
-        <div className="warning text-center pt-1">
-          <i className="fa fa-warning" />
-          <span>{warning}</span>
-        </div>
-      )}
-      <div className="pt-2">
-        <Button
-          fullWidth
-          variant="contained"
-          color="primary"
-          disabled={exportSize === 'custom' && customExportCount > exportLimit}
-          onClick={() =>
-            onDownloadClick(addSnack, {
-              exportFormat,
-              exportSize,
-              customExportCount,
-              selectionInterface,
-            })
-          }
+    <>
+      <DialogContent>
+        <DialogContentText>
+          <div className="p-4" style={{ minWidth: '400px' }}>
+            <div className="pt-2">
+              <Autocomplete
+                size="small"
+                options={exportSizes}
+                onChange={(_e: any, newValue) => {
+                  setExportSize(newValue.value)
+                }}
+                isOptionEqualToValue={(option) => option.value === exportSize}
+                getOptionLabel={(option) => {
+                  return option.label
+                }}
+                disableClearable
+                value={exportSizes.find(
+                  (choice) => choice.value === exportSize
+                )}
+                renderInput={(params) => (
+                  <TextField {...params} label="Export" variant="outlined" />
+                )}
+              />
+            </div>
+            {exportSize === 'custom' ? (
+              <div className="pt-2">
+                <TextField
+                  fullWidth
+                  size="small"
+                  type="number"
+                  label=""
+                  placeholder="Enter number of results you would like to export"
+                  name="customExport"
+                  value={customExportCount}
+                  onChange={(e) => {
+                    setCustomExportCount(Number(e.target.value))
+                  }}
+                  variant="outlined"
+                />
+              </div>
+            ) : (
+              <div />
+            )}
+            <div className="pt-2 export-format">
+              <Autocomplete
+                size="small"
+                options={formats}
+                onChange={(_e: any, newValue) => {
+                  setExportFormat(newValue.value)
+                }}
+                isOptionEqualToValue={(option) => option.value === exportFormat}
+                getOptionLabel={(option) => {
+                  return option.label
+                }}
+                disableClearable
+                value={formats.find((choice) => choice.value === exportFormat)}
+                renderInput={(params) => (
+                  <TextField {...params} label="as" variant="outlined" />
+                )}
+              />
+            </div>
+            {['csv', 'rtf', 'xlsx'].includes(exportFormat) ? (
+              <SummaryManageAttributes isExport={true} />
+            ) : null}
+            {warning && (
+              <div className="warning text-center pt-1">
+                <i className="fa fa-warning" />
+                <span>{warning}</span>
+              </div>
+            )}
+          </div>
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <div
+          className="pt-2"
+          style={{ display: 'flex', justifyContent: 'flex-end' }}
         >
-          <GetAppIcon /> Download
-        </Button>
-      </div>
-    </div>
+          <Button
+            className="mr-2"
+            disabled={loading}
+            variant="text"
+            onClick={() => {
+              onClose()
+            }}
+          >
+            Cancel
+          </Button>
+          <ProgressButton
+            variant="contained"
+            color="primary"
+            loading={loading}
+            disabled={
+              loading &&
+              exportSize === 'custom' &&
+              customExportCount > exportLimit
+            }
+            onClick={() => {
+              try {
+                onExportClick(addSnack, {
+                  exportFormat,
+                  exportSize,
+                  customExportCount,
+                  selectionInterface,
+                })
+              } catch (error) {
+                console.error(error)
+              }
+            }}
+          >
+            Export
+          </ProgressButton>
+        </div>
+      </DialogActions>
+    </>
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
@@ -20,11 +20,13 @@ import { hot } from 'react-hot-loader'
 import { getExportResults } from '../utils/export/export'
 import { useDialogState } from '../../component/hooks/useDialogState'
 import Button from '@mui/material/Button'
-import CloseIcon from '@mui/icons-material/Close'
 import Divider from '@mui/material/Divider'
+import { Dialog, DialogActions, DialogTitle } from '@mui/material'
 
 export const ExportActions = (props: MetacardInteractionProps) => {
+  const [exportSuccessful, setExportSuccessful] = React.useState(false)
   const exportDialogState = useDialogState()
+
   if (!props.model || props.model.length <= 0) {
     return null
   }
@@ -35,26 +37,54 @@ export const ExportActions = (props: MetacardInteractionProps) => {
     <>
       <exportDialogState.MuiDialogComponents.Dialog
         {...exportDialogState.MuiDialogProps}
+        disableEscapeKeyDown
+        onClose={(event, reason) => {
+          if (reason === 'backdropClick') {
+            return
+          }
+          exportDialogState.MuiDialogProps.onClose(event, reason)
+        }}
       >
         <exportDialogState.MuiDialogComponents.DialogTitle>
           <div className="flex flex-row items-center justify-between flex-nowrap w-full">
-            Export Results
-            <Button
-              className="ml-auto"
-              onClick={() => {
-                exportDialogState.handleClose()
-              }}
-            >
-              <CloseIcon />
-            </Button>
+            Export
           </div>
         </exportDialogState.MuiDialogComponents.DialogTitle>
         <Divider></Divider>
         <ResultsExport
           results={getExportResults(props.model)}
           lazyQueryResults={props.model[0].parent}
+          setExportSuccessful={setExportSuccessful}
+          onClose={() => {
+            exportDialogState.handleClose()
+          }}
         />
       </exportDialogState.MuiDialogComponents.Dialog>
+
+      {exportSuccessful && (
+        <Dialog open={exportSuccessful}>
+          <DialogTitle>
+            <div className="flex flex-row items-center justify-between flex-nowrap w-full">
+              Export Successful!
+            </div>
+          </DialogTitle>
+          <Divider />
+          <DialogActions>
+            <div
+              className="pt-2"
+              style={{ display: 'flex', justifyContent: 'flex-end' }}
+            >
+              <Button
+                color="primary"
+                onClick={() => setExportSuccessful(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </DialogActions>
+        </Dialog>
+      )}
+
       <MetacardInteraction
         onClick={() => {
           props.onClose()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/export-interaction.tsx
@@ -25,6 +25,7 @@ import { Dialog, DialogActions, DialogTitle } from '@mui/material'
 
 export const ExportActions = (props: MetacardInteractionProps) => {
   const [exportSuccessful, setExportSuccessful] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
   const exportDialogState = useDialogState()
 
   if (!props.model || props.model.length <= 0) {
@@ -55,6 +56,9 @@ export const ExportActions = (props: MetacardInteractionProps) => {
           results={getExportResults(props.model)}
           lazyQueryResults={props.model[0].parent}
           setExportSuccessful={setExportSuccessful}
+          exportSuccessful={exportSuccessful}
+          setLoading={setLoading}
+          loading={loading}
           onClose={() => {
             exportDialogState.handleClose()
           }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -29,6 +29,7 @@ import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResult
 import contentDisposition from 'content-disposition'
 import { StartupDataStore } from '../../js/model/Startup/startup'
 import { OverridableSaveFile } from '../utils/save-file/save-file'
+import { AddSnack } from '../../component/snack/snack.provider'
 
 type Result = {
   id: string
@@ -40,22 +41,36 @@ type Props = {
   results: Result[]
   lazyQueryResults: LazyQueryResults
   isZipped?: boolean
+  onClose?: any
+  exportSuccessful?: boolean
+  setExportSuccessful?: any
+  setLoading?: any
 } & WithBackboneProps
 
 type State = {
-  downloadDisabled: boolean
+  exportDisabled: boolean
   selectedFormat: string
   exportFormats: ExportFormat[]
+  loading?: boolean
+  exportSuccessful?: boolean
 }
 
 class ResultsExport extends React.Component<Props, State> {
+  setExportSuccessful: any
+  onClose: any
+  setLoading: any
   constructor(props: Props) {
     super(props)
     this.state = {
       selectedFormat: 'Binary Resource',
       exportFormats: [],
-      downloadDisabled: true,
+      exportDisabled: true,
+      loading: false,
+      exportSuccessful: false,
     }
+    this.onClose = props.onClose
+    this.setExportSuccessful = props.setExportSuccessful
+    this.setLoading = props.setLoading
   }
 
   componentDidUpdate(_prevProps: Props) {
@@ -66,7 +81,7 @@ class ResultsExport extends React.Component<Props, State> {
       this.fetchExportOptions()
       this.setState({
         selectedFormat: 'Binary Resource',
-        downloadDisabled: true,
+        exportDisabled: true,
       })
     }
   }
@@ -109,7 +124,7 @@ class ResultsExport extends React.Component<Props, State> {
     return undefined
   }
 
-  async onDownloadClick() {
+  onExportClick = async (addSnack: AddSnack) => {
     const uriEncodedTransformerId = this.getSelectedExportFormatId()
 
     if (uriEncodedTransformerId === undefined) {
@@ -155,19 +170,34 @@ class ResultsExport extends React.Component<Props, State> {
       })
     }
 
-    if (response.status === 200) {
-      const filename = contentDisposition.parse(
-        response.headers.get('content-disposition')
-      ).parameters.filename
-      const contentType = response.headers.get('content-type')
-      const data = await response.blob()
-      OverridableSaveFile.get()(filename, 'data:' + contentType, data)
+    try {
+      if (response.status === 200) {
+        const filename = contentDisposition.parse(
+          response.headers.get('content-disposition')
+        ).parameters.filename
+        const contentType = response.headers.get('content-type')
+        const data = await response.blob()
+        OverridableSaveFile.get()(filename, 'data:' + contentType, data)
+        if (this.state.loading === false) {
+          this.onClose()
+          this.setExportSuccessful(true)
+        }
+      } else {
+        this.setExportSuccessful(false)
+        addSnack('Error: Could not export results.', {
+          alertProps: { severity: 'error' },
+        })
+      }
+    } catch (error) {
+      console.error(error)
+      this.setExportSuccessful(false)
     }
   }
+
   handleExportOptionChange(name: string) {
     this.setState({
       selectedFormat: name,
-      downloadDisabled: false,
+      exportDisabled: false,
     })
   }
   render() {
@@ -175,9 +205,13 @@ class ResultsExport extends React.Component<Props, State> {
       <ResultsExportComponent
         selectedFormat={this.state.selectedFormat}
         exportFormats={this.state.exportFormats}
-        downloadDisabled={this.state.downloadDisabled}
-        onDownloadClick={this.onDownloadClick.bind(this)}
+        exportDisabled={this.state.exportDisabled}
+        onExportClick={this.onExportClick.bind(this)}
         handleExportOptionChange={this.handleExportOptionChange.bind(this)}
+        onClose={this.onClose.bind(this)}
+        loading={this.state.loading}
+        exportSuccessful={this.state.exportSuccessful}
+        setExportSuccessful={this.setExportSuccessful.bind(this)}
       />
     )
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
@@ -19,7 +19,7 @@ import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import SummaryManageAttributes from '../summary-manage-attributes/summary-manage-attributes'
 import ProgressButton from '../progress-button'
-import { DialogActions, DialogContent } from '@mui/material'
+import { DialogActions, DialogContent, LinearProgress } from '@mui/material'
 import useSnack from '../../component/hooks/useSnack'
 import { AddSnack } from '../../component/snack/snack.provider'
 
@@ -47,6 +47,7 @@ const ResultsExportComponent = ({
   exportDisabled,
   onExportClick,
   handleExportOptionChange,
+  exportSuccessful,
   onClose,
   loading,
 }: Props) => {
@@ -55,7 +56,13 @@ const ResultsExportComponent = ({
     handleExportOptionChange(exportFormats[0]?.displayName)
   }, [exportFormats])
 
-  return (
+  if (exportSuccessful) {
+    onClose()
+  }
+
+  return exportFormats.length === 0 ? (
+    <LinearProgress className="w-full h-2" />
+  ) : (
     <>
       <DialogContent>
         <div className="p-4" style={{ minWidth: '400px' }}>
@@ -110,7 +117,9 @@ const ResultsExportComponent = ({
             color="primary"
             data-id="export-button"
             disabled={exportDisabled}
-            onClick={() => onExportClick(addSnack)}
+            onClick={() => {
+              onExportClick(addSnack)
+            }}
             loading={loading}
           >
             Export

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/results-export/presentation.tsx
@@ -15,77 +15,109 @@
 import * as React from 'react'
 import { hot } from 'react-hot-loader'
 import Button from '@mui/material/Button'
-import GetAppIcon from '@mui/icons-material/GetApp'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import SummaryManageAttributes from '../summary-manage-attributes/summary-manage-attributes'
+import ProgressButton from '../progress-button'
+import { DialogActions, DialogContent } from '@mui/material'
+import useSnack from '../../component/hooks/useSnack'
+import { AddSnack } from '../../component/snack/snack.provider'
 
 type ExportFormat = {
   id: string
   displayName: string
 }
 
-type Props = {
+export type Props = {
   selectedFormat: string
   exportFormats: ExportFormat[]
-  downloadDisabled: boolean
-  onDownloadClick: () => void
+  exportDisabled: boolean
+  onExportClick: (addSnack: AddSnack) => void
   handleExportOptionChange: (val: string) => void
+  loading?: boolean
+  setLoading?: any
+  onClose?: any
+  exportSuccessful?: boolean
+  setExportSuccessful?: any
 }
 
-const ResultsExportComponent = (props: Props) => {
-  const {
-    selectedFormat,
-    exportFormats,
-    downloadDisabled,
-    onDownloadClick,
-    handleExportOptionChange,
-  } = props
-
+const ResultsExportComponent = ({
+  selectedFormat,
+  exportFormats,
+  exportDisabled,
+  onExportClick,
+  handleExportOptionChange,
+  onClose,
+  loading,
+}: Props) => {
+  const addSnack = useSnack()
   React.useEffect(() => {
     handleExportOptionChange(exportFormats[0]?.displayName)
   }, [exportFormats])
 
   return (
-    <div className="p-4" style={{ minWidth: '400px' }}>
-      <div data-id="export-format-select" className="export-option">
-        <Autocomplete
-          key={JSON.stringify(exportFormats)}
-          data-id="filter-type-autocomplete"
-          fullWidth
-          size="small"
-          options={exportFormats}
-          getOptionLabel={(option) => option.displayName}
-          isOptionEqualToValue={(option, value) =>
-            option.displayName === value.displayName
-          }
-          onChange={(_e, newValue) => {
-            handleExportOptionChange(newValue.displayName)
-          }}
-          disableClearable
-          value={
-            exportFormats.find(
-              (format) => format.displayName === selectedFormat
-            ) || exportFormats[0]
-          }
-          renderInput={(params) => <TextField {...params} variant="outlined" />}
-        />
-      </div>
-      {['CSV', 'RTF', 'XLSX'].includes(selectedFormat) ? (
-        <SummaryManageAttributes isExport={true} />
-      ) : null}
-      <Button
-        variant="contained"
-        color="primary"
-        data-id="download-export-button"
-        disabled={downloadDisabled}
-        onClick={onDownloadClick}
-        className="mt-3"
-        fullWidth
-      >
-        <GetAppIcon /> Download
-      </Button>
-    </div>
+    <>
+      <DialogContent>
+        <div className="p-4" style={{ minWidth: '400px' }}>
+          <div data-id="export-format-select" className="export-option">
+            <Autocomplete
+              key={JSON.stringify(exportFormats)}
+              data-id="filter-type-autocomplete"
+              fullWidth
+              size="small"
+              options={exportFormats}
+              getOptionLabel={(option) => option.displayName}
+              isOptionEqualToValue={(option, value) =>
+                option.displayName === value.displayName
+              }
+              onChange={(_e, newValue) => {
+                handleExportOptionChange(newValue.displayName)
+              }}
+              disableClearable
+              value={
+                exportFormats.find(
+                  (format) => format.displayName === selectedFormat
+                ) || exportFormats[0]
+              }
+              renderInput={(params) => (
+                <TextField {...params} variant="outlined" />
+              )}
+            />
+          </div>
+
+          {['CSV', 'RTF', 'XLSX'].includes(selectedFormat) ? (
+            <SummaryManageAttributes isExport={true} />
+          ) : null}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <div
+          className="pt-2"
+          style={{ display: 'flex', justifyContent: 'flex-end' }}
+        >
+          <Button
+            className="mr-2"
+            disabled={loading}
+            variant="text"
+            onClick={() => {
+              onClose()
+            }}
+          >
+            Cancel
+          </Button>
+          <ProgressButton
+            variant="contained"
+            color="primary"
+            data-id="export-button"
+            disabled={exportDisabled}
+            onClick={() => onExportClick(addSnack)}
+            loading={loading}
+          >
+            Export
+          </ProgressButton>
+        </div>
+      </DialogActions>
+    </>
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -49,7 +49,7 @@ export interface ExportCountInfo {
   customExportCount: number
 }
 
-export type DownloadInfo = {
+export type ExportInfo = {
   exportFormat: string
   exportSize: string
   customExportCount: number

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/index.tsx
@@ -19,7 +19,7 @@ export {
   Transformer,
   ResultSet,
   ExportCountInfo,
-  DownloadInfo,
+  ExportInfo,
   OverridableGetColumnOrder,
   getColumnOrder,
   aliasMap,


### PR DESCRIPTION
Changes:

**Table export and individual metacard export**

- Download button -> Separates to `export button` and `cancel button`
- Removes `[x] close button` at the top right -> Replaces by the `cancel button`
- Uses `ProgressButton` for `export button` -> Provides user with a progress status indicator when waiting for downloads that take longer and while this is happening, `cancel button` will be disabled and user cannot click outside to close dialog.
- After a successful completion of export -> user is prompt with `export successful dialog` with a `close button`. This `export successful dialog` will be persistent to satisfy use case of "user wants to leave the action running while they're doing other things e.g "navigating to other tabs" then come back to see a successful message". Note* the `export successful dialog` will show **after** the export is finished performing on DDF-UI side. After that, the browser will prompt user to save/cancel to their local system.
- After export failure -> User is prompt with an `error snack bar` and given the option to try export again

----
Test steps:

**Successful download**
1. Upload 10 or so products
2. Search for the products
3. If testing **table exports**, select `export button`. If testing **metacard export**, select `vertical ellipsis` to open drop down, and then select `export as` -> `export dialog` will display. Verify removal of `[x] close button` and added `export button` and `cancel button`
4. Leave default dropdown selections -> Export: all results **as** preview html
5. Select export -> Verify you see `export button` has a loading effect (that is the `ProgressButton`)
6. Browser's saving dialog will display. select save -> Browser will close. Verify that you see `export successful dialog`
7. Close `export successful dialog`


**Failed download for metacard export**
1. Using a product that doesn't have a thumbnail, select `vertical ellipsis` to open drop down, and then select `export as` -> `export dialog` will display.
2. Change format to `thumbnail`
3. Select `export button` -> An error snackbar will display. the dialog will remain to let the user try to export again

might be hard to see metarcard export's progress bar / linear bar so here are some screenshots

<img width="1062" alt="Screenshot 2024-06-06 at 10 37 10 AM" src="https://github.com/codice/ddf-ui/assets/58529232/1dac7c78-cc4c-4980-b660-81b75c3d5aae">
<img width="1163" alt="Screenshot 2024-06-06 at 10 36 53 AM" src="https://github.com/codice/ddf-ui/assets/58529232/c41ac26f-5d44-4d94-9a3b-2fee00688e86">


----
----
**Failed download for table export**
1. Search for a query that will return 0 results
2. Select `current page` in `export dropdown`
3. Select `export button` -> An error snackbar will display. the dialog will remain to let the user try to export again
Note* Users can still export successfully using `all results` in `export dropdown` even with 0 results. This probably should be re-worked in a later bug ticket

----
**testing both cases video**

https://github.com/codice/ddf-ui/assets/58529232/ddffe86b-a1ac-4e0f-91e2-96912c99298f



