### PR TITLE
Move cookie to be set as soon as possible on app start

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.tsx
@@ -44,11 +44,20 @@ export class StartupData extends Subscribable<{
     this.MetacardDefinitions = new MetacardDefinitions(this)
     this.fetch()
   }
+  handleEnhancedRoles() {
+    /**
+     *  The "path=/" part is so the cookie is included / available to all domain paths
+     */
+    document.cookie = `useElevatedRights=${
+      this.data?.user.preferences.actingRole === 'enhanced'
+    }; path=/`
+  }
   fetch() {
     fetch('./internal/compose/startup')
       .then((response) => response.json())
       .then((startupPayload: StartupPayloadType) => {
         this.data = startupPayload
+        this.handleEnhancedRoles()
         this._notifySubscribers({ thing: 'fetched', args: startupPayload })
       })
   }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/startup.types.tsx
@@ -276,7 +276,7 @@ interface PreferencesType {
   }
   animation: boolean
   hoverPreview: boolean
-  actingRole: string
+  actingRole: 'user' | 'enhanced'
   layoutId: string
   mapLayers: {
     type: string


### PR DESCRIPTION
 - Certain connections only get the value of the cookie at their opening, like websockets.  To ensure we don't have issues around a missing cookie, we can move it here and ensure that the moment we know we need a cookie we apply it.