### PR TITLE
set default source querySetting value from all to local

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/preferences/DefaultCatalogUiPreferences.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/preferences/DefaultCatalogUiPreferences.java
@@ -95,7 +95,7 @@ public class DefaultCatalogUiPreferences implements DefaultPreferencesSupplier {
         "querySettings",
         new ImmutableMap.Builder<>()
             .put("type", "text")
-            .put("sources", Collections.singletonList("all"))
+            .put("sources", Collections.singletonList("local"))
             .put(
                 "sorts",
                 Collections.singletonList(


### PR DESCRIPTION
This change is to ensure that the default value for search sources that is selected is local(fast sources).
When 'all' is selected as default, search is perceived to be "slow", due to the searching including slow sources by default.

To test.
1. Build catalog-ui jar and drop into /ddf/deploy
2. Verify that your user has no preference metacards in solr. e.g delete the metacard that is associated with query: metacard-tags_txt:ddf-preferences && user_txt:<your_user>
3. On the landing page, verify that the default source drop down is defaulting to "fast sources" and that the metacard that gets created (using step 2 query) has 'local' in 'querySettings'
