### PR TITLE
Fix issues with openlayer geometry styles sometimes not appearing correctly

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -802,7 +802,7 @@ export default function (
           width: 4,
         }),
       })
-      ;(feature as any).unselectedStyle = [
+      feature.set('unselectedStyle', [
         new Style({
           stroke: new Stroke({
             color: 'white',
@@ -810,8 +810,8 @@ export default function (
           }),
         }),
         commonStyle,
-      ]
-      ;(feature as any).selectedStyle = [
+      ])
+      feature.set('selectedStyle', [
         new Style({
           stroke: new Stroke({
             color: 'black',
@@ -819,11 +819,11 @@ export default function (
           }),
         }),
         commonStyle,
-      ]
+      ])
       feature.setStyle(
         options.isSelected
-          ? (feature as any).selectedStyle
-          : (feature as any).unselectedStyle
+          ? feature.get('selectedStyle')
+          : feature.get('unselectedStyle')
       )
       const vectorSource = new VectorSource({
         features: [feature],


### PR DESCRIPTION
 - This aligns the addLine method to be more like other areas involving styles that use the proper get / set methods that exist on Features in openlayers.  Previous versions it doesn't appear to have mattered, but with the latest upgrade it appears to cause issues if we don't use them, likely due to how they manage the Feature object internally.

Current issue (seen with results that have complex geometries):
![Screenshot 2025-03-21 at 3 25 02 PM](https://github.com/user-attachments/assets/2a09b505-5974-4ad9-ac1e-a4c095670c95)
![Screenshot 2025-03-21 at 3 25 07 PM](https://github.com/user-attachments/assets/d48afd55-d912-4f1c-bc17-e01c31aaef78)

With the fix:
![Screenshot 2025-03-21 at 3 25 41 PM](https://github.com/user-attachments/assets/63e6ce06-dd32-436f-8ea2-ccb5316dcb66)
![Screenshot 2025-03-21 at 3 25 37 PM](https://github.com/user-attachments/assets/4eea9c2a-6ab4-49f8-a33f-2f6c0aab90b7)

