### PR TITLE
Updated array check for cross window functionality

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/app.tsx
@@ -96,7 +96,7 @@ const matchesRoute = ({
     )
   } else if (
     routeInfo.routeProps.path &&
-    routeInfo.routeProps.path.constructor === Array
+    Array.isArray(routeInfo.routeProps.path)
   ) {
     return routeInfo.routeProps.path.some(
       (possibleRoute) =>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/reserved-basic-datatype/reserved.basic-datatype.tsx
@@ -254,7 +254,7 @@ function hasValidShape({
 }: {
   value: BasicDatatypeFilter['value']
 }): boolean {
-  if (value === undefined || value === null || value.constructor !== Array) {
+  if (value === undefined || value === null || !Array.isArray(value)) {
     return false
   } else {
     return (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -494,7 +494,7 @@ const AttributeComponent = ({
   if (value === undefined || value === null) {
     value = []
   }
-  if (value.constructor !== Array) {
+  if (!Array.isArray(value)) {
     value = [value]
   }
   const { getAlias, getType } = useMetacardDefinitions()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.tsx
@@ -284,7 +284,7 @@ export const Histogram = ({ selectionInterface }: Props) => {
       const matchedResults = findMatchesForAttributeValues(
         results,
         attributeToBin,
-        category.constructor === Array ? category : [category]
+        Array.isArray(category) ? category : [category]
       )
 
       if (
@@ -484,7 +484,7 @@ export const Histogram = ({ selectionInterface }: Props) => {
           findMatchesForAttributeValues(
             activeSearchResults,
             attributeToCheck,
-            category.constructor === Array ? category : [category]
+            Array.isArray(category) ? category : [category]
           )
         )
         return results

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
@@ -1083,7 +1083,7 @@ export default function CesiumMap(
              Options passed in are color and isSelected.
             */
     updateCluster(geometry: any, options: any) {
-      if (geometry.constructor === Array) {
+      if (Array.isArray(geometry)) {
         geometry.forEach((innerGeometry) => {
           this.updateCluster(innerGeometry, options)
         })
@@ -1122,7 +1122,7 @@ export default function CesiumMap(
               Options passed in are color and isSelected.
               */
     updateGeometry(geometry: any, options: any) {
-      if (geometry.constructor === Array) {
+      if (Array.isArray(geometry)) {
         geometry.forEach((innerGeometry) => {
           this.updateGeometry(innerGeometry, options)
         })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.tsx
@@ -321,7 +321,7 @@ const handleMapHover = ({
     Boolean(
       mapEvent.mapTarget &&
         mapEvent.mapTarget !== 'userDrawing' &&
-        (mapEvent.mapTarget.constructor === Array ||
+        (Array.isArray(mapEvent.mapTarget) ||
           (mapEvent.mapTarget.constructor === String &&
             !(mapEvent.mapTarget as string).startsWith(SHAPE_ID_PREFIX)))
     )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/line-display.tsx
@@ -49,7 +49,7 @@ export function translateFromOpenlayersCoordinates(coords: CoordinatesType) {
 export function translateToOpenlayersCoordinates(coords: CoordinatesType) {
   const coordinates = [] as CoordinatesType
   coords.forEach((item) => {
-    if (item[0].constructor === Array) {
+    if (Array.isArray(item[0])) {
       coordinates.push(
         translateToOpenlayersCoordinates(
           item as unknown as CoordinatesType

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -370,7 +370,7 @@ export default function (
       this.panToExtent(coordinates)
     },
     panToExtent(coords: [number, number][]) {
-      if (coords.constructor === Array && coords.length > 0) {
+      if (Array.isArray(coords) && coords.length > 0) {
         const lineObject = coords.map((coordinate) =>
           convertPointCoordinate(coordinate)
         )
@@ -810,7 +810,7 @@ export default function (
              Options passed in are color and isSelected.
              */
     updateCluster(geometry: any, options: any) {
-      if (geometry.constructor === Array) {
+      if (Array.isArray(geometry)) {
         geometry.forEach((innerGeometry) => {
           this.updateCluster(innerGeometry, options)
         })
@@ -856,7 +856,7 @@ export default function (
               Options passed in are color and isSelected.
             */
     updateGeometry(geometry: any, options: any) {
-      if (geometry.constructor === Array) {
+      if (Array.isArray(geometry)) {
         geometry.forEach((innerGeometry) => {
           this.updateGeometry(innerGeometry, options)
         })

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item-row.tsx
@@ -293,7 +293,7 @@ const RowComponent = ({
                   if (value === undefined) {
                     value = ''
                   }
-                  if (value.constructor !== Array) {
+                  if (!Array.isArray(value)) {
                     value = [value]
                   }
                   if (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -485,7 +485,7 @@ export const ResultItem = ({
     if (value && MetacardDefinitions.getAttributeMap()[detail]) {
       switch (MetacardDefinitions.getAttributeMap()[detail].type) {
         case 'DATE':
-          if (value.constructor === Array) {
+          if (Array.isArray(value)) {
             value = value.map((val: any) =>
               TypedUserInstance.getMomentDate(val)
             )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/AsyncTask/async-task.tsx
@@ -22,7 +22,7 @@ export const convertToBackendCompatibleForm = ({
   const duplicatedProperties = _cloneDeep(properties)
   Object.keys(duplicatedProperties).forEach((key) => {
     if (typeof duplicatedProperties[key] !== 'string') {
-      if (duplicatedProperties[key]?.constructor === Array) {
+      if (Array.isArray(duplicatedProperties[key])) {
         duplicatedProperties[key] = (duplicatedProperties[key] as any[]).map(
           (value) => {
             if (typeof value === 'object') {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/sort.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/sort.tsx
@@ -18,7 +18,7 @@ import { LazyQueryResult } from './LazyQueryResult'
 import { QuerySortType } from './types'
 
 function parseMultiValue(value: any) {
-  if (value && value.constructor === Array) {
+  if (value && Array.isArray(value)) {
     return value[0]
   }
   return value


### PR DESCRIPTION
Cross window array checks would fail - for example in the inspector pop out - because the instanceof check is dependent on the window.Array constructor being the same as the current window's. See more details below:


From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray:

Array.isArray() checks if the passed value is an Array. It does not check the value's prototype chain, nor does it rely on the Array constructor it is attached to. It returns true for any value that was created using the array literal syntax or the Array constructor. This makes it safe to use with cross-realm objects, where the identity of the Array constructor is different and would therefore cause instanceof Array to fail.