### PR TITLE
Get default sources from sources from configuration instead of using "local"

### DIFF
--- a/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/preferences/DefaultCatalogUiPreferences.java
+++ b/ui-backend/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/preferences/DefaultCatalogUiPreferences.java
@@ -18,9 +18,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.codice.ddf.catalog.ui.config.ConfigurationApplication;
 import org.codice.ddf.preferences.DefaultPreferencesSupplier;
 
 public class DefaultCatalogUiPreferences implements DefaultPreferencesSupplier {
+
+  private final ConfigurationApplication configurationApplication;
+
+  public DefaultCatalogUiPreferences(ConfigurationApplication configurationApplication) {
+    this.configurationApplication = configurationApplication;
+  }
+
   @Override
   public Map<String, Object> create() {
 
@@ -95,7 +103,7 @@ public class DefaultCatalogUiPreferences implements DefaultPreferencesSupplier {
         "querySettings",
         new ImmutableMap.Builder<>()
             .put("type", "text")
-            .put("sources", Collections.singletonList("local"))
+            .put("sources", configurationApplication.getDefaultSources())
             .put(
                 "sorts",
                 Collections.singletonList(

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -597,7 +597,9 @@ Implementation details
 
     <service ref="queryFactory" interface="org.codice.ddf.catalog.ui.query.utility.QueryRequestFactory"/>
 
-    <bean id="defaultPreferenceSettings" class="org.codice.ddf.catalog.ui.preferences.DefaultCatalogUiPreferences"/>
+    <bean id="defaultPreferenceSettings" class="org.codice.ddf.catalog.ui.preferences.DefaultCatalogUiPreferences">
+        <argument ref="configurationApplication"/>
+    </bean>
 
     <service ref="defaultPreferenceSettings" interface="org.codice.ddf.preferences.DefaultPreferencesSupplier"/>
 


### PR DESCRIPTION
To test, clear Solr of def-preferences metacards, or use a user that doesn't have a preference metacard. In the admin catalog-ui system settings, set the default sources. Then log in as the user. In Settings->Search, make sure the sources are pre-selected based on the configuration. Go to Saved Searches and click the New Search button. Make sure the search has the correct sources pre-selected. Pull up the ddf-preferences metacard and make sure querySettings_txt has the sources as expected.
