### PR TITLE
Add size to export audit log

### DIFF
--- a/ui-backend/catalog-ui-search/pom.xml
+++ b/ui-backend/catalog-ui-search/pom.xml
@@ -401,6 +401,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
                 <configuration>
                     <finalName>catalog-ui-search</finalName>
                     <descriptor>catalog-ui-search.xml</descriptor>

--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -415,10 +415,10 @@ public class CqlTransformHandler implements Route {
 
     try (OutputStream servletOutputStream = response.raw().getOutputStream();
         InputStream resultStream = content.getInputStream()) {
-      int byteCount = IOUtils.copy(resultStream, servletOutputStream);
+      long byteCount = IOUtils.copyLarge(resultStream, servletOutputStream);
       securityLogger.audit(
           String.format(
-              "exported metacards: %s from source(s): %s to format: %s with output size: %d",
+              "exported metacards: %s from source(s): %s to format: %s with output size: %d bytes",
               metacardIds, sources, transformerId, byteCount));
     }
 

--- a/ui-frontend/pom.xml
+++ b/ui-frontend/pom.xml
@@ -34,6 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
                 <configuration>
                     <finalName>packages</finalName>
                     <descriptor>packages.xml</descriptor>


### PR DESCRIPTION
Ingest some products. Export them (eg. as CSV). Verify that the audit log includes the size of the file exported. This should be the size as the file saved to disc.
