### PR TITLE
Update filter components to support non metacard based filters, add better number validation

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.spec.tsx
@@ -113,10 +113,11 @@ describe('verify date around field works', () => {
     verifyDateRender('12', 'minute', data.date1.userFormat12.minute)
   )
   it('calls onChange with updated value when precision changes', () => {
+    let updatedDate = data.date1.userFormatISO.millisecond
     wrapper = mount(
       <DateAroundField
         value={{
-          date: data.date1.userFormatISO.millisecond,
+          date: updatedDate,
           buffer: {
             amount: '1',
             unit: 'd',
@@ -124,7 +125,7 @@ describe('verify date around field works', () => {
           direction: 'both',
         }}
         onChange={(updatedValue) => {
-          expect(updatedValue.date).to.equal(data.date1.utcISOMinutes)
+          updatedDate = updatedValue.date
         }}
       />
     )
@@ -132,5 +133,8 @@ describe('verify date around field works', () => {
       .get('user')
       .get('preferences')
       .set('dateTimeFormat', Common.getDateTimeFormats()['ISO']['minute'])
+    setTimeout(() => {
+      expect(updatedDate).to.equal(data.date1.utcISOMinutes)
+    }, 100)
   })
 })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -59,6 +59,10 @@ const validateDate = (
 }
 
 export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
+  const validValue = {
+    ...defaultValue(),
+    ...value,
+  }
   const dateRef = React.useRef(value.date)
   const blueprintDateRef = React.useRef<DateInput>(null)
 
@@ -70,8 +74,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
       DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(shiftedDate)
     dateRef.current = unshiftedDate.toISOString()
     onChange({
-      ...defaultValue(),
-      ...value,
+      ...validValue,
       date: unshiftedDate.toISOString(),
     })
   })
@@ -97,8 +100,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           onChange={DateHelpers.Blueprint.DateProps.generateOnChange((date) => {
             dateRef.current = date
             onChange({
-              ...defaultValue(),
-              ...value,
+              ...validValue,
               date,
             })
           })}
@@ -118,13 +120,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
               }, 0)
             },
           }}
-          {...(value.date
-            ? {
-                value: DateHelpers.Blueprint.DateProps.generateValue(
-                  value.date
-                ),
-              }
-            : {})}
+          value={DateHelpers.Blueprint.DateProps.generateValue(validValue.date)}
         />
       </Grid>
       <Grid item className="w-full pb-2">
@@ -137,20 +133,16 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
             onChange={(val) => {
               if (onChange)
                 onChange({
-                  ...defaultValue(),
-                  ...value,
+                  ...validValue,
                   buffer: {
-                    ...defaultValue().buffer,
-                    ...value.buffer,
-                    amount: val,
+                    ...validValue.buffer,
+                    amount: val.toString(),
                   },
                 })
             }}
-            {...(value.buffer
-              ? {
-                  value: value.buffer.amount,
-                }
-              : {})}
+            validation={(val) => val > 0}
+            validationText="Must be greater than 0, using previous value of "
+            value={validValue.buffer.amount}
           />
         </Grid>
         <Grid item xs={8} className="pl-2">
@@ -161,22 +153,16 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
             onChange={(e) => {
               if (onChange)
                 onChange({
-                  ...defaultValue(),
-                  ...value,
+                  ...validValue,
                   buffer: {
-                    ...defaultValue().buffer,
-                    ...value.buffer,
+                    ...validValue.buffer,
                     unit: e.target
                       .value as ValueTypes['around']['buffer']['unit'],
                   },
                 })
             }}
             size="small"
-            {...(value.buffer
-              ? {
-                  value: value.buffer.unit,
-                }
-              : { value: 'd' })}
+            value={validValue.buffer.unit}
           >
             <MenuItem value="s">Seconds</MenuItem>
             <MenuItem value="m">Minutes</MenuItem>
@@ -191,12 +177,11 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
       <TextField
         variant="outlined"
         select
