### PR TITLE
Update query set to ensure filterTree is always the correct type

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -28,6 +28,7 @@ import {
 import {
   FilterBuilderClass,
   FilterClass,
+  isFilterBuilderClass,
 } from '../../component/filter-builder/filter.structure'
 import { downgradeFilterTreeToBasic } from '../../component/query-basic/query-basic.view'
 import {
@@ -45,7 +46,7 @@ import { CommonAjaxSettings } from '../AjaxSettings'
 import { StartupDataStore } from './Startup/startup'
 export type QueryType = {
   constructor: (_attributes: any, options: any) => void
-  set: (p1: any, p2?: any) => void
+  set: (p1: any, p2?: any, p3?: any) => void
   toJSON: () => any
   defaults: () => any
   resetToDefaults: (overridenDefaults: any) => void
@@ -155,20 +156,39 @@ export default Backbone.AssociatedModel.extend({
     this.options = options
     return Backbone.AssociatedModel.apply(this, arguments)
   },
-  set(data: any) {
-    if (
-      typeof data === 'object' &&
-      data.filterTree !== undefined &&
-      typeof data.filterTree === 'string'
-    ) {
-      // for backwards compatability
-      try {
-        data.filterTree = new FilterBuilderClass(JSON.parse(data.filterTree))
-      } catch (e) {
-        console.error(e)
+  set(data: any, value: any, options: any) {
+    try {
+      switch (typeof data) {
+        case 'object':
+          if (
+            data.filterTree !== undefined &&
+            typeof data.filterTree === 'string'
+          ) {
+            data.filterTree = JSON.parse(data.filterTree)
+          }
+          if (!isFilterBuilderClass(data.filterTree)) {
+            data.filterTree = new FilterBuilderClass(data.filter)
+          }
+          break
+        case 'string':
+          if (data === 'filterTree') {
+            if (typeof value === 'string') {
+              value = JSON.parse(value)
+            }
+            if (!isFilterBuilderClass(value)) {
+              value = new FilterBuilderClass(value)
+            }
+          }
+          break
       }
+    } catch (e) {
+      console.error(e)
     }
-    return Backbone.AssociatedModel.prototype.set.apply(this, arguments)
+    return Backbone.AssociatedModel.prototype.set.apply(this, [
+      data,
+      value,
+      options,
+    ])
   },
   toJSON(...args: any) {
     const json = Backbone.AssociatedModel.prototype.toJSON.call(this, ...args)


### PR DESCRIPTION
This ensures that regardless of the set / initialize we'll always be able to know a query.get('filterTree') is of the correct type.

Previously we were only catching instances of string in the set, thinking the defaults area would handle this conversion, however that turned out to not always be the case.