### PR TITLE
Updates the date range overlap test to properly diff the dates

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/fields/date-range.spec.tsx
@@ -114,9 +114,9 @@ describe('verify date range field works', () => {
 
     const handleChange = (validValue: ValueTypes['during']) => {
       // verify these are one day apart, as should happen when fed overlapping dates or invalid values
-      const start = new Date(validValue.start)
-      const end = new Date(validValue.end)
-      expect(start.getDate()).to.equal(end.getDate() - 1)
+      const start = moment(validValue.start)
+      const end = moment(validValue.end)
+      expect(start.diff(end, 'days')).to.equal(-1)
     }
 
     render(


### PR DESCRIPTION
 - The previous version would fail if run on the final day of the month, since the next day would be smaller than it (resulting in something like -30 on the 31st instead of 1).  This uses moment so the diff is always going to work.