### PR TITLE
Allow unsuccessful results to be counted

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -244,8 +244,8 @@ const QueryFeed = ({ selectionInterface }: Props) => {
       let possible = 0
 
       results.forEach((result) => {
-        available += result.count
-        possible += result.hits
+        available += result?.count ?? 0
+        possible += result?.hits ?? 0
       })
 
       resultMessage = `${available} hit${

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -238,9 +238,7 @@ const QueryFeed = ({ selectionInterface }: Props) => {
     )
 
     if (sourcesThatHaveReturned.length > 0) {
-      const results = statusBySource
-        .filter((status) => status.hasReturned)
-        .filter((status) => status.successful)
+      const results = statusBySource.filter((status) => status.hasReturned)
 
       let available = 0
       let possible = 0

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/result-selector/query-feed.tsx
@@ -82,9 +82,7 @@ const CellValue = (props: CellValueProps) => {
           <WarningIcon style={{ paddingRight: '5px' }} color="warning" />
         </Tooltip>
       )}
-      {alwaysShowValue || (!message && hasReturned && successful)
-        ? value
-        : null}
+      {alwaysShowValue || (!message && hasReturned) ? value : null}
       {!hasReturned && !alwaysShowValue && (
         <span
           className="fa fa-circle-o-notch fa-spin"


### PR DESCRIPTION
Some federated sources can produce error details but still return results.  Currently, when the UI receives results from a query for a source that indicates an error, the available and possible counts reported do not include updates from "unsuccessful" sources.  This means that if the source did in fact return results, they would be displayed to the user in the results visual but the status in the heartbeat area would indicate that there were zero results.  This is a confusing state for the user to be in.

This PR removes the filtering of unsuccessful results so that all of the returned data is counted appropriately.