### PR TITLE
Fix issues with multiple react router instances for react router v6

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/base-app.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/base-app.tsx
@@ -1,4 +1,4 @@
-import { lazy, SuspenseProps } from 'react'
+import React, { lazy, SuspenseProps } from 'react'
 import App, { IndividualRouteType, useDefaultWelcome } from './app'
 
 import SourcesPageIcon from '@mui/icons-material/Cloud'
@@ -11,7 +11,7 @@ import ExtensionPoints from '../../extension-points/extension-points'
 import { BaseSettings } from '../../react-component/user-settings/user-settings'
 import Paper from '@mui/material/Paper'
 import { Elevations } from '../theme/theme'
-import { Navigate } from 'react-router-dom'
+import { HashRouter, Navigate } from 'react-router-dom'
 import AddIcon from '@mui/icons-material/Add'
 import ViewListIcon from '@mui/icons-material/ViewList'
 import selectionInterfaceModel from '../selection-interface/selection-interface.model'
@@ -454,9 +454,15 @@ const BaseApp = () => {
 
 const WrappedWithProviders = () => {
   return (
-    <ExtensionPoints.providers>
-      <BaseApp />
-    </ExtensionPoints.providers>
+    <HashRouter
+      future={{
+        v7_startTransition: true,
+      }}
+    >
+      <ExtensionPoints.providers>
+        <BaseApp />
+      </ExtensionPoints.providers>
+    </HashRouter>
   )
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/react-router.patches.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/app/react-router.patches.tsx
@@ -1,0 +1,212 @@
+import {
+  UNSAFE_LocationContext,
+  UNSAFE_NavigationContext,
+} from 'react-router-dom'
+import React from 'react'
+import { Subscribable } from '../../js/model/Base/base-classes'
+import { useSubscribable } from '../../js/model/Base/base-classes.hooks'
+import { GoldenLayoutWindowCommunicationEvents } from '../golden-layout/cross-window-communication'
+
+/**
+ * This module provides a solution for sharing React Router v6 context across multiple React roots, as well as golden-layout subwindows (popouts).
+ * See https://github.com/remix-run/react-router/issues/10089 for more details.
+ *
+ * Problem:
+ * - React Router v6 uses internal history/location objects that aren't shared between different Router instances
+ * - Our application uses multiple React roots due to golden-layout integration
+ * - Golden-layout doesn't have native React support, so we need to patch the contexts somehow
+ * - We need the ability to also handle popouts, which have their own Router instances.
+ */
+
+class SubscribableNavigationContextClass extends Subscribable<{
+  thing: 'update'
+}> {
+  navigationContext: React.ContextType<typeof UNSAFE_NavigationContext> | null =
+    null
+  updateNavigationContext(
+    navigationContext: React.ContextType<typeof UNSAFE_NavigationContext>
+  ) {
+    this.navigationContext = navigationContext
+    this._notifySubscribers({ thing: 'update' })
+    console.log('updateNavigationContext', navigationContext)
+  }
+}
+
+class SubscribableLocationContextClass extends Subscribable<{
+  thing: 'update'
+}> {
+  locationContext: React.ContextType<typeof UNSAFE_LocationContext> | null =
+    null
+  updateLocationContext(
+    locationContext: React.ContextType<typeof UNSAFE_LocationContext>
+  ) {
+    this.locationContext = locationContext
+    this._notifySubscribers({ thing: 'update' })
+    console.log('updateLocationContext', locationContext)
+  }
+}
+
+let SubscribableNavigationContext = new SubscribableNavigationContextClass()
+let SubscribableLocationContext = new SubscribableLocationContextClass()
+
+/**
+ * Component that syncs the current React Router context to our shared variables.  While we could alternatively use prop drilling by
+ * accessing context and passing it to the new root, this is much simpler.
+ *
+ * This should be rendered within the Router component of the primary React root
+ */
+export const SyncReactRouterContextToVariables = () => {
+  const navigationContext = React.useContext(UNSAFE_NavigationContext)
+  const locationContext = React.useContext(UNSAFE_LocationContext)
+
+  React.useEffect(() => {
+    SubscribableNavigationContext.updateNavigationContext(navigationContext)
+  }, [navigationContext])
+  React.useEffect(() => {
+    SubscribableLocationContext.updateLocationContext(locationContext)
+  }, [locationContext])
+
+  return null
+}
+
+function useSharedNavigationContext() {
+  const [navigationContext, setNavigationContext] =
+    React.useState<React.ContextType<typeof UNSAFE_NavigationContext> | null>(
+      SubscribableNavigationContext.navigationContext
+    )
+  useSubscribable(SubscribableNavigationContext, 'update', () => {
+    setNavigationContext(SubscribableNavigationContext.navigationContext)
+  })
+  return navigationContext
+}
+
+function useSharedLocationContext() {
+  const [locationContext, setLocationContext] =
+    React.useState<React.ContextType<typeof UNSAFE_LocationContext> | null>(
+      SubscribableLocationContext.locationContext
+    )
+  useSubscribable(SubscribableLocationContext, 'update', () => {
+    setLocationContext(SubscribableLocationContext.locationContext)
+  })
+  return locationContext
+}
+
+/**
+ * Provider component that provides the shared Router context to its children
+ * This should be used in secondary React roots to receive the shared context
+ */
+export const PatchReactRouterContext = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const navigationContext = useSharedNavigationContext()
+  const locationContext = useSharedLocationContext()
+  if (!navigationContext || !locationContext) {
+    throw new Error('Navigation or location context not found')
+  }
+  return (
+    <UNSAFE_NavigationContext.Provider value={navigationContext}>
+      <UNSAFE_LocationContext.Provider value={locationContext}>
+        {children}
+      </UNSAFE_LocationContext.Provider>
+    </UNSAFE_NavigationContext.Provider>
+  )
+}
+
+/**
+ *  In subwindows (popouts) we want to redirect navigation events back to the main window through the event bus.
+ */
+function patchNavigationContextForGoldenLayoutSubwindows({
+  navigationContext,
+  goldenLayout,
+}: {
+  navigationContext: React.ContextType<typeof UNSAFE_NavigationContext> | null
+  goldenLayout: any
+}) {
+  if (!navigationContext) {
+    throw new Error('Navigation context not found')
+  }
+  const replaceWrapper = (to: string, options?: { state?: any }) => {
+    goldenLayout.eventHub.emit(
+      GoldenLayoutWindowCommunicationEvents.consumeNavigationChange,
+      {
+        replace: [to, { ...options, replace: true }],
+      }
+    )
+  }
+  const pushWrapper = (to: string, options?: { state?: any }) => {
+    goldenLayout.eventHub.emit(
+      GoldenLayoutWindowCommunicationEvents.consumeNavigationChange,
+      {
+        push: [to, options],
+      }
+    )
+  }
+  Object.defineProperty(navigationContext.navigator, 'replace', {
+    value: replaceWrapper,
+    writable: true,
+  })
+  Object.defineProperty(navigationContext.navigator, 'push', {
+    value: pushWrapper,
+    writable: true,
+  })
+  return navigationContext
+}
+
+/**
+ * Hook that provides the shared Router context for golden layout subwindows (popouts)
+ */
+function useSharedNavigationContextForGoldenLayoutSubwindows({
+  goldenLayout,
+}: {
+  goldenLayout: any
+}) {
+  const [navigationContext, setNavigationContext] =
+    React.useState<React.ContextType<typeof UNSAFE_NavigationContext> | null>(
+      patchNavigationContextForGoldenLayoutSubwindows({
+        navigationContext: SubscribableNavigationContext.navigationContext,
+        goldenLayout,
+      })
+    )
+  useSubscribable(SubscribableNavigationContext, 'update', () => {
+    setNavigationContext(
+      patchNavigationContextForGoldenLayoutSubwindows({
+        navigationContext: SubscribableNavigationContext.navigationContext,
+        goldenLayout,
+      })
+    )
+  })
+  return navigationContext
+}
+
+/**
+ * Provider component that patches the React Router context for golden layout subwindows (popouts), and also handles normal React roots when applicable.
+ */
+export const PatchReactRouterContextForGoldenLayoutSubwindows = ({
+  children,
+  goldenLayout,
+}: {
+  children: React.ReactNode
+  goldenLayout: any
+}) => {
+  if (!goldenLayout || !goldenLayout.isSubWindow) {
+    return <PatchReactRouterContext>{children}</PatchReactRouterContext>
+  }
+  const navigationContext = useSharedNavigationContextForGoldenLayoutSubwindows(
+    {
+      goldenLayout,
+    }
+  )
+  const locationContext = useSharedLocationContext()
+  if (!navigationContext || !locationContext) {
+    throw new Error('Navigation or location context not found')
+  }
+  return (
+    <UNSAFE_NavigationContext.Provider value={navigationContext}>
+      <UNSAFE_LocationContext.Provider value={locationContext}>
+        {children}
+      </UNSAFE_LocationContext.Provider>
+    </UNSAFE_NavigationContext.Provider>
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/cross-window-communication.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/cross-window-communication.tsx
@@ -466,9 +466,6 @@ const useConsumeWreqrEvents = ({
 /**
  *  Overrides navigation functionality within subwindows of golden layout, so that navigation is handled by the main window.
  *
- *  Notice we do this as a component rather than a hook so we can override the same useHistory instance that the visualization is using.
- *  (we temporarily eject from react to use golden layout, and rewrap each visual in it's own instance of the various providers, like react router)
- *
  *  We could rewrite it as a hook and put it further down in the tree, but this is the same thing so no need.
  *
  *  Also notice we attach this at the visual level for that reason, rather than at the single golden layout instance level.
@@ -478,11 +475,8 @@ export const UseSubwindowConsumeNavigationChange = ({
 }: {
   goldenLayout: any
 }) => {
-  const navigate = useNavigate()
-  const location = useLocation()
-
   React.useEffect(() => {
-    if (goldenLayout && navigate && goldenLayout.isSubWindow) {
+    if (goldenLayout && goldenLayout.isSubWindow) {
       const callback = (e: MouseEvent) => {
         if (
           e.target?.constructor === HTMLAnchorElement &&
@@ -498,38 +492,12 @@ export const UseSubwindowConsumeNavigationChange = ({
         }
       }
       document.addEventListener('click', callback)
-      // Override navigate functions
-      const replaceWrapper = (to: string, options?: { state?: any }) => {
-        goldenLayout.eventHub.emit(
-          GoldenLayoutWindowCommunicationEvents.consumeNavigationChange,
-          {
-            replace: [to, { ...options, replace: true }],
-          }
-        )
-      }
-      const pushWrapper = (to: string, options?: { state?: any }) => {
-        goldenLayout.eventHub.emit(
-          GoldenLayoutWindowCommunicationEvents.consumeNavigationChange,
-          {
-            push: [to, options],
-          }
-        )
-      }
-      // Attach the wrapper functions
-      Object.defineProperty(navigate, 'replace', {
-        value: replaceWrapper,
-        writable: true,
-      })
-      Object.defineProperty(navigate, 'push', {
-        value: pushWrapper,
-        writable: true,
-      })
       return () => {
         document.removeEventListener('click', callback)
       }
     }
     return () => {}
-  }, [navigate, location, goldenLayout])
+  }, [goldenLayout])
   return null
 }
 

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.tsx
@@ -54,7 +54,9 @@ import { getGoldenLayoutSettings } from './golden-layout.layout-config-handling'
  */
 import { getDefaultComponentState } from '../visualization/settings-helpers'
 import { ComponentNameType } from './golden-layout.types'
-;(function preventRemovalFromStorage() {
+import { PatchReactRouterContextForGoldenLayoutSubwindows } from '../app/react-router.patches'
+
+function preventRemovalFromStorage() {
   const normalRemoveItem = window.localStorage.removeItem
   window.localStorage.removeItem = (key: string) => {
     if (key.includes('gl-window')) {
@@ -63,7 +65,8 @@ import { ComponentNameType } from './golden-layout.types'
       normalRemoveItem(key)
     }
   }
-})()
+}
+preventRemovalFromStorage()
 
 /**
  *  We attach this at the component level due to how popouts work.
@@ -125,22 +128,29 @@ const GoldenLayoutComponent = ({
   }, [componentState])
 
   return (
-    <ExtensionPoints.providers>
-      <VisualSettingsProvider container={container} goldenLayout={goldenLayout}>
-        <UseSubwindowConsumeNavigationChange goldenLayout={goldenLayout} />
-        <UseMissingParentWindow goldenLayout={goldenLayout} />
-        <Paper
-          elevation={Elevations.panels}
-          className={`w-full h-full ${isMinimized ? 'hidden' : ''}`}
-          square
+    <PatchReactRouterContextForGoldenLayoutSubwindows
+      goldenLayout={goldenLayout}
+    >
+      <ExtensionPoints.providers>
+        <VisualSettingsProvider
+          container={container}
+          goldenLayout={goldenLayout}
         >
-          <ComponentView
-            selectionInterface={options.selectionInterface}
-            componentState={normalizedComponentState}
-          />
-        </Paper>
-      </VisualSettingsProvider>
-    </ExtensionPoints.providers>
+          <UseSubwindowConsumeNavigationChange goldenLayout={goldenLayout} />
+          <UseMissingParentWindow goldenLayout={goldenLayout} />
+          <Paper
+            elevation={Elevations.panels}
+            className={`w-full h-full ${isMinimized ? 'hidden' : ''}`}
+            square
+          >
+            <ComponentView
+              selectionInterface={options.selectionInterface}
+              componentState={normalizedComponentState}
+            />
+          </Paper>
+        </VisualSettingsProvider>
+      </ExtensionPoints.providers>
+    </PatchReactRouterContextForGoldenLayoutSubwindows>
   )
 }
 // see https://github.com/deepstreamIO/golden-layout/issues/239 for details on why the setTimeout is necessary

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/providers/providers.container.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/providers/providers.container.tsx
@@ -19,7 +19,6 @@ import { IntlProvider } from 'react-intl'
 import { Provider as ThemeProvider } from '../../component/theme/theme'
 import { SnackProvider } from '../../component/snack/snack.provider'
 import { DialogProvider } from '../../component/dialog'
-import { HashRouter as Router } from 'react-router-dom'
 import { useConfiguration } from '../../js/model/Startup/configuration.hooks'
 
 export type Props = {
@@ -33,17 +32,9 @@ const ProviderContainer = (props: Props) => {
       <ThemeContainer>
         <IntlProvider locale={navigator.language} messages={getI18n()}>
           <ThemeProvider>
-            <Router
-              future={{
-                v7_startTransition: true,
-              }}
-            >
-              <SnackProvider>
-                <DialogProvider>
-                  <>{props.children}</>
-                </DialogProvider>
-              </SnackProvider>
-            </Router>
+            <SnackProvider>
+              <DialogProvider>{props.children}</DialogProvider>
+            </SnackProvider>
           </ThemeProvider>
         </IntlProvider>
       </ThemeContainer>


### PR DESCRIPTION
 - In v6, react router moved to an internal history object, which means navigation in separate roots no longer send events to the original router.
 - We now render a single router at the root of the app rather than in providers.
 - We have a hook that runs within that router to sync context to an outside variable (history and location).
 - The non primary react roots now are wrapped in a provider that uses that to construct history and location contexts.
 - The provider also handles golden layout subwindows, as those need to handle navigation events by emitting them back to the main window.