### PR TITLE
Update fonts to use fallbacks immediately, then swap

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -257,7 +257,7 @@ const GlobalStyles = createGlobalStyle<ThemeInterface>`
       .font-awesome-span {
         && {
           font-size: 1.4rem;
-          font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+          font-family: 'Open Sans', arial, sans-serif;
         }
         /* stylelint-disable */
         &::before {
@@ -447,6 +447,12 @@ export const Provider = ({ children }: { children: any }) => {
     ? lightenUntilContrasting(secondaryMain, paperColor)
     : darkenUntilContrasting(secondaryMain, paperColor)
 
+  /**
+   *  Specify theme settings that don't need variables from theme
+   *
+   *  We do things like the typography here because otherwise the defaults get applied to each individual typography component,
+   *  meaning we'd have to specify overrides for each one.
+   */
   const initialTheme = createTheme({
     palette: {
       mode: darkMode ? 'dark' : 'light',
@@ -466,22 +472,29 @@ export const Provider = ({ children }: { children: any }) => {
         main: '#fff',
       },
     },
+    // Typography must be set here to ensure all components use the same font
+    typography: {
+      fontFamily: `'Open Sans', arial, sans-serif`,
+      button: {
+        textTransform: 'none',
+      },
+    },
+    zIndex: {
+      mobileStepper: 101,
+      appBar: 101,
+      drawer: 101,
+      modal: 101,
+      snackbar: 101,
+      tooltip: 101,
+      fab: 101,
+      speedDial: 101,
+    },
   })
 
   /**
    *  We split these out to so that we can access theme variables within our custom theme
    */
   const themeBasedTheme: ThemeOptions = {
-    typography: {
-      fontFamily: `'Open Sans', arial, sans-serif`,
-      h6: {
-        fontSize: '1.2rem',
-      },
-      fontSize: 16,
-      button: {
-        textTransform: 'none',
-      },
-    },
     components: {
       MuiChip: {
         styleOverrides: {
@@ -607,14 +620,6 @@ export const Provider = ({ children }: { children: any }) => {
           },
         },
       },
-    },
-    zIndex: {
-      mobileStepper: 101,
-      appBar: 101,
-      drawer: 101,
-      modal: 101,
-      snackbar: 101,
-      tooltip: 101,
     },
   }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/additional-styles.css
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/additional-styles.css
@@ -17,6 +17,8 @@ body {
   font-size: inherit;
   transition: font-size 0.25s ease-out;
   overflow: hidden;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 html.theme-dark {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/custom-preflight.css
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/custom-preflight.css
@@ -20,8 +20,6 @@
 1. Use a consistent sensible line-height in all browsers.
 2. Prevent adjustments of font size after orientation changes in iOS.
 3. Use a more readable tab size.
-4. Use the user's configured `sans` font-family by default.
-5. Use the user's configured `sans` font-feature-settings by default.
 */
 html {
   line-height: 1.5; /* 1 */
@@ -29,10 +27,6 @@ html {
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
   tab-size: 4; /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; /* 4 */
-  font-feature-settings: normal; /* 5 */
 }
 /*
 1. Remove the margin in all browsers.

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/fonts.css
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/styles/fonts.css
@@ -5,6 +5,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url('fonts/open-sans/open-sans-v15-latin-300.eot'); /* IE9 Compat Modes */
   src: local('Open Sans Light'), local('OpenSans-Light'),
     url('fonts/open-sans/open-sans-v15-latin-300.eot?#iefix')
@@ -23,6 +24,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('fonts/open-sans/open-sans-v15-latin-regular.eot'); /* IE9 Compat Modes */
   src: local('Open Sans Regular'), local('OpenSans-Regular'),
     url('fonts/open-sans/open-sans-v15-latin-regular.eot?#iefix')
@@ -42,6 +44,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url('fonts/open-sans/open-sans-v15-latin-600.eot'); /* IE9 Compat Modes */
   src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
     url('fonts/open-sans/open-sans-v15-latin-600.eot?#iefix')
@@ -61,6 +64,7 @@
   font-family: 'Inconsolata';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('fonts/inconsolata/inconsolata-v16-latin-regular.eot'); /* IE9 Compat Modes */
   src: local('Inconsolata Regular'), local('Inconsolata-Regular'),
     url('fonts/inconsolata/inconsolata-v16-latin-regular.eot?#iefix')
@@ -81,6 +85,7 @@
   font-family: 'Inconsolata';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('fonts/inconsolata/inconsolata-v16-latin-700.eot'); /* IE9 Compat Modes */
   src: local('Inconsolata Bold'), local('Inconsolata-Bold'),
     url('fonts/inconsolata/inconsolata-v16-latin-700.eot?#iefix')


### PR DESCRIPTION
 - This might help in case certain environments load custom fonts slower than expected.
 - Fixes an issue in theme where we create a theme without a font specified and merge it into one with it specified.  In this case, it was causing the font default to be correct, but individual components to use the default Mui fonts.