### PR TITLE
Add validation to date range filters / inputs

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-around.tsx
@@ -42,10 +42,7 @@ const defaultValue = () => {
   } as ValueTypes['around']
 }
 
-const validateDate = (
-  { value, onChange }: DateAroundProps,
-  dateRef: React.MutableRefObject<string>
-) => {
+const validateDate = ({ value, onChange }: DateAroundProps) => {
   if (
     !value.date ||
     !value.buffer ||
@@ -53,7 +50,6 @@ const validateDate = (
     DateHelpers.Blueprint.commonProps.parseDate(value.date) === null
   ) {
     const newDate = DateHelpers.General.withPrecision(new Date())
-    dateRef.current = newDate.toISOString()
     onChange({ ...defaultValue(), date: newDate.toISOString() })
   }
 }
@@ -63,16 +59,14 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
     ...defaultValue(),
     ...value,
   }
-  const dateRef = React.useRef(value.date)
   const blueprintDateRef = React.useRef<DateInput>(null)
 
   useTimePrefs(() => {
     const shiftedDate = DateHelpers.Blueprint.DateProps.generateValue(
-      dateRef.current
+      value.date
     )
     const unshiftedDate =
       DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(shiftedDate)
-    dateRef.current = unshiftedDate.toISOString()
     onChange({
       ...validValue,
       date: unshiftedDate.toISOString(),
@@ -80,7 +74,7 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
   })
 
   React.useEffect(() => {
-    validateDate({ onChange, value }, dateRef)
+    validateDate({ onChange, value })
   }, [])
 
   return (
@@ -98,7 +92,6 @@ export const DateAroundField = ({ value, onChange }: DateAroundProps) => {
           fill
           formatDate={DateHelpers.Blueprint.commonProps.formatDate}
           onChange={DateHelpers.Blueprint.DateProps.generateOnChange((date) => {
-            dateRef.current = date
             onChange({
               ...validValue,
               date,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-helpers.tsx
@@ -126,24 +126,29 @@ export const DateHelpers = {
           }
         }) as IDateRangeInputProps['onChange']
       },
+      // null is how the blueprint datepicker represents an empty or invalid date
       generateValue: (
         value: ValueTypes['during'],
         minDate?: Date,
         maxDate?: Date
       ) =>
         [
-          DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
-            value.start,
-            ISO_8601_FORMAT_ZONED,
-            minDate,
-            maxDate
-          ),
-          DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
-            value.end,
-            ISO_8601_FORMAT_ZONED,
-            minDate,
-            maxDate
-          ),
+          value.start
+            ? DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+                value.start,
+                ISO_8601_FORMAT_ZONED,
+                minDate,
+                maxDate
+              )
+            : null,
+          value.end
+            ? DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
+                value.end,
+                ISO_8601_FORMAT_ZONED,
+                minDate,
+                maxDate
+              )
+            : null,
         ] as IDateRangeInputProps['value'],
     },
     converters: {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -4,7 +4,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 Enzyme.configure({ adapter: new Adapter() })
 import { expect } from 'chai'
 
-import { DateRangeField } from './date-range'
+import { DateRangeField, defaultValue } from './date-range'
 import moment from 'moment'
 
 import user from '../singletons/user-instance'
@@ -124,14 +124,13 @@ describe('verify date range field works', () => {
           start: data.date1.originalISO,
           end: data.date4.originalISO,
         }}
-        onChange={() => {}}
+        onChange={(validValue) => {
+          // verify these are one day apart, as should happen when fed overlapping dates or invalid values
+          const start = new Date(validValue.start)
+          const end = new Date(validValue.end)
+          expect(start.getDate()).to.equal(end.getDate() - 1)
+        }}
       />
-    )
-    expect(wrapper.render().find('input').first().val()).to.equal(
-      data.date1.userFormatISO.millisecond
-    )
-    expect(wrapper.render().find('input').last().val()).to.equal(
-      'Overlapping dates'
     )
   })
   const verifyDateRender = (
@@ -269,17 +268,14 @@ describe('verify date range field works', () => {
   it(`should generate appropriately shifted ISO strings on change (DST)`, () => {
     wrapper = mount(
       <DateRangeField
-        value={{
-          start: new Date().toISOString(),
-          end: new Date().toISOString(),
-        }}
+        value={defaultValue()}
         onChange={(updatedValue) => {
           expect(updatedValue.start).to.equal(data.date5.originalISO)
           expect(updatedValue.end).to.equal(data.date5.originalISO)
         }}
       />
     )
-    const dateFieldInstance = wrapper.children().get(0)
+    const dateFieldInstance = wrapper.children().children().get(0)
     dateFieldInstance.props.onChange(
       [
         DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
@@ -297,25 +293,22 @@ describe('verify date range field works', () => {
   it(`should generate appropriately shifted ISO strings on change`, () => {
     wrapper = mount(
       <DateRangeField
-        value={{
-          start: new Date().toISOString(),
-          end: new Date().toISOString(),
-        }}
+        value={defaultValue()}
         onChange={(updatedValue) => {
-          expect(updatedValue.start).to.equal(data.date1.originalISO)
-          expect(updatedValue.end).to.equal(data.date1.originalISO)
+          expect(updatedValue.start).to.equal(data.date4.originalISO)
+          expect(updatedValue.end).to.equal(data.date5.originalISO)
         }}
       />
     )
-    const dateFieldInstance = wrapper.children().get(0)
+    const dateFieldInstance = wrapper.children().children().get(0)
     dateFieldInstance.props.onChange(
       [
         DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
-          data.date1.originalISO,
+          data.date4.originalISO,
           ISO_8601_FORMAT_ZONED
         ),
         DateHelpers.Blueprint.converters.TimeshiftForDatePicker(
-          data.date1.originalISO,
+          data.date5.originalISO,
           ISO_8601_FORMAT_ZONED
         ),
       ],
@@ -325,10 +318,7 @@ describe('verify date range field works', () => {
   it(`should not allow dates beyond max future`, () => {
     wrapper = mount(
       <DateRangeField
-        value={{
-          start: new Date().toISOString(),
-          end: new Date().toISOString(),
-        }}
+        value={defaultValue()}
         onChange={(updatedValue) => {
           expect(updatedValue.start).to.not.equal(data.date3.maxFuture)
         }}
@@ -340,13 +330,9 @@ describe('verify date range field works', () => {
     })
   })
   it(`should allow dates up to max future`, () => {
-    const initValue = {
-      start: new Date().toISOString(),
-      end: new Date().toISOString(),
-    }
     wrapper = mount(
       <DateRangeField
-        value={initValue}
+        value={defaultValue()}
         onChange={(updatedValue) => {
           expect(updatedValue.start).to.equal(data.date3.maxFuture)
         }}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -21,6 +21,8 @@ import useTimePrefs from './useTimePrefs'
 
 import user from '../singletons/user-instance'
 import { EnterKeySubmitProps } from '../custom-events/enter-key-submit'
+import FormHelperText from '@mui/material/FormHelperText'
+import LinearProgress from '@mui/material/LinearProgress'
 
 type Props = {
   value: ValueTypes['during']
@@ -31,33 +33,109 @@ type Props = {
   BPDateRangeProps?: Partial<IDateRangeInputProps>
 }
 
-const validateDates = ({ value, onChange }: Props) => {
-  if (
-    value === undefined ||
-    value.start === undefined ||
-    value.end === undefined
-  ) {
-    const end = DateHelpers.General.withPrecision(new Date())
-    const start = DateHelpers.General.withPrecision(
-      new Date(end.valueOf() - 86_400_000)
-    ) // start and end can't be equal or the backend will throw a fit
-    const newValue = {
-      start: start.toISOString(),
-      end: end.toISOString(),
-    }
-    onChange(newValue)
+export function defaultValue() {
+  const end = DateHelpers.General.withPrecision(new Date())
+  const start = DateHelpers.General.withPrecision(
+    new Date(end.valueOf() - 86_400_000)
+  ) // start and end can't be equal or the backend will throw a fit
+  return {
+    start: start.toISOString(),
+    end: end.toISOString(),
   }
 }
 
-export const DateRangeField = ({
+/**
+ *  Used in the below components to test values for validity and to provide a message to the user if they are invalid.
+ */
+function isValidValue(value: Props['value']): {
+  valid: boolean
+  message: string
+} {
+  if (value && value.start && value.end) {
+    // end has to be after start too, so convert from iso and check
+    const startDate = new Date(value.start)
+    const endDate = new Date(value.end)
+    return {
+      valid: startDate < endDate,
+      message:
+        'Start date must be before end date, using previous valid values:',
+    }
+  } else {
+    return {
+      valid: false,
+      message: 'Start and end date must be set, using previous valid values:',
+    }
+  }
+}
+
+/**
+ *  There are two things to check before passing values upwards to parent components through the onChange.
+ *  1.  Start and end date need to be valid dates.
+ *  2.  Start date must be before end date. (cannot be equal either)
+ *
+ *  Given those possibilities, we can construct a message to try and prod the user as to why a value is invalid.
+ */
+function useLocalValue({ value, onChange }: Props) {
+  const [localValue, setLocalValue] = React.useState<Props['value']>(value) // since we don't get here with an invalid value, we can just set it to the value
+  const [hasValidationIssues, setHasValidationIssues] = React.useState(false)
+  const [constructedValidationText, setConstructedValidationText] =
+    React.useState<React.ReactNode>(null)
+
+  React.useEffect(() => {
+    const validity = isValidValue(localValue)
+    if (onChange && validity.valid) {
+      setHasValidationIssues(false)
+      setConstructedValidationText('')
+      if (value !== localValue) onChange(localValue)
+    } else {
+      setConstructedValidationText(
+        <>
+          <div>{validity.message}</div>
+          <div>start: {value.start}</div>
+          <div>end: {value.end}</div>
+        </>
+      )
+      setHasValidationIssues(true)
+    }
+  }, [localValue, value])
+
+  return {
+    localValue,
+    setLocalValue,
+    hasValidationIssues,
+    constructedValidationText,
+  }
+}
+
+/**
+ *  If the initial value is invalid, we immediately call the onChange to make sure we start with a valid value.
+ */
+function useInitialValueValidation({ value, onChange }: Props) {
+  React.useEffect(() => {
+    if (!isValidValue(value).valid) {
+      onChange(defaultValue())
+    }
+  }, [])
+}
+
+/**
+ *  This component will always have a valid value (start and end date set and start < end), and onChange will never get an invalid value
+ */
+const DateRangeFieldWithoutInitialValidation = ({
   value,
   onChange,
   BPDateRangeProps,
 }: Props) => {
+  const {
+    localValue,
+    setLocalValue,
+    hasValidationIssues,
+    constructedValidationText,
+  } = useLocalValue({ value, onChange })
   useTimePrefs(() => {
     const shiftedDates =
-      DateHelpers.Blueprint.DateRangeProps.generateValue(value)
-    onChange({
+      DateHelpers.Blueprint.DateRangeProps.generateValue(value) // as said above, this will always be valid, so no need to fret on converting
+    setLocalValue({
       start: DateHelpers.Blueprint.converters
         .UntimeshiftFromDatePicker(shiftedDates![0]!)
         .toISOString(),
@@ -66,49 +144,73 @@ export const DateRangeField = ({
         .toISOString(),
     })
   })
-  React.useEffect(() => {
-    validateDates({ value, onChange, BPDateRangeProps })
-  }, [])
   return (
-    <DateRangeInput
-      timePickerProps={{
-        useAmPm: user.getAmPmDisplay(),
-      }}
-      allowSingleDayRange
-      minDate={DefaultMinDate}
-      maxDate={DefaultMaxDate}
-      endInputProps={{
-        fill: true,
-        className: MuiOutlinedInputBorderClasses,
-        ...EnterKeySubmitProps,
-      }}
-      startInputProps={{
-        fill: true,
-        className: MuiOutlinedInputBorderClasses,
-        ...EnterKeySubmitProps,
-      }}
-      className="where"
-      closeOnSelection={false}
-      formatDate={DateHelpers.Blueprint.commonProps.formatDate}
-      onChange={DateHelpers.Blueprint.DateRangeProps.generateOnChange(
-        (value) => {
-          onChange(value)
-        }
-      )}
-      popoverProps={{
-        boundary: 'viewport',
-        position: 'bottom',
-      }}
-      parseDate={DateHelpers.Blueprint.commonProps.parseDate}
-      shortcuts
-      timePrecision={DateHelpers.General.getTimePrecision()}
-      placeholder={DateHelpers.General.getDateFormat()}
-      {...(value
-        ? {
-            value: DateHelpers.Blueprint.DateRangeProps.generateValue(value),
+    <>
+      <DateRangeInput
+        timePickerProps={{
+          useAmPm: user.getAmPmDisplay(),
+        }}
+        allowSingleDayRange
+        minDate={DefaultMinDate}
+        maxDate={DefaultMaxDate}
+        endInputProps={{
+          fill: true,
+          className: MuiOutlinedInputBorderClasses,
+          ...EnterKeySubmitProps,
+        }}
+        startInputProps={{
+          fill: true,
+          className: MuiOutlinedInputBorderClasses,
+          ...EnterKeySubmitProps,
+        }}
+        className="where"
+        closeOnSelection={false}
+        formatDate={DateHelpers.Blueprint.commonProps.formatDate}
+        onChange={DateHelpers.Blueprint.DateRangeProps.generateOnChange(
+          (value) => {
+            setLocalValue(value)
           }
-        : {})}
-      {...BPDateRangeProps}
+        )}
+        popoverProps={{
+          boundary: 'viewport',
+          position: 'bottom',
+        }}
+        parseDate={DateHelpers.Blueprint.commonProps.parseDate}
+        shortcuts
+        timePrecision={DateHelpers.General.getTimePrecision()}
+        placeholder={DateHelpers.General.getDateFormat()}
+        value={DateHelpers.Blueprint.DateRangeProps.generateValue(localValue)}
+        {...BPDateRangeProps}
+      />
+      {hasValidationIssues ? (
+        <>
+          <FormHelperText className="px-2 Mui-text-error">
+            {constructedValidationText}
+          </FormHelperText>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+/**
+ *  By updating invalid starting values before we go into the above component, we can make sure we always have a valid value to fall back to.
+ */
+export const DateRangeField = ({
+  value,
+  onChange,
+  BPDateRangeProps,
+}: Props) => {
+  useInitialValueValidation({ value, onChange, BPDateRangeProps })
+  const valueValidity = isValidValue(value)
+  if (!valueValidity.valid) {
+    return <LinearProgress className="w-full h-2" />
+  }
+  return (
+    <DateRangeFieldWithoutInitialValidation
+      value={value}
+      onChange={onChange}
+      BPDateRangeProps={BPDateRangeProps}
     />
   )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.tsx
@@ -31,10 +31,7 @@ type Props = {
   BPDateRangeProps?: Partial<IDateRangeInputProps>
 }
 
-const validateDates = (
-  { value, onChange }: Props,
-  valueRef: React.MutableRefObject<{ start: string; end: string }>
-) => {
+const validateDates = ({ value, onChange }: Props) => {
   if (
     value === undefined ||
     value.start === undefined ||
@@ -48,7 +45,6 @@ const validateDates = (
       start: start.toISOString(),
       end: end.toISOString(),
     }
-    valueRef.current = newValue
     onChange(newValue)
   }
 }
@@ -58,12 +54,9 @@ export const DateRangeField = ({
   onChange,
   BPDateRangeProps,
 }: Props) => {
-  const valueRef = React.useRef(value)
-
   useTimePrefs(() => {
-    const shiftedDates = DateHelpers.Blueprint.DateRangeProps.generateValue(
-      valueRef.current
-    )
+    const shiftedDates =
+      DateHelpers.Blueprint.DateRangeProps.generateValue(value)
     onChange({
       start: DateHelpers.Blueprint.converters
         .UntimeshiftFromDatePicker(shiftedDates![0]!)
@@ -74,7 +67,7 @@ export const DateRangeField = ({
     })
   })
   React.useEffect(() => {
-    validateDates({ value, onChange, BPDateRangeProps }, valueRef)
+    validateDates({ value, onChange, BPDateRangeProps })
   }, [])
   return (
     <DateRangeInput
@@ -99,7 +92,6 @@ export const DateRangeField = ({
       formatDate={DateHelpers.Blueprint.commonProps.formatDate}
       onChange={DateHelpers.Blueprint.DateRangeProps.generateOnChange(
         (value) => {
-          valueRef.current = value
           onChange(value)
         }
       )}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date.tsx
@@ -40,16 +40,12 @@ type DateFieldProps = {
   isNullable?: boolean
 }
 
-const validateDate = (
-  { value, onChange, isNullable }: DateFieldProps,
-  valueRef: React.MutableRefObject<string>
-) => {
+const validateDate = ({ value, onChange, isNullable }: DateFieldProps) => {
   if (value === null && isNullable) return
 
   const date = moment(value, ISO_8601_FORMAT_ZONED)
   if (!date.isValid()) {
     const newDate = DateHelpers.General.withPrecision(new Date())
-    valueRef.current = newDate.toISOString()
     onChange(newDate.toISOString())
   }
 }
@@ -60,19 +56,16 @@ export const DateField = ({
   BPDateProps,
   isNullable,
 }: DateFieldProps) => {
-  const valueRef = useRef(value)
   const blueprintDateRef = useRef<DateInput>(null)
 
   useTimePrefs(() => {
-    const shiftedDate = DateHelpers.Blueprint.DateProps.generateValue(
-      valueRef.current
-    )
+    const shiftedDate = DateHelpers.Blueprint.DateProps.generateValue(value)
     const unshiftedDate =
       DateHelpers.Blueprint.converters.UntimeshiftFromDatePicker(shiftedDate)
     onChange(unshiftedDate.toISOString())
   })
   React.useEffect(() => {
-    validateDate({ onChange, value, isNullable }, valueRef)
+    validateDate({ onChange, value, isNullable })
   }, [])
 
   return (
@@ -86,7 +79,6 @@ export const DateField = ({
         fill
         formatDate={DateHelpers.Blueprint.commonProps.formatDate}
         onChange={DateHelpers.Blueprint.DateProps.generateOnChange((value) => {
-          valueRef.current = value
           onChange(value)
         })}
         parseDate={DateHelpers.Blueprint.commonProps.parseDate}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/useTimePrefs.tsx
@@ -22,7 +22,7 @@ const useTimePrefs = (action?: () => void) => {
         'change:dateTimeFormat change:timeZone',
         callback
       )
-  }, [])
+  }, [action])
 }
 
 export default useTimePrefs

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -320,6 +320,9 @@ const GlobalStyles = createGlobalStyle<ThemeInterface>`
       .Mui-text-warning {
         color: ${(props) => props.palette.warning.main};
       }
+      .Mui-text-error {
+        color: ${(props) => props.palette.error.main};
+      }
       .Mui-bg-default {
         background-color: ${(props) => props.palette.background.default};
       }


### PR DESCRIPTION
 - Updated date range for better UX, allowing blank values / invalid values.
 - Similar to the number filters etc, invalid or blank values now show a message to the user saying the most recent previous valid value will be used instead.
 - This prevents the possibility of bad filters for date ranges being sent to the backend through cql.
 - Removes the need for refs in the date components by updating the useTimePrefs hook.  We needed a dep on the action, so that the current action would be run (with the right values in it).


https://github.com/user-attachments/assets/823d8a3e-d296-4fa8-94f3-67b34a4049bd

