### PR TITLE
Websocket no longer registered via whiteboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <fmt.maven.plugin.version>2.3.0</fmt.maven.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.29.18</ddf.version>
+    <ddf.version>2.29.19</ddf.version>
     <ddf-jsonrpc.version>0.9</ddf-jsonrpc.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <antlr.version>4.3</antlr.version>

--- a/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/endpoints.xml
+++ b/ui-backend/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/endpoints.xml
@@ -45,15 +45,6 @@ Services (HTTP/WS) that catalog-ui-search provides for the UI
         </service-properties>
     </service>
 
-    <service ref="socketServlet" interface="javax.servlet.Servlet">
-        <service-properties>
-            <entry key="osgi.http.whiteboard.servlet.pattern" value="/search/catalog/ws/*"/>
-            <entry key="osgi.http.whiteboard.servlet.name" value="websocketServlet"/>
-            <entry key="osgi.http.whiteboard.context.select" value="(osgi.http.whiteboard.context.path=/)"/>
-            <entry key="osgi.http.whiteboard.servlet.asyncSupported" value="true"/>
-        </service-properties>
-    </service>
-
     <!--
     =============================================================
     MAP LAYERS DYNAMIC PROXY


### PR DESCRIPTION
Left in/missed during rebase. Socket Servlet (/search/catalog/ws websocket) should no longer be registered as a servlet