-        value={value.direction || 'both'}
+        value={validValue.direction}
         onChange={(e) => {
           if (onChange)
             onChange({
-              ...defaultValue(),
-              ...value,
+              ...validValue,
               direction: e.target.value as ValueTypes['around']['direction'],
             })
         }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-relative.tsx
@@ -26,6 +26,10 @@ const isInvalid = ({ value }: Props) => {
 }
 
 export const DateRelativeField = ({ value, onChange }: Props) => {
+  const validValue = {
+    ...defaultValue,
+    ...value,
+  }
   React.useEffect(() => {
     validateShape({ value, onChange })
   }, [])
@@ -41,16 +45,13 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
           onChange={(val) => {
             if (onChange)
               onChange({
-                ...defaultValue,
-                ...value,
-                last: val,
+                ...validValue,
+                last: val.toString(),
               })
           }}
-          {...(value
-            ? {
-                value: value.last,
-              }
-            : {})}
+          validation={(val) => val > 0}
+          validationText="Must be greater than 0, using previous value of "
+          value={validValue.last}
         />
       </Grid>
       <Grid item xs={8} className="pl-2">
@@ -61,13 +62,12 @@ export const DateRelativeField = ({ value, onChange }: Props) => {
           onChange={(e) => {
             if (onChange)
               onChange({
-                ...defaultValue,
-                ...value,
+                ...validValue,
                 unit: e.target.value as ValueTypes['relative']['unit'],
               })
           }}
           size="small"
-          value={value.unit}
+          value={validValue.unit}
         >
           <MenuItem value="s">Seconds</MenuItem>
           <MenuItem value="m">Minutes</MenuItem>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/float.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/float.tsx
@@ -14,9 +14,9 @@
  **/
 import * as React from 'react'
 
-import TextField from '@mui/material/TextField'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
+import { NumberField } from './number'
 
 type FloatFieldProps = {
   value: ValueTypes['float']
@@ -36,15 +36,12 @@ export const FloatField = ({ value, onChange }: FloatFieldProps) => {
     validateShape({ value, onChange })
   }, [])
   return (
-    <TextField
-      fullWidth
-      variant="outlined"
-      value={value}
-      type="number"
+    <NumberField
+      value={value.toString()}
+      type="float"
       onChange={(e) => {
-        onChange(parseFloat(e.target.value))
+        onChange(e)
       }}
-      size="small"
       {...EnterKeySubmitProps}
     />
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/integer.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/integer.tsx
@@ -14,9 +14,9 @@
  **/
 import * as React from 'react'
 
-import TextField from '@mui/material/TextField'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
+import { NumberField } from './number'
 
 type IntegerFieldProps = {
   value: ValueTypes['integer']
@@ -36,14 +36,11 @@ export const IntegerField = ({ value, onChange }: IntegerFieldProps) => {
     validateShape({ value, onChange })
   }, [])
   return (
-    <TextField
-      fullWidth
-      variant="outlined"
-      size="small"
-      placeholder="Use * for wildcard."
-      value={value}
+    <NumberField
+      type="integer"
+      value={value.toString()}
       onChange={(e) => {
-        onChange(parseInt(e.target.value))
+        onChange(e)
       }}
       {...EnterKeySubmitProps}
     />

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/near.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/near.tsx
@@ -14,14 +14,13 @@
  **/
 import * as React from 'react'
 
-import TextField from '@mui/material/TextField'
 import Grid from '@mui/material/Grid'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { CustomInputOrDefault } from '../../react-component/filter/filter-input/customInputOrDefault'
-import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
+import { NumberField } from './number'
 
 type NearFieldProps = {
-  value: ValueTypes['proximity']
+  value: Partial<ValueTypes['proximity']>
   onChange: (val: ValueTypes['proximity']) => void
 }
 
@@ -42,6 +41,10 @@ const validateShape = ({ value, onChange }: NearFieldProps) => {
 }
 
 export const NearField = ({ value, onChange }: NearFieldProps) => {
+  const validValue = {
+    ...defaultValue,
+    ...value,
+  }
   React.useEffect(() => {
     validateShape({ value, onChange })
   }, [])
@@ -55,10 +58,10 @@ export const NearField = ({ value, onChange }: NearFieldProps) => {
     >
       <Grid item className="w-full pb-2">
         <CustomInputOrDefault
-          value={value.second}
+          value={validValue.second}
           onChange={(val: any) => {
             onChange({
-              ...value,
+              ...validValue,
               second: val,
             })
           }}
@@ -74,19 +77,17 @@ export const NearField = ({ value, onChange }: NearFieldProps) => {
         within
       </Grid>
       <Grid item className="w-full pb-2">
-        <TextField
-          fullWidth
-          type="number"
-          variant="outlined"
-          value={value.distance}
-          onChange={(e) => {
+        <NumberField
+          type="integer"
+          value={validValue.distance.toString()}
+          onChange={(val) => {
             onChange({
-              ...value,
-              distance: Math.max(1, parseInt(e.target.value) || 0),
+              ...validValue,
+              distance: val,
             })
           }}
-          size="small"
-          {...EnterKeySubmitProps}
+          validation={(val) => val > 0}
+          validationText="Must be greater than 0, using previous value of "
         />
       </Grid>
       <Grid item className="w-full pb-2 pl-2">
@@ -94,10 +95,10 @@ export const NearField = ({ value, onChange }: NearFieldProps) => {
       </Grid>
       <Grid item className="w-full">
         <CustomInputOrDefault
-          value={value.first}
+          value={validValue.first}
           onChange={(val: any) => {
             onChange({
-              ...value,
+              ...validValue,
               first: val,
             })
           }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/number-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/number-range.tsx
@@ -14,13 +14,13 @@
  **/
 import * as React from 'react'
 
-import TextField from '@mui/material/TextField'
 import Grid from '@mui/material/Grid'
 import { ValueTypes } from '../filter-builder/filter.structure'
 import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
+import { NumberField } from './number'
 
 type NumberRangeFieldProps = {
-  value: ValueTypes['between']
+  value: Partial<ValueTypes['between']>
   onChange: (val: ValueTypes['between']) => void
   type: 'integer' | 'float'
 }
@@ -41,6 +41,10 @@ export const NumberRangeField = ({
   onChange,
   type,
 }: NumberRangeFieldProps) => {
+  const validValue = {
+    ...defaultValue,
+    ...value,
+  }
   React.useEffect(() => {
     validateShape({ value, onChange, type })
   }, [])
@@ -50,23 +54,18 @@ export const NumberRangeField = ({
         <div>from</div>
       </Grid>
       <Grid item>
-        <TextField
-          fullWidth
-          variant="outlined"
-          value={value.start}
-          placeholder="lower bound"
-          type="number"
-          onChange={(e) => {
-            const newVal =
-              type === 'integer'
-                ? parseInt(e.target.value)
-                : parseFloat(e.target.value)
+        <NumberField
+          value={validValue.start.toString()}
+          TextFieldProps={{
+            placeholder: 'lower bound',
+          }}
+          type={type}
+          onChange={(val) => {
             onChange({
-              ...value,
-              start: newVal,
+              ...validValue,
+              start: val,
             })
           }}
-          size="small"
           {...EnterKeySubmitProps}
         />
       </Grid>
@@ -74,23 +73,18 @@ export const NumberRangeField = ({
         <div>to</div>
       </Grid>
       <Grid item>
-        <TextField
-          fullWidth
-          variant="outlined"
-          placeholder="upper bound"
-          value={value.end}
-          type="number"
-          onChange={(e) => {
-            const newVal =
-              type === 'integer'
-                ? parseInt(e.target.value)
-                : parseFloat(e.target.value)
+        <NumberField
+          TextFieldProps={{
+            placeholder: 'upper bound',
+          }}
+          value={validValue.end.toString()}
+          type={type}
+          onChange={(val) => {
             onChange({
-              ...value,
-              end: newVal,
+              ...validValue,
+              end: val,
             })
           }}
-          size="small"
           {...EnterKeySubmitProps}
         />
       </Grid>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/number.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/number.tsx
@@ -2,34 +2,105 @@ import * as React from 'react'
 import TextField, { TextFieldProps } from '@mui/material/TextField'
 import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
 
+type LocalValueType = number | '' | '-'
+
 type Props = {
   value?: string
-  onChange?: (val: string) => void
+  onChange?: (val: number) => void
   type: 'integer' | 'float'
   TextFieldProps?: TextFieldProps
+  validation?: (val: number) => boolean
+  validationText?: string
+}
+
+const defaultValue = 1
+
+function parseValue(value: string, type: Props['type']) {
+  let parsedValue = defaultValue
+  if (type === 'integer') {
+    parsedValue = parseInt(value)
+  } else {
+    parsedValue = parseFloat(value)
+  }
+  if (isNaN(parsedValue)) {
+    return defaultValue
+  } else {
+    return parsedValue
+  }
+}
+
+function useLocalValue({
+  value,
+  onChange,
+  type,
+  validation = () => true,
+  validationText = 'Must be a valid number, using previous value of ',
+}: Props) {
+  const [localValue, setLocalValue] = React.useState<LocalValueType>(
+    parseValue(value || '1', type)
+  )
+  const [hasValidationIssues, setHasValidationIssues] = React.useState(false)
+  const [constructedValidationText, setConstructedValidationText] =
+    React.useState('')
+
+  React.useEffect(() => {
+    if (
+      onChange &&
+      typeof localValue === 'number' &&
+      !isNaN(localValue) &&
+      validation(localValue)
+    ) {
+      setHasValidationIssues(false)
+      onChange(localValue)
+    } else {
+      setConstructedValidationText(validationText + value)
+      setHasValidationIssues(true)
+    }
+  }, [localValue, value])
+  return {
+    localValue,
+    setLocalValue,
+    hasValidationIssues,
+    constructedValidationText,
+  }
 }
 
 export const NumberField = ({
   value,
   onChange,
   type,
+  validation,
+  validationText,
   TextFieldProps,
 }: Props) => {
+  const {
+    localValue,
+    setLocalValue,
+    hasValidationIssues,
+    constructedValidationText,
+  } = useLocalValue({ value, onChange, type, validation, validationText })
   return (
     <TextField
       fullWidth
       size="small"
       variant="outlined"
-      value={value}
+      value={localValue}
       type="number"
       onChange={(e) => {
         if (onChange) {
-          if (type === 'integer') {
-            onChange(parseInt(e.target.value).toString())
+          const inputValue = e.target.value
+          if (inputValue === '' || inputValue === '-') {
+            setLocalValue(inputValue)
+          } else if (type === 'integer') {
+            setLocalValue(parseInt(inputValue))
           } else {
-            onChange(parseFloat(e.target.value).toString())
+            setLocalValue(parseFloat(inputValue))
           }
         }
+      }}
+      helperText={hasValidationIssues ? constructedValidationText : ''}
+      FormHelperTextProps={{
+        error: true,
       }}
       {...TextFieldProps}
       {...EnterKeySubmitProps}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.tsx
@@ -67,7 +67,7 @@ export const serialize = {
     //Weeks is not a valid unit, so convert this to days
     if (unit === 'w') {
       let convertedUnit = 'd'
-      let convertedLast = (parseInt(last) * 7).toString()
+      let convertedLast = (parseFloat(last) * 7).toString()
       return `RELATIVE(${'P' + convertedLast + convertedUnit.toUpperCase()})`
     }
     const prefix = unit === 's' || unit === 'm' || unit === 'h' ? 'PT' : 'P'
@@ -263,6 +263,8 @@ export type PointRadiusLocation = {
   locationType?: 'dd'
 }
 
+export type ValueType = string | boolean | null | ValuesType<ValueTypes>
+
 export class FilterClass extends SpreadOperatorProtectedClass {
   type:
     | 'BEFORE'
@@ -286,7 +288,7 @@ export class FilterClass extends SpreadOperatorProtectedClass {
     | 'AROUND' // This isn't valid cql, but something we support
     | 'BOOLEAN_TEXT_SEARCH' // This isn't valid cql, but something we support
   readonly property: string
-  readonly value: string | boolean | null | ValuesType<ValueTypes>
+  readonly value: ValueType
   readonly negated: boolean | undefined
   readonly id: string
   constructor({

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.util.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter.structure.util.tsx
@@ -1,0 +1,221 @@
+import { FilterClass, ValueType, ValueTypes } from './filter.structure'
+
+export const isRelativeValue = (
+  value: ValueType
+): value is ValueTypes['relative'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'last' in value &&
+    'unit' in value &&
+    typeof value.last === 'string' &&
+    ['m', 'h', 'd', 'M', 'y', 's', 'w'].includes(value.unit)
+  )
+}
+
+export const isAroundValue = (
+  value: ValueType
+): value is ValueTypes['around'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'date' in value &&
+    'buffer' in value &&
+    'direction' in value &&
+    typeof value.date === 'string' &&
+    typeof value.buffer === 'object' &&
+    'amount' in value.buffer &&
+    'unit' in value.buffer &&
+    typeof value.buffer.amount === 'string' &&
+    ['both', 'before', 'after'].includes(value.direction)
+  )
+}
+
+export const isProximityValue = (
+  value: ValueType
+): value is ValueTypes['proximity'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'first' in value &&
+    'second' in value &&
+    'distance' in value &&
+    typeof value.first === 'string' &&
+    typeof value.second === 'string' &&
+    typeof value.distance === 'number'
+  )
+}
+
+export const isDateValue = (value: ValueType): value is ValueTypes['date'] => {
+  return typeof value === 'string'
+}
+
+export const isBooleanValue = (
+  value: ValueType
+): value is ValueTypes['boolean'] => {
+  return typeof value === 'boolean'
+}
+
+export const isTextValue = (value: ValueType): value is ValueTypes['text'] => {
+  return typeof value === 'string'
+}
+
+export const isFloatValue = (
+  value: ValueType
+): value is ValueTypes['float'] => {
+  return typeof value === 'number'
+}
+
+export const isIntegerValue = (
+  value: ValueType
+): value is ValueTypes['integer'] => {
+  return Number.isInteger(value)
+}
+
+export const isDuringValue = (
+  value: ValueType
+): value is ValueTypes['during'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'start' in value &&
+    'end' in value &&
+    typeof value.start === 'string' &&
+    typeof value.end === 'string'
+  )
+}
+
+export const isBetweenValue = (
+  value: ValueType
+): value is ValueTypes['between'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'start' in value &&
+    'end' in value &&
+    Number.isInteger(value.start) &&
+    Number.isInteger(value.end)
+  )
+}
+
+export const isMultivalue = (
+  value: ValueType
+): value is ValueTypes['multivalue'] => {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string')
+}
+
+export const isBooleanTextValue = (
+  value: ValueType
+): value is ValueTypes['booleanText'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'text' in value &&
+    'cql' in value &&
+    'error' in value &&
+    typeof value.text === 'string' &&
+    typeof value.cql === 'string' &&
+    typeof value.error === 'boolean'
+  )
+}
+
+export const isLocationValue = (
+  value: ValueType
+): value is ValueTypes['location'] => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    (value.type === 'LINE' ||
+      value.type === 'POLYGON' ||
+      value.type === 'POINTRADIUS')
+  )
+}
+
+export const isValueEmpty = (filter: FilterClass): boolean => {
+  const type = filter.type
+  if (type === 'IS NULL') {
+    return false // IS NULL is never empty
+  }
+
+  const value = filter.value
+  if (value === null || value === undefined || value === '') {
+    return true
+  }
+
+  if (isDateValue(value)) {
+    return value.trim() === ''
+  }
+
+  if (isBooleanValue(value)) {
+    return false // Boolean values can't be "empty"
+  }
+
+  if (isTextValue(value)) {
+    return value.trim() === ''
+  }
+
+  if (isFloatValue(value)) {
+    return isNaN(value)
+  }
+
+  if (isIntegerValue(value)) {
+    return isNaN(value)
+  }
+
+  if (isDuringValue(value)) {
+    return value.start.trim() === '' || value.end.trim() === ''
+  }
+
+  if (isBetweenValue(value)) {
+    return isNaN(value.start) || isNaN(value.end)
+  }
+
+  if (isMultivalue(value)) {
+    return value.length === 0 || value.every((v) => v.trim() === '')
+  }
+
+  if (isBooleanTextValue(value)) {
+    return value.text.trim() === '' || value.cql.trim() === ''
+  }
+
+  if (isLocationValue(value)) {
+    if (value.type === 'LINE') {
+      return value.line.length === 0
+    } else if (value.type === 'POLYGON') {
+      return value.polygon.length === 0
+    } else if (value.type === 'POINTRADIUS') {
+      return (
+        isNaN(value.lat) ||
+        isNaN(value.lon) ||
+        isNaN(parseFloat(value.radius.toString()))
+      )
+    }
+  }
+
+  if (isProximityValue(value)) {
+    return (
+      value.first.trim() === '' ||
+      value.second.trim() === '' ||
+      isNaN(value.distance)
+    )
+  }
+
+  if (isAroundValue(value)) {
+    return (
+      value.date.trim() === '' ||
+      isNaN(parseFloat(value.buffer.amount)) ||
+      parseFloat(value.buffer.amount) <= 0
+    )
+  }
+
+  if (isRelativeValue(value)) {
+    return (
+      value.last.trim() === '' ||
+      isNaN(parseFloat(value.last)) ||
+      parseFloat(value.last) <= 0
+    )
+  }
+
+  return false
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/filter-comparator.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-comparator/filter-comparator.tsx
@@ -13,13 +13,13 @@
  *
  **/
 import React, { useEffect } from 'react'
-import { getComparators } from './comparatorUtils'
 import MenuItem from '@mui/material/MenuItem'
 import TextField, { TextFieldProps } from '@mui/material/TextField'
 import {
   FilterClass,
   isBasicDatatypeClass,
 } from '../../../component/filter-builder/filter.structure'
+import { useComparatorsForAttribute } from './comparatorUtils'
 
 type Props = {
   filter: FilterClass
@@ -28,8 +28,8 @@ type Props = {
 }
 
 const FilterComparator = ({ filter, setFilter, textFieldProps }: Props) => {
+  const comparators = useComparatorsForAttribute(filter.property)
   useEffect(() => {
-    const comparators = getComparators(filter.property)
     if (
       !comparators.map((comparator) => comparator.value).includes(filter.type)
     ) {
@@ -40,13 +40,12 @@ const FilterComparator = ({ filter, setFilter, textFieldProps }: Props) => {
         })
       )
     }
-  }, [filter, setFilter])
+  }, [filter, setFilter, comparators])
 
   if (isBasicDatatypeClass(filter)) {
     return null
   }
 
-  const comparators = getComparators(filter.property)
   return (
     <TextField
       data-id="filter-comparator-select"

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.tsx
@@ -13,7 +13,7 @@
  *
  **/
 import React from 'react'
-import { getAttributeType } from '../filterHelper'
+import { getAttributeType as defaultGetAttributeType } from '../filterHelper'
 import LocationInput from './filter-location-input'
 
 import { DateField } from '../../../component/fields/date'
@@ -44,9 +44,15 @@ export type Props = {
   errorListener?: (validationResults: {
     [key: string]: ValidationResult | undefined
   }) => void
+  getAttributeType?: typeof defaultGetAttributeType
 }
 
-const FilterInput = ({ filter, setFilter, errorListener }: Props) => {
+const FilterInput = ({
+  filter,
+  setFilter,
+  errorListener,
+  getAttributeType = defaultGetAttributeType,
+}: Props) => {
   const type = getAttributeType(filter.property)
   const MetacardDefinitions = useMetacardDefinitions()
   const { value } = filter

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.tsx
@@ -24,6 +24,7 @@ import { hot } from 'react-hot-loader'
 import { FilterClass } from '../../component/filter-builder/filter.structure'
 import { ValidationResult } from '../location/validators'
 import { FilterProperty } from './filter-property'
+import { DefaultComparatorProvider } from './filter-comparator/comparatorUtils'
 
 export type Props = {
   filter: FilterClass
@@ -47,7 +48,9 @@ const Filter = ({ filter, setFilter, errorListener }: Props) => {
         />
       </Grid>
       <Grid item className="w-full pb-2">
-        <FilterComparator filter={filter} setFilter={setFilter} />
+        <DefaultComparatorProvider>
+          <FilterComparator filter={filter} setFilter={setFilter} />
+        </DefaultComparatorProvider>
       </Grid>
       <Grid data-id="filter-input" item className="w-full">
         <FilterInput

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filterHelper.tsx
@@ -17,6 +17,7 @@ import { StartupDataStore } from '../../js/model/Startup/startup'
 import {
   AttributeDefinitionType,
   AttributeMapType,
+  AttributeTypes,
 } from '../../js/model/Startup/startup.types'
 export type Attribute = {
   label: string
@@ -91,7 +92,8 @@ export const getFilteredAttributeList = (group?: string): Attribute[] => {
     )
     .map((attr) => toAttribute(attr, group))
 }
-export const getAttributeType = (attribute: string): string => {
+
+export const getAttributeType = (attribute: string): AttributeTypes => {
   const type =
     StartupDataStore.MetacardDefinitions.getAttributeMap()[attribute]?.type
   if (type === 'GEOMETRY') return 'LOCATION'


### PR DESCRIPTION
 - It's useful to use these filter components on non metacard filters in order to build UI components that hit solr for other things, which this will allow.
 - The number validation on some of the filters was preventing users from doing things like deleting their value and starting with a negative, so it's been rewritten to keep values around locally no matter what, and only propagate those as changes to the filter when they're valid.  If unvalid, the user is notified that the previous valid value will be used instead.