### PR TITLE
Fix paging and exporting with additional query options

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -152,6 +152,7 @@ public class CqlTransformHandler implements Route {
     private boolean phonetics = false;
     private boolean spellcheck = false;
     private List<String> hiddenResults = Collections.emptyList();
+    private String additionalOptions = null;
 
     public void setSearches(List<CqlRequestImpl> searches) {
       this.searches = searches;
@@ -200,6 +201,14 @@ public class CqlTransformHandler implements Route {
     public List<String> getHiddenResults() {
       return this.hiddenResults;
     }
+
+    public void setAdditionalOptions(String additionalOptions) {
+      this.additionalOptions = additionalOptions;
+    }
+
+    public String getAdditionalOptions() {
+      return this.additionalOptions;
+    }
   }
 
   @Override
@@ -232,6 +241,7 @@ public class CqlTransformHandler implements Route {
           cqlRequest.setSorts(cqlTransformRequest.getSorts());
           cqlRequest.setPhonetics((cqlTransformRequest.getPhonetics()));
           cqlRequest.setSpellcheck((cqlTransformRequest.getSpellcheck()));
+          cqlRequest.setAdditionalOptions(cqlTransformRequest.getAdditionalOptions());
         });
 
     if (CollectionUtils.isEmpty(cqlRequests)) {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/table-export/table-export.tsx
@@ -45,6 +45,7 @@ import DialogActions from '@mui/material/DialogActions/DialogActions'
 import DialogContentText from '@mui/material/DialogContentText'
 import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
 import { limitToDeleted, limitToHistoric } from '../../js/model/Query'
+import { limitCqlToDeleted } from '../../react-component/utils/cql/cql'
 
 export type Props = {
   selectionInterface: any
@@ -197,9 +198,13 @@ export const getExportBody = async (ExportInfo: ExportInfo) => {
       {} as Record<string, string[]>
     )
     Object.keys(srcMap).forEach((src) => {
+      let cql = getResultSetCql(srcMap[src])
+      if (query.options.limitToDeleted) {
+        cql = limitCqlToDeleted(cql)
+      }
       searches.push({
         srcs: [src],
-        cql: getResultSetCql(srcMap[src]),
+        cql,
         count: srcMap[src].length,
         cacheId,
       })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -430,7 +430,7 @@ export default Backbone.AssociatedModel.extend({
       },
       options
     )
-    _.extend(this.options, options)
+    this.options = _.extend(this.options, options)
 
     const data = _cloneDeep(this.buildSearchData())
 
@@ -610,7 +610,7 @@ export default Backbone.AssociatedModel.extend({
   },
   getPreviousServerPage() {
     this.setNextIndexForSourceGroupToPrevPage()
-    this.startSearch()
+    this.startSearch(this.options)
   },
   /**
    * Much simpler than seeing if a next page exists
@@ -630,14 +630,14 @@ export default Backbone.AssociatedModel.extend({
   },
   getNextServerPage() {
     this.setNextIndexForSourceGroupToNextPage()
-    this.startSearch()
+    this.startSearch(this.options)
   },
   getHasFirstServerPage() {
     // so technically always "true" but what we really mean is, are we not on page 1 already
     return this.hasPreviousServerPage()
   },
   getFirstServerPage() {
-    this.startSearchFromFirstPage()
+    this.startSearchFromFirstPage(this.options)
   },
   getHasLastServerPage() {
     // so technically always "true" but what we really mean is, are we not on last page already
@@ -652,7 +652,7 @@ export default Backbone.AssociatedModel.extend({
         count: this.get('count'),
       })
     )
-    this.startSearch()
+    this.startSearch(this.options)
   },
   resetCurrentIndexForSourceGroup() {
     this.set('currentIndexForSourceGroup', {})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Query.tsx
@@ -99,7 +99,7 @@ export type QueryType = {
   canRefetch: () => boolean
   [key: string]: any
 }
-function limitToDeleted(cqlFilterTree: any) {
+export function limitToDeleted(cqlFilterTree: any) {
   return new FilterBuilderClass({
     type: 'AND',
     filters: [
@@ -117,7 +117,7 @@ function limitToDeleted(cqlFilterTree: any) {
     ],
   })
 }
-function limitToHistoric(cqlFilterTree: any) {
+export function limitToHistoric(cqlFilterTree: any) {
   return new FilterBuilderClass({
     type: 'AND',
     filters: [
@@ -426,10 +426,19 @@ export default Backbone.AssociatedModel.extend({
       {
         limitToDeleted: false,
         limitToHistoric: false,
+        additionalOptions: undefined,
       },
       options
     )
+    _.extend(this.options, options)
+
     const data = _cloneDeep(this.buildSearchData())
+
+    if (options.additionalOptions) {
+      let optionsObj = JSON.parse(data.additionalOptions || '{}')
+      optionsObj = _.extend(optionsObj, options.additionalOptions)
+      data.additionalOptions = JSON.stringify(optionsObj)
+    }
     data.batchId = v4()
     // Data.sources is set in `buildSearchData` based on which sources you have selected.
     let selectedSources = data.sources

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/TypedQuery.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/TypedQuery.tsx
@@ -71,6 +71,7 @@ export type QueryOptions = {
   }) => number
   limitToDeleted?: boolean
   limitToHistoric?: boolean
+  additionalOptions?: any
 }
 
 export const DEFAULT_QUERY_OPTIONS: Readonly<Required<QueryOptions>> = {
@@ -88,6 +89,7 @@ export const DEFAULT_QUERY_OPTIONS: Readonly<Required<QueryOptions>> = {
   },
   limitToHistoric: false,
   limitToDeleted: false,
+  additionalOptions: undefined,
 }
 
 export const Query = (
@@ -139,6 +141,7 @@ export const DEFAULT_USER_QUERY_OPTIONS: Readonly<Required<QueryOptions>> = {
   },
   limitToDeleted: false,
   limitToHistoric: false,
+  additionalOptions: undefined,
 }
 
 /**

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/cql/cql.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/cql/cql.tsx
@@ -16,3 +16,8 @@ export const getResultSetCql = (ids: string[]) => {
   const queries = ids.map((id) => `(("id" = '${id}'))`)
   return `(${queries.join(' OR ')})`
 }
+
+export const limitCqlToDeleted = (cql: string) => {
+  const deletedCql = `(("metacard-tags" ILIKE 'deleted') AND ("metacard.deleted.tags" ILIKE 'resource'))`
+  return `(${cql} AND ${deletedCql})`
+}


### PR DESCRIPTION
* Respect additional options when exporting results so what is exported matches the search results in the UI.
* Pass additional options through when requesting next, previous, last, and first page of query results.

Testing:
Verify that exporting and paging works when using query options. Reach out to me for more specific testing instructions.