### PR TITLE
Keep Exisiting Shapes In 3D Map While Drawing a New Shape

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
@@ -18,7 +18,7 @@ import Cesium from 'cesium/Build/Cesium/Cesium'
 import _ from 'underscore'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing } from './drawing-and-display'
+import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
 import DistanceUtils from '../../../../js/DistanceUtils'
@@ -150,7 +150,7 @@ const drawGeometry = ({
     }
   }
 
-  removeOldDrawing({ map, id })
+  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   let primitive
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
@@ -20,7 +20,7 @@ import _ from 'underscore'
 import * as Turf from '@turf/turf'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing } from './drawing-and-display'
+import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import TurfCircle from '@turf/circle'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
@@ -134,7 +134,7 @@ const drawGeometry = ({
     modelProp.lat += translation.latitude
   }
 
-  removeOldDrawing({ map, id })
+  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   let primitive
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -61,6 +61,39 @@ export const removeOldDrawing = ({ map, id }: { map: any; id: string }) => {
   relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
 }
 
+const makeOldShapeNonEditable = ({ map, id }: { map: any; id: string }) => {
+  const relevantPrimitives = map
+    .getMap()
+    .scene.primitives._primitives.filter((prim: any) => {
+      return prim.id === id
+    })
+  relevantPrimitives.forEach((relevantPrimitive: any) => {
+    if (typeof relevantPrimitive.setEditMode === 'function') {
+      relevantPrimitive.setEditMode(false)
+    }
+    if (typeof relevantPrimitive.setEditable === 'function') {
+      relevantPrimitive.setEditable(false)
+    }
+  })
+  relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
+}
+
+export const removeOrLockOldDrawing = (
+  isInteractive: boolean,
+  id: any,
+  map: any,
+  model: any
+) => {
+  if (
+    isInteractive ||
+    (!isInteractive && Object.keys(model.changed).includes('isInteractive'))
+  ) {
+    removeOldDrawing({ map, id })
+  } else {
+    makeOldShapeNonEditable({ map, id })
+  }
+}
+
 let drawingLocation: any
 
 const updateDrawingLocation = (newDrawingLocation: any) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -80,7 +80,7 @@ const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
 
 const nestedArraysOverlap = (arrayA: any[], arrayB: any[]) => {
   let result = false
-  arrayA.map((elemA) => {
+  return arrayA.some((elemA) => arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB)))
     result =
       result ||
       arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB))

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -79,7 +79,9 @@ const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
 }
 
 const nestedArraysOverlap = (arrayA: any[], arrayB: any[]) => {
-  return arrayA.some((elemA) => arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB)))
+  return arrayA.some((elemA) =>
+    arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB))
+  )
 }
 
 const isNewShape = (model: any) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -61,7 +61,7 @@ export const removeOldDrawing = ({ map, id }: { map: any; id: string }) => {
   relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
 }
 
-const makeOldShapeNonEditable = ({ map, id }: { map: any; id: string }) => {
+const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
   const relevantPrimitives = map
     .getMap()
     .scene.primitives._primitives.filter((prim: any) => {
@@ -78,19 +78,103 @@ const makeOldShapeNonEditable = ({ map, id }: { map: any; id: string }) => {
   relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
 }
 
+const nestedArraysOverlap = (arrayA: any[], arrayB: any[]) => {
+  let result = false
+  arrayA.map((elemA) => {
+    result =
+      result ||
+      arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB))
+  })
+  return result
+}
+
+const isNewShape = (model: any) => {
+  const mode = model.get('mode')
+  switch (mode) {
+    case 'bbox':
+      const box = {
+        north: model.get('north'),
+        east: model.get('east'),
+        west: model.get('west'),
+        south: model.get('south'),
+      }
+      let prevModel = model.previousAttributes()
+      if (box.north && prevModel) {
+        const prevBox = {
+          north: prevModel['north'],
+          east: prevModel['east'],
+          west: prevModel['west'],
+          south: prevModel['south'],
+        }
+        if (prevBox.north) {
+          return !(
+            box.north === prevBox.north ||
+            box.east === prevBox.east ||
+            box.west === prevBox.west ||
+            box.south === prevBox.south
+          )
+        }
+      }
+    case 'circle':
+      const circle = { lon: model.get('lon'), lat: model.get('lat') }
+      prevModel = model.previousAttributes()
+      if (circle && prevModel) {
+        const prevCircle = { lon: prevModel['lon'], lat: prevModel['lat'] }
+        if (prevCircle.lat && prevCircle.lon) {
+          return !(
+            circle.lat === prevCircle.lat || circle.lon === prevCircle.lon
+          )
+        }
+      }
+    case 'line':
+      const line = model.get('line')
+      prevModel = model.previousAttributes()
+      if (line && prevModel) {
+        const prevLine = prevModel['line']
+        if (prevLine) {
+          return !nestedArraysOverlap(line, prevLine)
+        }
+      }
+    case 'poly':
+      const poly = model.get('polygon')
+      prevModel = model.previousAttributes()
+      if (prevModel) {
+        const prevPoly = prevModel['polygon']
+        if (prevPoly) {
+          return !nestedArraysOverlap(poly, prevPoly)
+        }
+      }
+    default:
+      return false
+  }
+}
+
 export const removeOrLockOldDrawing = (
   isInteractive: boolean,
   id: any,
   map: any,
   model: any
 ) => {
+  const canChange = [
+    'isInteractive',
+    'polygonBufferWidth',
+    'lineWidth',
+    'line',
+    'polygon',
+    'usng',
+    'bbox',
+  ]
+
+  // remove previous shape from map after updating attributes, dragging shape, or exiting interactive mode
   if (
     isInteractive ||
-    (!isInteractive && Object.keys(model.changed).includes('isInteractive'))
+    (!isInteractive &&
+      Object.keys(model.changed).some((change) => canChange.includes(change)) &&
+      !isNewShape(model))
   ) {
     removeOldDrawing({ map, id })
   } else {
-    makeOldShapeNonEditable({ map, id })
+    makeOldDrawingNonEditable({ map, id })
   }
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -79,13 +79,7 @@ const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
 }
 
 const nestedArraysOverlap = (arrayA: any[], arrayB: any[]) => {
-  let result = false
   return arrayA.some((elemA) => arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB)))
-    result =
-      result ||
-      arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB))
-  })
-  return result
 }
 
 const isNewShape = (model: any) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
@@ -22,7 +22,7 @@ import * as Turf from '@turf/turf'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing } from './drawing-and-display'
+import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
 import utility from './utility'
@@ -233,7 +233,7 @@ const drawGeometry = ({
   const cameraMagnitude = map.getMap().camera.getMagnitude()
   setDrawnMagnitude(cameraMagnitude)
 
-  removeOldDrawing({ map, id })
+  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   let primitive
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
@@ -19,7 +19,7 @@ import Cesium from 'cesium/Build/Cesium/Cesium'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing } from './drawing-and-display'
+import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
 import ShapeUtils from '../../../../js/ShapeUtils'
 import {
   constructSolidLinePrimitive,
@@ -140,7 +140,7 @@ const drawGeometry = ({
   const cameraMagnitude = map.getMap().camera.getMagnitude()
   setDrawnMagnitude(cameraMagnitude)
 
-  removeOldDrawing({ map, id })
+  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   const buffer = DistanceUtils.getDistanceInMeters(
     json.polygonBufferWidth,


### PR DESCRIPTION
In order to align the behaviors of the 2D and 3D maps, while in draw mode, the old shapes in a 3D map will now remain on the map until the user applies or cancels the changes.