### PR TITLE
[5.2.9.x] Fix the logic for updating old drawings vs locking them

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
@@ -18,7 +18,10 @@ import Cesium from 'cesium/Build/Cesium/Cesium'
 import _ from 'underscore'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
+import {
+  removeOldDrawing,
+  makeOldDrawingNonEditable,
+} from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
 import DistanceUtils from '../../../../js/DistanceUtils'
@@ -150,8 +153,6 @@ const drawGeometry = ({
     }
   }
 
-  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
-
   let primitive
 
   if (onDraw) {
@@ -251,6 +252,10 @@ const useListenToModel = ({
           // want to update the existing model unless the user clicks Apply.
           const newModel = model.clone()
           newModel.set(newBbox)
+          makeOldDrawingNonEditable({
+            map,
+            id: getIdFromModelForDisplay({ model }),
+          })
           drawGeometry({
             map,
             model: newModel,
@@ -259,6 +264,7 @@ const useListenToModel = ({
             onDraw,
           })
         } else if (model) {
+          removeOldDrawing({ map, id: getIdFromModelForDisplay({ model }) })
           drawGeometry({
             map,
             model,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
@@ -20,7 +20,10 @@ import _ from 'underscore'
 import * as Turf from '@turf/turf'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
+import {
+  removeOldDrawing,
+  makeOldDrawingNonEditable,
+} from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import TurfCircle from '@turf/circle'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
@@ -133,8 +136,6 @@ const drawGeometry = ({
     modelProp.lon += translation.longitude
     modelProp.lat += translation.latitude
   }
-
-  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   let primitive
 
@@ -255,6 +256,10 @@ const useListenToModel = ({
           // want to update the existing model unless the user clicks Apply.
           const newModel = model.clone()
           newModel.set(newCircle)
+          makeOldDrawingNonEditable({
+            map,
+            id: getIdFromModelForDisplay({ model }),
+          })
           drawGeometry({
             map,
             model: newModel,
@@ -263,6 +268,7 @@ const useListenToModel = ({
             onDraw,
           })
         } else if (model) {
+          removeOldDrawing({ map, id: getIdFromModelForDisplay({ model }) })
           drawGeometry({
             map,
             model,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/drawing-and-display.tsx
@@ -61,7 +61,13 @@ export const removeOldDrawing = ({ map, id }: { map: any; id: string }) => {
   relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
 }
 
-const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
+export const makeOldDrawingNonEditable = ({
+  map,
+  id,
+}: {
+  map: any
+  id: string
+}) => {
   const relevantPrimitives = map
     .getMap()
     .scene.primitives._primitives.filter((prim: any) => {
@@ -76,102 +82,6 @@ const makeOldDrawingNonEditable = ({ map, id }: { map: any; id: string }) => {
     }
   })
   relevantPrimitives.length > 0 && map.getMap().scene.requestRender()
-}
-
-const nestedArraysOverlap = (arrayA: any[], arrayB: any[]) => {
-  return arrayA.some((elemA) =>
-    arrayB.some((elemB) => JSON.stringify(elemA) === JSON.stringify(elemB))
-  )
-}
-
-const isNewShape = (model: any) => {
-  const mode = model.get('mode')
-  switch (mode) {
-    case 'bbox':
-      const box = {
-        north: model.get('north'),
-        east: model.get('east'),
-        west: model.get('west'),
-        south: model.get('south'),
-      }
-      let prevModel = model.previousAttributes()
-      if (box.north && prevModel) {
-        const prevBox = {
-          north: prevModel['north'],
-          east: prevModel['east'],
-          west: prevModel['west'],
-          south: prevModel['south'],
-        }
-        if (prevBox.north) {
-          return !(
-            box.north === prevBox.north ||
-            box.east === prevBox.east ||
-            box.west === prevBox.west ||
-            box.south === prevBox.south
-          )
-        }
-      }
-    case 'circle':
-      const circle = { lon: model.get('lon'), lat: model.get('lat') }
-      prevModel = model.previousAttributes()
-      if (circle && prevModel) {
-        const prevCircle = { lon: prevModel['lon'], lat: prevModel['lat'] }
-        if (prevCircle.lat && prevCircle.lon) {
-          return !(
-            circle.lat === prevCircle.lat || circle.lon === prevCircle.lon
-          )
-        }
-      }
-    case 'line':
-      const line = model.get('line')
-      prevModel = model.previousAttributes()
-      if (line && prevModel) {
-        const prevLine = prevModel['line']
-        if (prevLine) {
-          return !nestedArraysOverlap(line, prevLine)
-        }
-      }
-    case 'poly':
-      const poly = model.get('polygon')
-      prevModel = model.previousAttributes()
-      if (prevModel) {
-        const prevPoly = prevModel['polygon']
-        if (prevPoly) {
-          return !nestedArraysOverlap(poly, prevPoly)
-        }
-      }
-    default:
-      return false
-  }
-}
-
-export const removeOrLockOldDrawing = (
-  isInteractive: boolean,
-  id: any,
-  map: any,
-  model: any
-) => {
-  const canChange = [
-    'isInteractive',
-    'polygonBufferWidth',
-    'lineWidth',
-    'line',
-    'polygon',
-    'usng',
-    'bbox',
-  ]
-
-  // remove previous shape from map after updating attributes, dragging shape, or exiting interactive mode
-  if (
-    isInteractive ||
-    (!isInteractive &&
-      Object.keys(model.changed).some((change) => canChange.includes(change)) &&
-      !isNewShape(model))
-  ) {
-    removeOldDrawing({ map, id })
-  } else {
-    makeOldDrawingNonEditable({ map, id })
-  }
 }
 
 let drawingLocation: any

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
@@ -22,7 +22,10 @@ import * as Turf from '@turf/turf'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
+import {
+  removeOldDrawing,
+  makeOldDrawingNonEditable,
+} from './drawing-and-display'
 import { getIdFromModelForDisplay } from '../drawing-and-display'
 import DrawHelper from '../../../../lib/cesium-drawhelper/DrawHelper'
 import utility from './utility'
@@ -233,8 +236,6 @@ const drawGeometry = ({
   const cameraMagnitude = map.getMap().camera.getMagnitude()
   setDrawnMagnitude(cameraMagnitude)
 
-  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
-
   let primitive
 
   if (onDraw) {
@@ -352,6 +353,10 @@ const useListenToLineModel = ({
           // want to update the existing model unless the user clicks Apply.
           const newModel = model.clone()
           newModel.set(newLine)
+          makeOldDrawingNonEditable({
+            map,
+            id: getIdFromModelForDisplay({ model }),
+          })
           drawGeometry({
             map,
             model: newModel,
@@ -360,6 +365,7 @@ const useListenToLineModel = ({
             onDraw,
           })
         } else if (model) {
+          removeOldDrawing({ map, id: getIdFromModelForDisplay({ model }) })
           drawGeometry({
             map,
             model,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
@@ -19,7 +19,10 @@ import Cesium from 'cesium/Build/Cesium/Cesium'
 import { validateGeo } from '../../../../react-component/utils/validation'
 import { useListenTo } from '../../../selection-checkbox/useBackbone.hook'
 import { useRender } from '../../../hooks/useRender'
-import { removeOldDrawing, removeOrLockOldDrawing } from './drawing-and-display'
+import {
+  makeOldDrawingNonEditable,
+  removeOldDrawing,
+} from './drawing-and-display'
 import ShapeUtils from '../../../../js/ShapeUtils'
 import {
   constructSolidLinePrimitive,
@@ -163,8 +166,6 @@ const drawGeometry = ({
 
   const cameraMagnitude = map.getMap().camera.getMagnitude()
   setDrawnMagnitude(cameraMagnitude)
-
-  removeOrLockOldDrawing(Boolean(isInteractive), id, map, model)
 
   const buffer = DistanceUtils.getDistanceInMeters(
     json.polygonBufferWidth,
@@ -332,6 +333,10 @@ const useListenToLineModel = ({
           // want to update the existing model unless the user clicks Apply.
           const newModel = model.clone()
           newModel.set(newPoly)
+          makeOldDrawingNonEditable({
+            map,
+            id: getIdFromModelForDisplay({ model }),
+          })
           drawGeometry({
             map,
             model: newModel,
@@ -340,6 +345,7 @@ const useListenToLineModel = ({
             onDraw,
           })
         } else if (model) {
+          removeOldDrawing({ map, id: getIdFromModelForDisplay({ model }) })
           drawGeometry({
             map,
             model,


### PR DESCRIPTION
 - In the old logic, translating a shape on another map (click, then drag) would cause other cesium maps to show both the new location of the shape and the old.
 -  Now, each shape directly calls the appropriate method (lock or remove) based on internal branching logic, preventing duplicate renderings and ensuring consistent state across maps.
 
 Backport of https://github.com/codice/ddf-ui/pull/1040