### PR TITLE
Download Latest Resource Version

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/download/download.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/download/download.tsx
@@ -5,7 +5,12 @@ import { Overridable } from '../../js/model/Base/base-classes'
 import { useOverridable } from '../../js/model/Base/base-classes.hooks'
 
 export const normalDownload = ({ result }: { result: LazyQueryResult }) => {
-  const downloadUrl = result.getDownloadUrl()
+  let downloadUrl = result.getDownloadUrl()
+  // append new query param to prevent downloading cached resource
+  downloadUrl =
+    downloadUrl +
+    (downloadUrl.includes('?') ? '&t=' : '?t=') +
+    new Date().getTime().toString()
   downloadUrl && window.open(downloadUrl)
 }
 


### PR DESCRIPTION
This change prevents cached resources from being downloaded. This is useful when users have overwritten a resource.

To test:
1. Upload a product
2. Overwrite that product with something else
3. Download the product
4. Repeat steps 2 and 3 a few times and verify the most recent version is always downloaded.