### PR TITLE
Various fixes for golden layout, particularly detecting changes / popouts working correctly, and componentState (individual visual settings)

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -132,7 +132,6 @@
     "react-window-components": "0.0.7",
     "re-resizable": "6.1.0",
     "rpc-websockets": "7.5.1",
-    "sanitize-html": "1.15.0",
     "scroll-into-view-if-needed": "^2.2.25",
     "sortablejs": "1.4.2",
     "styled-components": "5.3.10",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/base-app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/base-app.tsx
@@ -29,6 +29,42 @@ import Restore from '../pages/restore'
 import Create from '../pages/create'
 import AddIcon from '@mui/icons-material/Add'
 import ViewListIcon from '@mui/icons-material/ViewList'
+import { GoldenLayoutViewReact } from '../golden-layout/golden-layout.view'
+import selectionInterfaceModel from '../selection-interface/selection-interface.model'
+import { Query } from '../../js/model/TypedQuery'
+
+/**
+ * The issue with the original golden layout code for popout is that it will go to the current route and then load gl and all that.
+ *
+ * However, usually there are things on the route we don't want to run (for performance sometimes, and for other times because they reset prefs or whatnot to clear things)
+ *
+ * As a result, we have this route that is just for the popout, it doesn't show in the nav, and it doesn't run the other things on the route
+ *
+ * We have to have an instance of golden layout for the popout to attach to, which this provides, with a query that's blank (just so we can transfer results and what not to it)
+ */
+export const GoldenLayoutPopoutRoute: IndividualRouteType = {
+  routeProps: {
+    path: '/_gl_popout',
+    children: () => {
+      const baseQuery = Query()
+      return (
+        <div className="w-full h-full pb-2 pt-2 pr-2">
+          <Paper elevation={Elevations.panels} className="w-full h-full">
+            <GoldenLayoutViewReact
+              selectionInterface={
+                new selectionInterfaceModel({ currentQuery: baseQuery })
+              }
+              setGoldenLayout={() => {}}
+              configName="goldenLayout"
+            />
+          </Paper>
+        </div>
+      )
+    },
+  },
+  showInNav: false,
+}
+
 const RouteInformation: IndividualRouteType[] = [
   {
     showInNav: false,
@@ -279,6 +315,7 @@ const RouteInformation: IndividualRouteType[] = [
     },
     showInNav: true,
   },
+  GoldenLayoutPopoutRoute,
 ]
 
 /**

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.events.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.events.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { LayoutConfig } from './golden-layout.types'
+
+export const goldenLayoutChangeEventName = 'golden layout change'
+
+export type GoldenLayoutChangeEventType = CustomEvent<{
+  value: LayoutConfig
+  goldenLayout: any
+}>
+
+export const dispatchGoldenLayoutChangeEvent = (
+  target: HTMLElement,
+  detail: GoldenLayoutChangeEventType['detail']
+) => {
+  const customEvent = new CustomEvent(goldenLayoutChangeEventName, {
+    detail,
+    bubbles: true,
+  })
+  target.dispatchEvent(customEvent)
+}
+
+export const useListenToGoldenLayoutChangeEvent = ({
+  callback,
+}: {
+  callback: (e: GoldenLayoutChangeEventType) => void
+}) => {
+  const [element, setElement] = React.useState<HTMLElement | null>(null)
+
+  React.useEffect(() => {
+    if (element) {
+      element.addEventListener(goldenLayoutChangeEventName, callback)
+      return () => {
+        element.removeEventListener(goldenLayoutChangeEventName, callback)
+      }
+    }
+    return () => {}
+  }, [element, callback])
+  return {
+    setElement,
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.layout-config-handling.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.layout-config-handling.tsx
@@ -1,0 +1,242 @@
+import { GoldenLayoutViewProps } from './golden-layout.view'
+import * as React from 'react'
+import _merge from 'lodash/merge'
+import _ from 'underscore'
+import wreqr from '../../js/wreqr'
+import user from '../singletons/user-instance'
+import { dispatchGoldenLayoutChangeEvent } from './golden-layout.events'
+import { StartupDataStore } from '../../js/model/Startup/startup'
+import { LayoutConfig, PopoutContent, ContentItem } from './golden-layout.types'
+import { HeaderHeight } from './stack-toolbar'
+import { getDefaultComponentState } from '../visualization/settings-helpers'
+import { ResultType } from '../../js/model/Types'
+
+function normalizeContent(content: ContentItem) {
+  if (content.componentState === undefined && content.componentName) {
+    content.componentState = getDefaultComponentState(content.componentName)
+  }
+  if (content.content) {
+    content.content.forEach((subContent) => {
+      normalizeContent(subContent)
+    })
+  }
+}
+
+/**
+ *  add in missing component state defaults, as we do not create layouts using golden layout all the time and sometimes they have minimal details,
+ *  this will also add a default state to old layouts so they aren't seen as changed unnecessarily on load (we don't fire a change event)
+ */
+export function normalizeLayout(layout: LayoutConfig) {
+  if (layout.content && layout.content.length > 0) {
+    layout.content.forEach((contentItem) => {
+      normalizeContent(contentItem)
+    })
+  }
+  if (layout.openPopouts && layout.openPopouts.length > 0) {
+    layout.openPopouts.forEach((popout) => {
+      popout.content.forEach((contentItem) => {
+        normalizeContent(contentItem)
+      })
+    })
+  }
+  return layout
+}
+export function getInstanceConfig({ goldenLayout }: { goldenLayout: any }) {
+  const currentConfig = goldenLayout.toConfig()
+  // tagAsProcessedByGoldenLayout({ config: currentConfig })
+  return removeEphemeralStateAndNormalize(currentConfig)
+}
+
+export function parseResultLayout(layoutResult: ResultType) {
+  let config = undefined
+  try {
+    config = JSON.parse(layoutResult.metacard.properties.layout)
+  } catch (err) {
+    console.warn('issue parsing a saved layout, falling back to default')
+    config = DEFAULT_GOLDEN_LAYOUT_CONTENT
+  }
+  _merge(config, getGoldenLayoutSettings())
+  return normalizeLayout(config)
+}
+export function getGoldenLayoutConfig({
+  layoutResult,
+  editLayoutRef,
+  configName,
+}: GoldenLayoutViewProps) {
+  let currentConfig = undefined
+  if (layoutResult) {
+    return parseResultLayout(layoutResult)
+  } else if (editLayoutRef) {
+    currentConfig = editLayoutRef.current
+  } else {
+    currentConfig = user.get('user').get('preferences').get(configName)
+  }
+  if (currentConfig === undefined) {
+    currentConfig = DEFAULT_GOLDEN_LAYOUT_CONTENT
+  }
+  _merge(currentConfig, getGoldenLayoutSettings())
+  return normalizeLayout(currentConfig)
+}
+export function handleGoldenLayoutStateChange({
+  options,
+  goldenLayout,
+  currentConfig,
+  lastConfig,
+}: {
+  goldenLayout: any
+  currentConfig: any
+  options: GoldenLayoutViewProps
+  lastConfig: React.MutableRefObject<any>
+}) {
+  const lastConfigValue = removeEphemeralStateAndNormalize(lastConfig.current)
+
+  const currentConfigValue = removeEphemeralStateAndNormalize(currentConfig)
+  if (_.isEqual(lastConfigValue, currentConfigValue)) {
+    return
+  }
+  dispatchGoldenLayoutChangeEvent(goldenLayout.container[0], {
+    value: currentConfigValue,
+    goldenLayout,
+  })
+  lastConfig.current = currentConfig
+  /**
+   * If we have this option, then we're editing a layout in the layout editor.
+   * Otherwise, we're using a layout (or possibly custom) and need to take a change as indication of moving to custom.
+   */
+  if (options.editLayoutRef) {
+    options.editLayoutRef.current = currentConfig
+  } else {
+    // can technically do detections of max or empty here
+    //https://github.com/deepstreamIO/golden-layout/issues/253
+    if (goldenLayout.isInitialised) {
+      user.get('user').get('preferences').set(options.configName, currentConfig)
+      ;(wreqr as any).vent.trigger('resize')
+      //do not add a window resize event, that will cause an endless loop.  If you need something like that, listen to the wreqr resize event.
+    }
+    user.get('user').get('preferences').set(
+      {
+        layoutId: 'custom',
+      },
+      {
+        internal: true,
+      }
+    )
+  }
+}
+function removeMaximisedInformation(config: LayoutConfig) {
+  delete config.maximisedItemId
+}
+function isLayoutConfig(
+  config: LayoutConfig | PopoutContent | ContentItem
+): config is LayoutConfig {
+  return (config as LayoutConfig).openPopouts !== undefined
+}
+function isPopoutContent(
+  config: LayoutConfig | PopoutContent | ContentItem
+): config is PopoutContent {
+  return (config as PopoutContent).parentId !== undefined
+}
+function removeOpenPopoutDimensionInformation(
+  config: LayoutConfig | PopoutContent
+): any {
+  delete config.dimensions
+  if (
+    isLayoutConfig(config) &&
+    config.openPopouts &&
+    config.openPopouts?.length > 0
+  ) {
+    return _.forEach(config.openPopouts, removeOpenPopoutDimensionInformation)
+  }
+}
+function removeSettingsInformation(config: LayoutConfig) {
+  delete config.settings
+}
+function removeUnusedTopLevelInformation(
+  config: LayoutConfig | ContentItem | PopoutContent
+) {
+  delete config.isClosable
+  delete config.reorderEnabled
+  if (!isLayoutConfig(config) && !isPopoutContent(config)) {
+    delete config.activeItemIndex
+  }
+  if (config.content !== undefined && config.content.length > 0) {
+    _.forEach(config.content, removeUnusedTopLevelInformation)
+  }
+  if (
+    isLayoutConfig(config) &&
+    config.openPopouts &&
+    config.openPopouts.length > 0
+  ) {
+    _.forEach(config.openPopouts, removeUnusedTopLevelInformation)
+  }
+}
+function normalizeOpenPopouts(config: LayoutConfig) {
+  if (config.openPopouts === undefined) {
+    config.openPopouts = []
+  }
+}
+
+export function removeEphemeralStateAndNormalize(config: LayoutConfig) {
+  delete config.title // only on the top level
+  removeMaximisedInformation(config)
+  removeOpenPopoutDimensionInformation(config)
+  removeSettingsInformation(config)
+  removeUnusedTopLevelInformation(config)
+  normalizeOpenPopouts(config)
+  return config
+}
+export const FALLBACK_GOLDEN_LAYOUT = [
+  {
+    type: 'stack',
+    content: [
+      {
+        type: 'component',
+        componentName: 'cesium',
+        title: '3D Map',
+      },
+      {
+        type: 'component',
+        componentName: 'inspector',
+        title: 'Inspector',
+      },
+    ],
+  },
+]
+export const DEFAULT_GOLDEN_LAYOUT_CONTENT = {
+  content:
+    StartupDataStore.Configuration.getDefaultLayout() || FALLBACK_GOLDEN_LAYOUT,
+}
+
+export const getStringifiedDefaultLayout = () => {
+  try {
+    return JSON.stringify(DEFAULT_GOLDEN_LAYOUT_CONTENT)
+  } catch (err) {
+    console.warn(err)
+    return JSON.stringify(FALLBACK_GOLDEN_LAYOUT)
+  }
+}
+export function getGoldenLayoutSettings() {
+  return {
+    settings: {
+      showPopoutIcon: false,
+      popoutWholeStack: true,
+      responsiveMode: 'none',
+    },
+    dimensions: {
+      borderWidth: 8,
+      minItemHeight: HeaderHeight,
+      minItemWidth: 50,
+      headerHeight: HeaderHeight,
+      dragProxyWidth: 300,
+      dragProxyHeight: 200,
+    },
+    labels: {
+      close: 'close',
+      maximise: 'maximize',
+      minimise: 'minimize',
+      popout: 'open in new window',
+      popin: 'pop in',
+      tabDropdown: 'additional tabs',
+    },
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.types.tsx
@@ -1,0 +1,120 @@
+/**
+ *  Probably some competing locations for where we should put some of these types, like the componentState
+ */
+import { LayerType } from '../../js/controllers/layers'
+import { ModeType } from '../visualization/results-visual/results-visual'
+
+interface LabelConfig {
+  close: string
+  maximise: string
+  minimise: string
+  popout: string
+  popin: string
+  tabDropdown: string
+}
+
+export interface CesiumStateType {
+  mapLayers: LayerType[]
+}
+
+export interface OpenlayersStateType {
+  mapLayers: LayerType[]
+}
+
+interface TimelineState {}
+
+interface HistogramState {}
+
+export interface ResultsState {
+  'results-mode': ModeType
+  'results-attributesShownTable': string[]
+  'results-attributesShownList': string[]
+}
+
+interface InspectorState {}
+
+type ComponentState =
+  | { componentName: 'cesium'; state: CesiumStateType }
+  | { componentName: 'openlayers'; state: OpenlayersStateType }
+  | { componentName: 'timeline'; state: TimelineState }
+  | { componentName: 'histogram'; state: HistogramState }
+  | { componentName: 'results'; state: ResultsState }
+  | { componentName: 'inspector'; state: InspectorState }
+
+type ExtractComponentNames<T> = T extends { componentName: infer U } ? U : never
+
+export type ComponentNameType = ExtractComponentNames<ComponentState>
+
+export interface ContentItem {
+  type: string
+  isClosable?: boolean
+  reorderEnabled: boolean
+  title: string
+  activeItemIndex?: number
+  width?: number
+  height?: number
+  content?: ContentItem[]
+  componentName?: ComponentNameType
+  icon?: string
+  componentState?: ComponentState['state']
+  // one of the componentNames
+  component?: ComponentNameType
+  header?: Record<string, any>
+}
+
+export interface PopoutContent {
+  content: ContentItem[]
+  parentId: string
+  indexInParent: number
+  dimensions?: PopoutDimensions
+  reorderEnabled?: boolean
+  isClosable?: boolean
+  title?: string
+}
+
+interface LayoutSettings {
+  hasHeaders: boolean
+  constrainDragToContainer: boolean
+  reorderEnabled: boolean
+  selectionEnabled: boolean
+  popoutWholeStack: boolean
+  blockedPopoutsThrowError: boolean
+  closePopoutsOnUnload: boolean
+  showPopoutIcon: boolean
+  showMaximiseIcon: boolean
+  showCloseIcon: boolean
+  responsiveMode: string
+  tabOverlapAllowance: number
+  reorderOnTabMenuClick: boolean
+  tabControlOffset: number
+}
+
+interface LayoutDimensions {
+  borderWidth: number
+  borderGrabWidth: number
+  minItemHeight: number
+  minItemWidth: number
+  headerHeight: number
+  dragProxyWidth: number
+  dragProxyHeight: number
+}
+
+interface PopoutDimensions {
+  width: number
+  height: number
+  left: number
+  top: number
+}
+
+export interface LayoutConfig {
+  labels: LabelConfig
+  content: ContentItem[]
+  id?: string | string[]
+  openPopouts?: PopoutContent[]
+  settings?: LayoutSettings
+  dimensions?: LayoutDimensions
+  reorderEnabled?: boolean
+  isClosable?: boolean
+  title?: string
+  maximisedItemId?: string | null
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/browse.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/pages/browse.tsx
@@ -24,6 +24,7 @@ import { GoldenLayout } from '../golden-layout/golden-layout'
 import { LazyQueryResults } from '../../js/model/LazyQueryResult/LazyQueryResults'
 import { Memo } from '../memo/memo'
 import { useUpdateEffect } from 'react-use'
+import { getDefaultComponentState } from '../visualization/settings-helpers'
 
 type ModifySearchParams = {
   search: any
@@ -266,7 +267,10 @@ const SavedSearches = () => {
           <SplitPane variant="horizontal">
             <div className="py-2 w-full h-full">
               <Paper elevation={Elevations.panels} className="w-full h-full">
-                <ResultsVisual selectionInterface={selectionInterface} />
+                <ResultsVisual
+                  selectionInterface={selectionInterface}
+                  componentState={getDefaultComponentState('results') as any}
+                />
               </Paper>
             </div>
             <SelectionInfoPane searchSelectionInterface={selectionInterface} />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -192,6 +192,10 @@ export const TypedUserInstance = {
       date
     )}`
   },
+  getMapLayers: (): Backbone.Collection => {
+    const mapLayers = TypedUserInstance.getPreferences().get('mapLayers')
+    return mapLayers
+  },
   needsUpdate(upToDatePrefs: any) {
     return this.getPreferences().needsUpdate(upToDatePrefs)
   },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.tsx
@@ -26,10 +26,10 @@ import $ from 'jquery'
 import featureDetection from '../../../singletons/feature-detection'
 import { InteractionsProvider } from '../interactions.provider'
 import { LayoutContext } from '../../../golden-layout/visual-settings.provider'
-import user from '../../../singletons/user-instance'
 import User from '../../../../js/model/User'
 import { useBackbone } from '../../../selection-checkbox/useBackbone.hook'
-import { CESIUM_MAP_LAYERS } from '../../settings-helpers'
+import { MAP_LAYERS } from '../../settings-helpers'
+import { CesiumStateType } from '../../../golden-layout/golden-layout.types'
 
 const useSupportsCesium = () => {
   const [, setForceRender] = React.useState(Math.random())
@@ -67,9 +67,11 @@ const useCountdown = ({
 export const CesiumMapViewReact = ({
   selectionInterface,
   setMap: outerSetMap,
+  componentState,
 }: {
   setMap?: (map: any) => void // sometimes outer components want to know when the map is loaded
   selectionInterface: any
+  componentState: CesiumStateType
 }) => {
   const supportsCesium = useSupportsCesium()
   const countdownFinished = useCountdown({
@@ -84,15 +86,14 @@ export const CesiumMapViewReact = ({
   const { getValue, setValue } = React.useContext(LayoutContext)
 
   React.useEffect(() => {
-    const defaultLayers = user.get('user>preferences>mapLayers').toJSON()
-    const layerSettings = getValue(CESIUM_MAP_LAYERS, defaultLayers)
+    const layerSettings = getValue(MAP_LAYERS, componentState.mapLayers)
 
     const layerModels = layerSettings.map((layer: any) => {
       return new (User as any).MapLayer(layer, { parse: true })
     })
     const layerCollection = new (User as any).MapLayers(layerModels)
     listenTo(layerCollection, 'add remove', () =>
-      setValue(CESIUM_MAP_LAYERS, layerCollection.toJSON())
+      setValue(MAP_LAYERS, layerCollection.toJSON())
     )
     layerCollection.validate()
     setMapLayers(layerCollection)
@@ -100,7 +101,7 @@ export const CesiumMapViewReact = ({
 
   React.useEffect(() => {
     const callback = () => {
-      setValue(CESIUM_MAP_LAYERS, mapLayers.toJSON())
+      setValue(MAP_LAYERS, mapLayers.toJSON())
     }
     if (mapLayers) {
       listenTo(mapLayers, 'change', callback)
@@ -145,6 +146,7 @@ export const CesiumMapViewReact = ({
       <OpenlayersMapViewReact
         setMap={setMap}
         selectionInterface={selectionInterface}
+        componentState={componentState}
       />
     )
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/openlayers.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/openlayers.view.tsx
@@ -22,7 +22,8 @@ import { LayoutContext } from '../../../golden-layout/visual-settings.provider'
 import user from '../../../singletons/user-instance'
 import User from '../../../../js/model/User'
 import { useBackbone } from '../../../selection-checkbox/useBackbone.hook'
-import { OPENLAYERS_MAP_LAYERS } from '../../settings-helpers'
+import { MAP_LAYERS } from '../../settings-helpers'
+import { OpenlayersStateType } from '../../../golden-layout/golden-layout.types'
 
 const loadOpenLayersCode = () => {
   // @ts-expect-error ts-migrate(7009) FIXME: 'new' expression, whose target lacks a construct s... Remove this comment to see the full error message
@@ -36,9 +37,11 @@ const loadOpenLayersCode = () => {
 export const OpenlayersMapViewReact = ({
   selectionInterface,
   setMap: outerSetMap,
+  componentState,
 }: {
   selectionInterface: any
   setMap?: (map: any) => void
+  componentState: OpenlayersStateType
 }) => {
   const [map, setMap] = React.useState<any>(null)
   const [mapLayers, setMapLayers] = React.useState<any>(null)
@@ -49,7 +52,7 @@ export const OpenlayersMapViewReact = ({
 
   const saveLayers = (layers: any) => {
     if (hasLayoutContext) {
-      setValue(OPENLAYERS_MAP_LAYERS, layers.toJSON())
+      setValue(MAP_LAYERS, layers.toJSON())
     } else {
       user.get('user>preferences').savePreferences()
     }
@@ -60,10 +63,7 @@ export const OpenlayersMapViewReact = ({
 
     let layerCollection = userDefaultLayers
     if (hasLayoutContext) {
-      const layerSettings = getValue(
-        OPENLAYERS_MAP_LAYERS,
-        userDefaultLayers.toJSON()
-      )
+      const layerSettings = getValue(MAP_LAYERS, componentState.mapLayers)
       const layerModels = layerSettings.map((layer: any) => {
         return new (User as any).MapLayer(layer, { parse: true })
       })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/results-visual.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/results-visual.tsx
@@ -14,24 +14,26 @@ import Button from '@mui/material/Button'
 import BackgroundInheritingDiv from '../../theme/background-inheriting-div'
 import { LayoutContext } from '../../golden-layout/visual-settings.provider'
 import { RESULTS_MODE } from '../settings-helpers'
+import { ResultsState } from '../../golden-layout/golden-layout.types'
 type Props = {
   selectionInterface: any
+  componentState: ResultsState
 }
 
-type ModeType = 'card' | 'table'
+export type ModeType = 'card' | 'table'
 
 export const ResultsViewContext = React.createContext({
   edit: null as null | LazyQueryResult,
   setEdit: (() => {}) as React.Dispatch<null | LazyQueryResult>,
 })
 
-const ResultsView = ({ selectionInterface }: Props) => {
+const ResultsView = ({ selectionInterface, componentState }: Props) => {
   const { getValue, setValue } = React.useContext(LayoutContext)
   const [mode, setMode] = React.useState(null)
   const [edit, setEdit] = React.useState(null as null | LazyQueryResult)
 
   React.useEffect(() => {
-    setMode(getValue(RESULTS_MODE) || ('card' as ModeType))
+    setMode(getValue(RESULTS_MODE, componentState['results-mode']))
   }, [])
 
   React.useEffect(() => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/settings-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/settings-helpers.tsx
@@ -13,26 +13,61 @@
  *
  **/
 
-import { StartupDataStore } from '../../js/model/Startup/startup'
+/**
+ *  We might want to not export anything beyond the default state functions, but for now we can leave this and refactor when we have time.
+ *  The idea is this state should be flowing in at the top when we make the component, and not be getting fetched in the leaves.  Maybe we can add it to the context.
+ */
+import { ComponentNameType } from '../golden-layout/golden-layout.types'
 import { TypedUserInstance } from '../singletons/TypedUser'
+import { ModeType } from './results-visual/results-visual'
 
 export const RESULTS_ATTRIBUTES_TABLE = 'results-attributesShownTable'
 export const RESULTS_ATTRIBUTES_LIST = 'results-attributesShownList'
 export const RESULTS_MODE = 'results-mode'
 
-export const CESIUM_MAP_LAYERS = 'cesium-mapLayers'
-export const OPENLAYERS_MAP_LAYERS = 'openlayers-mapLayers'
+export const MAP_LAYERS = 'mapLayers'
+
+export function getDefaultComponentState(component: ComponentNameType) {
+  switch (component) {
+    case 'cesium':
+      return {
+        [MAP_LAYERS]: getUserPreferencesMapLayersJSON(),
+      }
+    case 'openlayers':
+      return {
+        [MAP_LAYERS]: getUserPreferencesMapLayersJSON(),
+      }
+    case 'results':
+      return {
+        [RESULTS_ATTRIBUTES_TABLE]: getDefaultResultsShownTable(),
+        [RESULTS_ATTRIBUTES_LIST]: getDefaultResultsShownList(),
+        [RESULTS_MODE]: getDefaultResultsMode(),
+      }
+    default:
+      return {}
+  }
+}
+
+export const getUserPreferencesMapLayersJSON = () => {
+  return TypedUserInstance.getMapLayers().toJSON()
+}
+
+export const getDefaultResultsMode = (): ModeType => {
+  return 'card'
+}
 
 export const getDefaultResultsShownList = () => {
-  if (StartupDataStore.Configuration.getResultShow().length > 0) {
-    return StartupDataStore.Configuration.getResultShow()
+  const defaultAttributes = TypedUserInstance.getResultsAttributesShownList()
+  if (defaultAttributes && defaultAttributes.length > 0) {
+    return defaultAttributes
   }
   return ['title', 'thumbnail']
 }
 
 export const getDefaultResultsShownTable = () => {
-  if (StartupDataStore.Configuration.getDefaultTableColumns().length > 0) {
-    return StartupDataStore.Configuration.getDefaultTableColumns()
+  const defaultAttributes = TypedUserInstance.getResultsAttributesShownTable()
+  if (defaultAttributes && defaultAttributes.length > 0) {
+    return defaultAttributes
   }
   return ['title', 'thumbnail']
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/layers.tsx
@@ -15,7 +15,7 @@
 
 import { Subscribable } from '../model/Base/base-classes'
 
-type LayerType = {
+export type LayerType = {
   alpha: string
   id: string
   label: string

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/User.ts
@@ -32,7 +32,7 @@ import 'backbone-associations'
 import { CommonAjaxSettings } from '../AjaxSettings'
 import { v4 } from 'uuid'
 import { StartupDataStore } from './Startup/startup'
-const User = {}
+const User = {} as any
 const Theme = Backbone.Model.extend({
   defaults() {
     return {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/visualization-selector/visualization-selector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/visualization-selector/visualization-selector.tsx
@@ -164,7 +164,6 @@ class VisualizationSelector extends React.Component<{
     if (this.interimState) {
       const content = {
         ...configs[choice],
-        componentState: {},
       }
       if (this.props.goldenLayout.root.contentItems.length === 0) {
         this.props.goldenLayout.root.addChild({


### PR DESCRIPTION
 - Updates the golden layout components to set a default componentState so that layouts from before the individual visual settings era will not be seen as changed upon load.
 - Updates the parsing of layouts, similar to above this handles missing component state / normalizes things.
 - Updates how we save layout configs to make sure all ephermeral state is removed, and that we normalize state in areas we have to, like openPopouts.
 - Adds some types for golden layout to make handling configs easier.  Some of these might belong in settings-helpers or vice versa.
 - Moves a lot of the config handling for golden layout / settings code into it's own component for clarity.
 - Adds to settings-helpers to make it possible to grab default componentState for visuals
 - Updates the golden layout base component and various leaves to handle taking in componentState for visuals.  See cesium.view and openlayers.view and results-visual, as well as GoldenLayoutComponent in golden-layout.view.
 - Part of these changes fixes the user modifying the default map layers, and those not being used when adding a new map to the set of visuals.
 - Adds a new event along with a hook that components can listen to that allows responding to golden layout config changes more reactively.
 - Patches the createUrl function in golden layout for popups to instead use a different route.  This avoids us loading an entire route just to cover it with a golden layout visual in a popout, and avoids weird unintended side effects from the route loading.  There is now a special route, just for popouts.
 - Removes some unused code, and the dependency sanitize-html as we weren't using it.