### PR TITLE
Escape Attribute Name Symbols in Boolean Query

### DIFF
--- a/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/handlers/QueryHandler.java
+++ b/ui-backend/boolean-search/boolean-search-application/src/main/java/org/codice/ddf/catalog/search/handlers/QueryHandler.java
@@ -28,6 +28,11 @@ public class QueryHandler implements Handler {
     // implementation not needed
   }
 
+  public static String formatSearchProperty(String str) {
+    String escapedSymbols = str.replaceAll("[^\\p{L}\\p{Nd}]+", "\\\\$0");
+    return "\"" + escapedSymbols + "\"";
+  }
+
   @Override
   public void handle(@NotNull final Context ctx) {
     final String searchExpression = ctx.queryParam("q");
@@ -37,7 +42,7 @@ public class QueryHandler implements Handler {
     if (searchProperty == null) {
       parser = new Parser(new StringReader(searchExpression));
     } else {
-      parser = new Parser(new StringReader(searchExpression), searchProperty);
+      parser = new Parser(new StringReader(searchExpression), formatSearchProperty(searchProperty));
     }
 
     try {

--- a/ui-backend/boolean-search/boolean-search-application/src/test/java/org/codice/ddf/catalog/search/handlers/QueryHandlerTest.java
+++ b/ui-backend/boolean-search/boolean-search-application/src/test/java/org/codice/ddf/catalog/search/handlers/QueryHandlerTest.java
@@ -1,0 +1,26 @@
+/* Copyright (c) Connexta, LLC */
+package org.codice.ddf.catalog.search.handlers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class QueryHandlerTest {
+  @Test
+  public void testFormatSearchProperty() {
+    String input = "test";
+    String expectedResult = "\"test\"";
+    String actualResult = QueryHandler.formatSearchProperty(input);
+    assertEquals(actualResult, expectedResult);
+
+    input = "foo.bar";
+    expectedResult = "\"foo\\.bar\"";
+    actualResult = QueryHandler.formatSearchProperty(input);
+    assertEquals(actualResult, expectedResult);
+
+    input = "a-b.c";
+    expectedResult = "\"a\\-b\\.c\"";
+    actualResult = QueryHandler.formatSearchProperty(input);
+    assertEquals(actualResult, expectedResult);
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -38,6 +38,14 @@ import { ValidationResult } from '../../location/validators'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import { ReservedBasicDatatype } from '../../../component/reserved-basic-datatype/reserved.basic-datatype'
 import { BasicDataTypePropertyName } from '../../../component/filter-builder/reserved.properties'
+
+const formatPropertyName = (property: string) => {
+  // escape non-alphanumeric characters
+  let modifiedProperty = property.replace(/(\W)/g, '\\$1')
+  modifiedProperty = `\"${modifiedProperty}\"`
+  return modifiedProperty
+}
+
 export type Props = {
   filter: FilterClass
   setFilter: (filter: FilterClass) => void
@@ -76,7 +84,7 @@ const FilterInput = ({ filter, setFilter, errorListener }: Props) => {
         <BooleanSearchBar
           value={value as ValueTypes['booleanText']}
           onChange={onChange}
-          property={filter.property}
+          property={formatPropertyName(filter.property)}
         />
       )
     case 'FILTER FUNCTION proximity':

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -38,14 +38,6 @@ import { ValidationResult } from '../../location/validators'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import { ReservedBasicDatatype } from '../../../component/reserved-basic-datatype/reserved.basic-datatype'
 import { BasicDataTypePropertyName } from '../../../component/filter-builder/reserved.properties'
-
-const formatPropertyName = (property: string) => {
-  // escape non-alphanumeric characters
-  let modifiedProperty = property.replace(/(\W)/g, '\\$1')
-  modifiedProperty = `\"${modifiedProperty}\"`
-  return modifiedProperty
-}
-
 export type Props = {
   filter: FilterClass
   setFilter: (filter: FilterClass) => void
@@ -84,7 +76,7 @@ const FilterInput = ({ filter, setFilter, errorListener }: Props) => {
         <BooleanSearchBar
           value={value as ValueTypes['booleanText']}
           onChange={onChange}
-          property={formatPropertyName(filter.property)}
+          property={filter.property}
         />
       )
     case 'FILTER FUNCTION proximity':


### PR DESCRIPTION
This PR formats the the property/attribute name in a boolean search by escaping non-alphanumeric characters and delimiting the string with quotes. This change prevents boolean queries containing non-alphanumeric characters from failing.

To test, perform an advanced search with
- an attribute containing at least one symbol (`-` or `.`)
- the boolean operator
- a valid search term

The query should return results as expected.

Example search 
![Screenshot 2024-06-27 at 15 52 45](https://github.com/codice/ddf-ui/assets/12192559/fd26f20c-1295-45bf-9be3-53676b068b28)
