### PR TITLE
Fix the display of multivalue  attributes in the results

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -494,11 +494,21 @@ export const ResultItem = ({
           }
           break
         case 'GEOMETRY':
-          value = convertToFormat(value)
+          if (value.constructor === Array) {
+            value = value.map((val: any) => convertToFormat(val))
+          } else {
+            value = convertToFormat(value)
+          }
+          break
         case 'LONG':
         case 'DOUBLE':
         case 'FLOAT':
-          value = convertToPrecision(value)
+          if (value.constructor === Array) {
+            value = value.map((val: any) => convertToPrecision(val))
+          } else {
+            value = convertToPrecision(value)
+          }
+          break
       }
     }
     if (Array.isArray(value)) {


### PR DESCRIPTION
The results panel would crash if GEO or FLOAT attributes had multiple values. 

To test:
1. Create a product with >1 extracted location
2. "Manage attributes" so that the extracted locations attribute displays
3. Confirm the correct information is displayed in the results panel