### PR TITLE
Update dialogs to instead use maxWidth lg, rather than setting it to none

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dialog/dialog.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/dialog/dialog.tsx
@@ -16,6 +16,7 @@ export const useDialog = useDialogContext
 
 export const DialogProvider = (props: DialogProviderProps) => {
   const [dialogProps, setDialogProps] = React.useState({
+    maxWidth: 'lg',
     children: <></>,
     open: false,
     onClose: () => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/transfer-list.tsx
@@ -238,11 +238,6 @@ const ItemRow = ({
           }}
           onClick={() => {
             dialogContext.setProps({
-              PaperProps: {
-                style: {
-                  minWidth: 'none',
-                },
-              },
               open: true,
               children: CustomAttributeEditor ? (
                 <CustomAttributeEditor
@@ -805,14 +800,8 @@ const TransferList = ({
       </div>
       <DarkDivider className="w-full h-min" />
       <DialogContent>
-        <Grid
-          container
-          spacing={2}
-          justifyContent="center"
-          alignItems="center"
-          className="m-auto"
-        >
-          <Grid item>
+        <div className="flex flex-row justify-center items-center space-x-2 flex-nowrap w-full">
+          <div>
             <CustomList
               title="Active"
               items={left}
@@ -829,9 +818,9 @@ const TransferList = ({
               totalPossible={totalPossible}
               mode={mode}
             />
-          </Grid>
-          <Grid item>
-            <Grid container direction="column" alignItems="center">
+          </div>
+          <div>
+            <div className="flex flex-col items-center">
               <Button
                 data-id="move-right-button"
                 variant="outlined"
@@ -852,9 +841,9 @@ const TransferList = ({
               >
                 <LeftArrowIcon />
               </Button>
-            </Grid>
-          </Grid>
-          <Grid item>
+            </div>
+          </div>
+          <div>
             <CustomList
               title="Hidden"
               items={right}
@@ -869,8 +858,8 @@ const TransferList = ({
               mode={mode}
               totalPossible={totalPossible}
             />
-          </Grid>
-        </Grid>
+          </div>
+        </div>
       </DialogContent>
       <DarkDivider className="w-full h-min" />
       <DialogActions>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/theme/theme.tsx
@@ -647,13 +647,6 @@ export const Provider = ({ children }: { children: any }) => {
           },
         },
       },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            maxWidth: 'none',
-          },
-        },
-      },
       MuiPaper: {
         styleOverrides: {
           root: { backgroundImage: 'unset' },

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/table.tsx
@@ -65,12 +65,6 @@ export const ResultsCommonControls = ({
           data-id="manage-attributes-button"
           onClick={() => {
             dialogContext.setProps({
-              PaperProps: {
-                style: {
-                  minWidth: 'none',
-                },
-                elevation: Elevations.panels,
-              },
               open: true,
               disableEnforceFocus: true,
               children: (

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/summary-manage-attributes/summary-manage-attributes.tsx
@@ -16,7 +16,6 @@
 import Button from '@mui/material/Button'
 import user from '../../component/singletons/user-instance'
 import TransferList from '../../component/tabs/metacard/transfer-list'
-import { Elevations } from '../../component/theme/theme'
 import { useDialog } from '../../component/dialog'
 import { TypedUserInstance } from '../../component/singletons/TypedUser'
 import { StartupDataStore } from '../../js/model/Startup/startup'
@@ -30,12 +29,6 @@ export default ({ isExport = false }: { isExport?: boolean }) => {
       data-id="manage-attributes-button"
       onClick={() => {
         dialogContext.setProps({
-          PaperProps: {
-            style: {
-              minWidth: 'none',
-            },
-            elevation: Elevations.panels,
-          },
           open: true,
           disableEnforceFocus: true,
           children: (


### PR DESCRIPTION
 - There were some changes in mui v6 that are hard to pin down, but amongst them is dialog classes / styles changed a bit.  Previously it seemed like setting no max width would be a good solution, but it messes with too many dialogs.  A better middle ground appears to be setting the maxWidth for the dialog to lg for now.