### PR TITLE
Migrate editable attributes / can write permission extensions to overridable pattern

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overridable/overridable-can-write-permission.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overridable/overridable-can-write-permission.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { Overridable } from '../../js/model/Base/base-classes'
+import { useOverridable } from '../../js/model/Base/base-classes.hooks'
+import type { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
+import type { TypedUserInstanceType } from '../singletons/TypedUser'
+import type { useConfigurationType } from '../../js/model/Startup/configuration.hooks'
+
+export type CanWritePermissionType = (props: {
+  attribute: string
+  lazyResult: LazyQueryResult
+  user: any
+  editableAttributes: string[]
+  typedUserInstance: TypedUserInstanceType
+  configuration: ReturnType<useConfigurationType>
+}) => boolean
+
+// export this as a fallback for downstream to use
+export const BaseCanWritePermission: CanWritePermissionType = (props) => {
+  const { attribute, lazyResult, typedUserInstance, configuration } = props
+  const canWrite =
+    !lazyResult.isRemote() &&
+    typedUserInstance.canWrite(lazyResult) &&
+    !configuration.isReadOnly(attribute)
+  return canWrite
+}
+
+export const OverridableCanWritePermission = new Overridable(
+  BaseCanWritePermission
+)
+
+export const useCanWritePermission = () => {
+  return useOverridable(OverridableCanWritePermission)
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overridable/overridable-editable-attributes.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/overridable/overridable-editable-attributes.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { Overridable } from '../../js/model/Base/base-classes'
+import { useOverridable } from '../../js/model/Base/base-classes.hooks'
+import React from 'react'
+
+export type BaseEditableAttributes = () => Promise<string[]>
+
+export const BaseFetchEditableAttributes: BaseEditableAttributes = async () => {
+  return []
+}
+
+export const OverridableFetchEditableAttributes = new Overridable(
+  BaseFetchEditableAttributes
+)
+
+export const useFetchEditableAttributes = () => {
+  return useOverridable(OverridableFetchEditableAttributes)
+}
+
+let cachedFetchEditableAttributesPromise = null as null | Promise<string[]>
+let cachedFetchEditableAttributesFunction = null as
+  | null
+  | (() => Promise<string[]>)
+
+export const useCustomEditableAttributes = () => {
+  const [customEditableAttributes, setCustomEditableAttributes] =
+    React.useState<null | string[]>(null)
+  const fetchEditableAttributes = useFetchEditableAttributes()
+
+  React.useEffect(() => {
+    if (
+      cachedFetchEditableAttributesPromise === null ||
+      cachedFetchEditableAttributesFunction !== fetchEditableAttributes
+    ) {
+      setCustomEditableAttributes(null)
+      cachedFetchEditableAttributesFunction = fetchEditableAttributes
+      cachedFetchEditableAttributesPromise = fetchEditableAttributes()
+    }
+    cachedFetchEditableAttributesPromise
+      .then((editableAttributes) => {
+        setCustomEditableAttributes(editableAttributes)
+      })
+      .catch(() => {
+        setCustomEditableAttributes([])
+      })
+  }, [fetchEditableAttributes])
+
+  return {
+    loading: customEditableAttributes === null,
+    customEditableAttributes,
+  }
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/TypedUser.tsx
@@ -223,3 +223,5 @@ type QuerySettingsModelType = {
   set: (attr: any, value?: any) => void
   toJSON: () => QuerySettingsType
 }
+
+export type TypedUserInstanceType = typeof TypedUserInstance

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/summary.tsx
@@ -40,6 +40,7 @@ import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-defin
 import Common from '../../../js/Common'
 import SummaryManageAttributes from '../../../react-component/summary-manage-attributes/summary-manage-attributes'
 import moment from 'moment-timezone'
+import CircularProgress from '@mui/material/CircularProgress'
 
 type Props = {
   result: LazyQueryResult
@@ -499,7 +500,7 @@ const AttributeComponent = ({
   }
   const { getAlias, getType } = useMetacardDefinitions()
   let label = getAlias(attr)
-  const { isNotWritable } = useCustomReadOnlyCheck()
+  const { isWritable, loading } = useCustomReadOnlyCheck()
   const dialogContext = useDialog()
   const convertToFormat = useCoordinateFormat()
   const convertToPrecision = (value: any) => {
@@ -540,7 +541,7 @@ const AttributeComponent = ({
         wrap={'nowrap'}
         className="group relative"
       >
-        {isNotWritable({ attribute: attr, lazyResult }) ? null : (
+        {!loading && isWritable({ attribute: attr, lazyResult }) ? (
           <div className="p-1 hidden group-hover:block absolute right-0 top-0">
             <Button
               onClick={() => {
@@ -568,8 +569,14 @@ const AttributeComponent = ({
               <EditIcon />
             </Button>
           </div>
-        )}
-
+        ) : null}
+        {loading ? (
+          <>
+            <div className="p-1 hidden group-hover:block absolute right-0 top-0">
+              <CircularProgress />
+            </div>
+          </>
+        ) : null}
         <Grid
           item
           xs={4}
@@ -703,7 +710,7 @@ const AttributeComponent = ({
         </Grid>
       </Grid>
     )
-  }, [summaryShown, forceRender, isNotWritable])
+  }, [summaryShown, forceRender, isWritable, loading])
   return (
     <div style={{ display: isFiltered ? 'none' : 'block' }}>{MemoItem}</div>
   )

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -42,13 +42,6 @@ export type ExtensionPointsType = {
     value: string
     onChange: (val: any) => void
   }) => React.ReactNode | undefined
-  customCanWritePermission: (props: {
-    attribute: string
-    lazyResult: LazyQueryResult
-    user: any
-    editableAttributes: string[]
-  }) => boolean | undefined
-  customEditableAttributes: () => Promise<any>
   resultItemTitleAddOn: ({
     lazyResult,
   }: {
@@ -128,8 +121,6 @@ const ExtensionPoints: ExtensionPointsType = {
   providers,
   metacardInteractions,
   customFilterInput: () => undefined,
-  customCanWritePermission: () => undefined,
-  customEditableAttributes: async () => undefined,
   resultItemTitleAddOn: () => null,
   resultTitleIconAddOn: () => null,
   resultItemRowAddOn: () => null,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -474,3 +474,5 @@ export class LazyQueryResult {
   }
   currentOverlayUrl?: string
 }
+
+export type LazyQueryResultType = typeof LazyQueryResult

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.hooks.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/Startup/configuration.hooks.tsx
@@ -37,3 +37,5 @@ export const useConfiguration = () => {
   )
   return configuration
 }
+
+export type useConfigurationType = typeof useConfiguration


### PR DESCRIPTION
 - Migrates these extension points to use overridable instead as it's more flexible, and involves less need to entangle them within startup procedures.
 - Updates the can write usages to use isWritable rather than isNotWritable as that's easier for folks to understand.
 - Fixes an issue with the original editable attributes extension in the new overridable, as previously this could be called many times resulting in a massive amount of network calls, when in reality it needs to only be called once.