### PR TITLE
Update cesium shape model listeners to include color changes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/bbox-display.tsx
@@ -274,7 +274,7 @@ const useListenToModel = ({
   }, [model, map, newBbox, translation, isInteractive])
   useListenTo(
     model,
-    'change:mapNorth change:mapSouth change:mapEast change:mapWest',
+    'change:mapNorth change:mapSouth change:mapEast change:mapWest change:color',
     callback
   )
   React.useEffect(() => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/circle-display.tsx
@@ -276,7 +276,11 @@ const useListenToModel = ({
       }
     }
   }, [model, map, newCircle, translation, isInteractive])
-  useListenTo(model, 'change:lat change:lon change:radius', callback)
+  useListenTo(
+    model,
+    'change:lat change:lon change:radius change:color',
+    callback
+  )
   React.useEffect(() => {
     if (map && needsRedraw({ map, drawnMagnitude })) {
       callback()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/line-display.tsx
@@ -373,7 +373,11 @@ const useListenToLineModel = ({
       }
     }
   }, [model, map, newLine, translation, isInteractive])
-  useListenTo(model, 'change:line change:lineWidth change:lineUnits', callback)
+  useListenTo(
+    model,
+    'change:line change:lineWidth change:lineUnits change:color',
+    callback
+  )
   React.useEffect(() => {
     if (map && needsRedraw({ map, drawnMagnitude })) {
       callback()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/polygon-display.tsx
@@ -355,7 +355,7 @@ const useListenToLineModel = ({
   }, [model, map, newPoly, translation, isInteractive])
   useListenTo(
     model,
-    'change:polygon change:polygonBufferWidth change:polygonBufferUnits',
+    'change:polygon change:polygonBufferWidth change:polygonBufferUnits change:color',
     callback
   )
   React.useEffect(() => {


### PR DESCRIPTION
 - Updates to color weren't being detected previously, until another property changed as well.