### PR TITLE
Fallback to user preferences for 2D map settings

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-settings.provider.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/visual-settings.provider.tsx
@@ -19,6 +19,7 @@ type LayoutContextType = {
   setValue: (key: string, value: any) => void
   onStateChanged: (callback: () => void) => void
   visualTitle: string
+  hasLayoutContext: boolean
 }
 
 export const LayoutContext = React.createContext<LayoutContextType>({
@@ -26,6 +27,7 @@ export const LayoutContext = React.createContext<LayoutContextType>({
   setValue: () => {},
   onStateChanged: (callback: () => void) => callback(),
   visualTitle: '',
+  hasLayoutContext: false,
 })
 
 type VisualSettingsProviderProps = {
@@ -61,6 +63,7 @@ export const VisualSettingsProvider = (props: VisualSettingsProviderProps) => {
         setValue: setVisualSettingValue,
         onStateChanged: onVisualSettingChangedListener,
         visualTitle: container.title,
+        hasLayoutContext: true,
       }}
     >
       {children}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/settings-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/settings-helpers.tsx
@@ -37,6 +37,6 @@ export const getDefaultResultsShownTable = () => {
   return ['title', 'thumbnail']
 }
 
-export const getDefaultCoordinateFormat = () => {
+export const getUserCoordinateFormat = () => {
   return TypedUserInstance.getCoordinateFormat()
 }


### PR DESCRIPTION
Fall back to user preferences to store map layers and coordinate format settings for the 2D map when it is not in the context of a layout. This allows the openlayers map component to be used outside the context of a golden layout.