### PR TITLE
Always visible external and artefact links v2

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/download-button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/download-button.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import Button from '@mui/material/Button'
+import GetAppIcon from '@mui/icons-material/GetApp'
+import { Grid2 } from '@mui/material'
+import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
+import { useDownloadComponent } from '../download/download'
+import { useDialog } from '../dialog'
+
+type DownloadButtonProps = {
+  lazyResult: LazyQueryResult
+}
+
+export const DownloadButton = ({ lazyResult }: DownloadButtonProps) => {
+    const DownloadComponent = useDownloadComponent()
+    const { setProps } = useDialog()
+
+    return (
+        <Grid2 className="h-full">
+            <Button
+            component="div"
+            data-id="download-button"
+            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                e.stopPropagation()
+                setProps({
+                open: true,
+                children: <DownloadComponent lazyResults={[lazyResult]} />,
+                })
+            }}
+            style={{ height: '100%' }}
+            size="small"
+            disabled={lazyResult.getDownloadUrl() ? false : true}
+            >
+            <GetAppIcon />
+            </Button>
+        </Grid2>
+    )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/download-button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/download-button.tsx
@@ -11,27 +11,27 @@ type DownloadButtonProps = {
 }
 
 export const DownloadButton = ({ lazyResult }: DownloadButtonProps) => {
-    const DownloadComponent = useDownloadComponent()
-    const { setProps } = useDialog()
+  const DownloadComponent = useDownloadComponent()
+  const { setProps } = useDialog()
 
-    return (
-        <Grid2 className="h-full">
-            <Button
-            component="div"
-            data-id="download-button"
-            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                e.stopPropagation()
-                setProps({
-                open: true,
-                children: <DownloadComponent lazyResults={[lazyResult]} />,
-                })
-            }}
-            style={{ height: '100%' }}
-            size="small"
-            disabled={lazyResult.getDownloadUrl() ? false : true}
-            >
-            <GetAppIcon />
-            </Button>
-        </Grid2>
-    )
+  return (
+    <Grid2 className="h-full">
+      <Button
+        component="div"
+        data-id="download-button"
+        onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+          e.stopPropagation()
+          setProps({
+            open: true,
+            children: <DownloadComponent lazyResults={[lazyResult]} />,
+          })
+        }}
+        style={{ height: '100%' }}
+        size="small"
+        disabled={lazyResult.getDownloadUrl() ? false : true}
+      >
+        <GetAppIcon />
+      </Button>
+    </Grid2>
+  )
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/link-button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/link-button.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import Button from '@mui/material/Button'
+import LinkIcon from '@mui/icons-material/Link'
+import { Grid2 } from '@mui/material'
+import { LazyQueryResult } from '../../js/model/LazyQueryResult/LazyQueryResult'
+
+type LinkButtonProps = {
+  lazyResult: LazyQueryResult
+}
+
+export const LinkButton = ({ lazyResult }: LinkButtonProps) => {
+  return (
+    <Grid2 className="h-full">
+      <Button
+        component="div"
+        title={lazyResult.plain.metacard.properties['ext.link']}
+        onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+          e.stopPropagation()
+          window.open(lazyResult.plain.metacard.properties['ext.link'])
+        }}
+        style={{ height: '100%' }}
+        size="small"
+        disabled={lazyResult.plain.metacard.properties['ext.link'] ? false : true}
+      >
+        <LinkIcon />
+      </Button>
+    </Grid2>
+  )
+}

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/link-button.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/button/link-button.tsx
@@ -20,7 +20,9 @@ export const LinkButton = ({ lazyResult }: LinkButtonProps) => {
         }}
         style={{ height: '100%' }}
         size="small"
-        disabled={lazyResult.plain.metacard.properties['ext.link'] ? false : true}
+        disabled={
+          lazyResult.plain.metacard.properties['ext.link'] ? false : true
+        }
       >
         <LinkIcon />
       </Button>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/inspector/inspector.tsx
@@ -33,6 +33,8 @@ import MaterialTab from '@mui/material/Tab'
 import MetacardTabs, { TabNames } from '../../tabs/metacard/tabs-metacard'
 import { useRerenderOnBackboneSync } from '../../../js/model/LazyQueryResult/hooks'
 import Extensions from '../../../extension-points'
+import { LinkButton } from '../../button/link-button'
+import { DownloadButton } from '../../button/download-button'
 
 type InspectorType = {
   selectionInterface: any
@@ -69,6 +71,8 @@ export const TitleView = ({ lazyResult }: TitleViewType) => {
       <OverflowTooltip className={'truncate'}>
         {lazyResult.plain.metacard.properties.title}
       </OverflowTooltip>
+      <LinkButton lazyResult={lazyResult} />
+      <DownloadButton lazyResult={lazyResult} />
       <Button {...menuState.MuiButtonProps}>
         <MoreVertIcon />
       </Button>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -72,7 +72,7 @@ const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
 }
 /**
  * Defines the basic properties for a ResultItem component.
- * 
+ *
  * @property lazyResults - An array of LazyQueryResult objects representing multiple query results.
  * @property lazyResult - A single LazyQueryResult object representing an individual result.
  * @property selectionInterface - An object providing selection functionality for results.
@@ -129,7 +129,7 @@ export const getIconClassName = ({
  *
  * The component displays the number of selected results and provides access
  * to actions for the selected items via a contextual menu.
- * 
+ *
  * - Disables actions if no results are selected.
  * - Allows interaction with selected results through a popover menu.
  * - Uses `LazyMetacardInteractions` to display actions for the selected results.
@@ -180,41 +180,60 @@ const MultiSelectActions = ({
  */
 const dynamicActionClasses = 'h-full'
 
-const HorizontalFixedActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
+const HorizontalFixedActions = ({
+  lazyResult,
+}: {
+  lazyResult: LazyQueryResult
+}) => {
   return (
-    <Grid2 container direction="row" wrap="nowrap" data-id="row-actions-container">
-        <LinkButton lazyResult={lazyResult} />
-        <DownloadButton lazyResult={lazyResult} />
-        <Grid2 className="h-full">
-          <Button
-            component="div"
-            data-id="result-item-more-vert-button"
-            style={{ height: '100%' }}
-            size="small"
-          >
-            <MoreIcon />
-          </Button>
-        </Grid2>
+    <Grid2
+      container
+      direction="row"
+      wrap="nowrap"
+      data-id="row-actions-container"
+    >
+      <LinkButton lazyResult={lazyResult} />
+      <DownloadButton lazyResult={lazyResult} />
+      <Grid2 className="h-full">
+        <Button
+          component="div"
+          data-id="result-item-more-vert-button"
+          style={{ height: '100%' }}
+          size="small"
+        >
+          <MoreIcon />
+        </Button>
       </Grid2>
+    </Grid2>
   )
 }
 
 /**
  * A component that displays a set of dynamic action buttons for a given result (lazyResult).
  * Includes options for more actions, download, validation errors/warnings, external links, and editing search results.
- * 
+ *
  * - Utilizes a popover menu for extended interactions through `LazyMetacardInteractions`.
  * - Displays visual indicators for validation errors or warnings.
  * - Provides buttons for result-specific actions such as opening external links, downloading resources,
  *   and editing search-based results.
- * 
+ *
  * Props:
  * - `lazyResult` (LazyQueryResult): The result object for which actions are displayed.
  */
-const VerticalDynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
+const VerticalDynamicActions = ({
+  lazyResult,
+}: {
+  lazyResult: LazyQueryResult
+}) => {
   const metacardInteractionMenuState = useMenuState()
   return (
-    <Grid2 container direction="column" wrap="nowrap" alignItems="center" data-id="column-actions-container">
+    <Grid2
+      container
+      direction="column"
+      wrap="nowrap"
+      alignItems="center"
+      data-id="column-actions-container"
+    >
       <Grid2 className="h-full">
         <Button
           component="div"
@@ -793,9 +812,7 @@ export const ResultItem = ({
             </div>
           </div>
         </div>
-      {renderExtras ? 
-        null :
-        (
+        {renderExtras ? null : (
           <>
             {' '}
             <div
@@ -828,35 +845,34 @@ export const ResultItem = ({
               </Paper>
             </div>
           </>
-        ) 
-      }
-      {renderExtras ? (
-        <>
-          {' '}
-          {/* trick to keep the dropdown visible over an arc of the cursor, so users have some leeway if going diagonal to the actions dropdowns **/}
-          <div
-            className={`${diagonalHoverClasses} w-full transform translate-y-1`}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-9/12 transform translate-y-2 `}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-6/12 transform translate-y-3`}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-5/12 transform translate-y-4`}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-4/12 transform translate-y-5`}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-3/12 transform translate-y-6`}
-          />
-          <div
-            className={`${diagonalHoverClasses} w-2/12 transform translate-y-8`}
-          />
-          <div
-            className={`absolute z-40 
+        )}
+        {renderExtras ? (
+          <>
+            {' '}
+            {/* trick to keep the dropdown visible over an arc of the cursor, so users have some leeway if going diagonal to the actions dropdowns **/}
+            <div
+              className={`${diagonalHoverClasses} w-full transform translate-y-1`}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-9/12 transform translate-y-2 `}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-6/12 transform translate-y-3`}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-5/12 transform translate-y-4`}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-4/12 transform translate-y-5`}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-3/12 transform translate-y-6`}
+            />
+            <div
+              className={`${diagonalHoverClasses} w-2/12 transform translate-y-8`}
+            />
+            <div
+              className={`absolute z-40 
               group-hover:z-50 
               focus-within:z-50 
               right-0 
@@ -873,18 +889,18 @@ export const ResultItem = ({
               duration-200 
               hover:translate-x-0 
               hover:scale-x-100`}
-          >
-            <Paper
-              onClick={(e) => {
-                e.stopPropagation()
-              }}
-              elevation={Elevations.overlays}
-              className="p-2"
             >
-              <VerticalDynamicActions lazyResult={lazyResult} />
-            </Paper>
-          </div>
-        </>
+              <Paper
+                onClick={(e) => {
+                  e.stopPropagation()
+                }}
+                elevation={Elevations.overlays}
+                className="p-2"
+              >
+                <VerticalDynamicActions lazyResult={lazyResult} />
+              </Paper>
+            </div>
+          </>
         ) : null}
       </div>
     </button>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -817,22 +817,16 @@ export const ResultItem = ({
             {' '}
             <div
               className={`absolute z-40 
-                group-hover:z-50 
                 focus-within:z-50 
                 right-0 
                 top-0 
                 focus-within:opacity-100 
-                group-hover:opacity-100 
-                hover:opacity-100 
                 opacity-100 
                 cursor-auto transform 
                 focus-within:scale-100 
                 transition-all 
-                hover:scale-100 
                 ease-in-out 
-                duration-200 
-                hover:translate-x-0 
-                hover:scale-x-100`}
+                duration-200`}
             >
               <Paper
                 onClick={(e) => {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -17,9 +17,6 @@ import LazyMetacardInteractions from './lazy-metacard-interactions'
 import IconHelper from '../../../js/IconHelper'
 import user from '../../singletons/user-instance'
 import Button from '@mui/material/Button'
-import LinkIcon from '@mui/icons-material/Link'
-import GetAppIcon from '@mui/icons-material/GetApp'
-import Grid from '@mui/material/Grid'
 
 import Paper from '@mui/material/Paper'
 import Tooltip from '@mui/material/Tooltip'
@@ -50,13 +47,14 @@ import ExtensionPoints from '../../../extension-points/extension-points'
 import { StartupDataStore } from '../../../js/model/Startup/startup'
 import { useMetacardDefinitions } from '../../../js/model/Startup/metacard-definitions.hooks'
 import wreqr from '../../../js/wreqr'
-import { useDialog } from '../../dialog'
-import { useDownloadComponent } from '../../download/download'
 import { LayoutContext } from '../../golden-layout/visual-settings.provider'
 import {
   RESULTS_ATTRIBUTES_LIST,
   getDefaultResultsShownList,
 } from '../settings-helpers'
+import { Grid2 } from '@mui/material'
+import { LinkButton } from '../../button/link-button'
+import { DownloadButton } from '../../button/download-button'
 
 const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
   return (
@@ -72,6 +70,13 @@ const PropertyComponent = (props: React.AllHTMLAttributes<HTMLDivElement>) => {
     />
   )
 }
+/**
+ * Defines the basic properties for a ResultItem component.
+ * 
+ * @property lazyResults - An array of LazyQueryResult objects representing multiple query results.
+ * @property lazyResult - A single LazyQueryResult object representing an individual result.
+ * @property selectionInterface - An object providing selection functionality for results.
+ */
 type ResultItemBasicProps = {
   lazyResults: LazyQueryResult[]
   lazyResult: LazyQueryResult
@@ -115,6 +120,20 @@ export const getIconClassName = ({
   }
   return IconHelper.getClassByMetacardObject(lazyResult.plain)
 }
+
+/**
+ * A React component that provides multi-select actions for managing a collection of selected results.
+ *
+ * @param {Object} props - The component properties.
+ * @param {any} props.selectionInterface - An interface for managing the selection of results.
+ *
+ * The component displays the number of selected results and provides access
+ * to actions for the selected items via a contextual menu.
+ * 
+ * - Disables actions if no results are selected.
+ * - Allows interaction with selected results through a popover menu.
+ * - Uses `LazyMetacardInteractions` to display actions for the selected results.
+ */
 // @ts-ignore
 const MultiSelectActions = ({
   selectionInterface,
@@ -155,14 +174,48 @@ const MultiSelectActions = ({
     </>
   )
 }
+/**
+ * A CSS class string for setting the height of a component to fill its container.
+ * Used to ensure consistent full-height styling across dynamic action elements.
+ */
 const dynamicActionClasses = 'h-full'
-const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
-  const { setProps } = useDialog()
-  const metacardInteractionMenuState = useMenuState()
-  const DownloadComponent = useDownloadComponent()
+
+const HorizontalFixedActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
   return (
-    <Grid container direction="column" wrap="nowrap" alignItems="center">
-      <Grid item className="h-full">
+    <Grid2 container direction="row" wrap="nowrap" data-id="row-actions-container">
+        <LinkButton lazyResult={lazyResult} />
+        <DownloadButton lazyResult={lazyResult} />
+        <Grid2 className="h-full">
+          <Button
+            component="div"
+            data-id="result-item-more-vert-button"
+            style={{ height: '100%' }}
+            size="small"
+          >
+            <MoreIcon />
+          </Button>
+        </Grid2>
+      </Grid2>
+  )
+}
+
+/**
+ * A component that displays a set of dynamic action buttons for a given result (lazyResult).
+ * Includes options for more actions, download, validation errors/warnings, external links, and editing search results.
+ * 
+ * - Utilizes a popover menu for extended interactions through `LazyMetacardInteractions`.
+ * - Displays visual indicators for validation errors or warnings.
+ * - Provides buttons for result-specific actions such as opening external links, downloading resources,
+ *   and editing search-based results.
+ * 
+ * Props:
+ * - `lazyResult` (LazyQueryResult): The result object for which actions are displayed.
+ */
+const VerticalDynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
+  const metacardInteractionMenuState = useMenuState()
+  return (
+    <Grid2 container direction="column" wrap="nowrap" alignItems="center" data-id="column-actions-container">
+      <Grid2 className="h-full">
         <Button
           component="div"
           data-id="result-item-more-vert-button"
@@ -187,8 +240,8 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
             />
           </Paper>
         </Popover>
-      </Grid>
-      <Grid item className={dynamicActionClasses}>
+      </Grid2>
+      <Grid2 className={dynamicActionClasses}>
         {lazyResult.hasErrors() ? (
           <div
             data-id="validation-errors-icon"
@@ -202,8 +255,8 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
         ) : (
           ''
         )}
-      </Grid>
-      <Grid item className={dynamicActionClasses}>
+      </Grid2>
+      <Grid2 className={dynamicActionClasses}>
         {!lazyResult.hasErrors() && lazyResult.hasWarnings() ? (
           <div
             data-id="validation-warnings-icon"
@@ -217,44 +270,11 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
         ) : (
           ''
         )}
-      </Grid>
-      <Grid item className={dynamicActionClasses}>
-        {lazyResult.plain.metacard.properties['ext.link'] ? (
-          <Button
-            component="div"
-            title={lazyResult.plain.metacard.properties['ext.link']}
-            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-              e.stopPropagation()
-              window.open(lazyResult.plain.metacard.properties['ext.link'])
-            }}
-            style={{ height: '100%' }}
-            size="small"
-          >
-            <LinkIcon />
-          </Button>
-        ) : null}
-      </Grid>
-      <Grid item className={dynamicActionClasses}>
-        {lazyResult.getDownloadUrl() ? (
-          <Button
-            component="div"
-            data-id="download-button"
-            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-              e.stopPropagation()
-              setProps({
-                open: true,
-                children: <DownloadComponent lazyResults={[lazyResult]} />,
-              })
-            }}
-            style={{ height: '100%' }}
-            size="small"
-          >
-            <GetAppIcon />
-          </Button>
-        ) : null}
-      </Grid>
+      </Grid2>
+      <LinkButton lazyResult={lazyResult} />
+      <DownloadButton lazyResult={lazyResult} />
       <Extensions.resultItemTitleAddOn lazyResult={lazyResult} />
-      <Grid item className={dynamicActionClasses}>
+      <Grid2 className={dynamicActionClasses}>
         {lazyResult.isSearch() ? (
           <Button
             component={Link}
@@ -266,7 +286,7 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
             <EditIcon />
           </Button>
         ) : null}
-      </Grid>
+      </Grid2>
       {/** add inline editing later */}
       {/* <Grid item className="h-full">
            {lazyResult.isSearch() ? (
@@ -282,7 +302,7 @@ const DynamicActions = ({ lazyResult }: { lazyResult: LazyQueryResult }) => {
              </Button>
            ) : null}
          </Grid> */}
-    </Grid>
+    </Grid2>
   )
 }
 export const SelectionBackground = ({
@@ -578,6 +598,7 @@ export const ResultItem = ({
          * thus making the dynamic actions stay visible when the user starts to mouse away.
          */
         try {
+          setRenderExtras(false)
           if (
             document.activeElement &&
             buttonRef.current &&
@@ -772,33 +793,29 @@ export const ResultItem = ({
             </div>
           </div>
         </div>
-        {renderExtras ? (
+      {renderExtras ? 
+        null :
+        (
           <>
             {' '}
-            {/* trick to keep the dropdown visible over an arc of the cursor, so users have some leeway if going diagonal to the actions dropdowns **/}
             <div
-              className={`${diagonalHoverClasses} w-full transform translate-y-1`}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-9/12 transform translate-y-2 `}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-6/12 transform translate-y-3`}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-5/12 transform translate-y-4`}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-4/12 transform translate-y-5`}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-3/12 transform translate-y-6`}
-            />
-            <div
-              className={`${diagonalHoverClasses} w-2/12 transform translate-y-8`}
-            />
-            <div
-              className={`absolute z-40 group-hover:z-50 focus-within:z-50 right-0 top-0 focus-within:opacity-100 group-hover:opacity-100 hover:opacity-100 opacity-0 cursor-auto transform focus-within:scale-100 transition-all hover:scale-100 ease-in-out duration-200 hover:translate-x-0 hover:scale-x-100`}
+              className={`absolute z-40 
+                group-hover:z-50 
+                focus-within:z-50 
+                right-0 
+                top-0 
+                focus-within:opacity-100 
+                group-hover:opacity-100 
+                hover:opacity-100 
+                opacity-100 
+                cursor-auto transform 
+                focus-within:scale-100 
+                transition-all 
+                hover:scale-100 
+                ease-in-out 
+                duration-200 
+                hover:translate-x-0 
+                hover:scale-x-100`}
             >
               <Paper
                 onClick={(e) => {
@@ -807,10 +824,67 @@ export const ResultItem = ({
                 elevation={Elevations.overlays}
                 className="p-2"
               >
-                <DynamicActions lazyResult={lazyResult} />
+                <HorizontalFixedActions lazyResult={lazyResult} />
               </Paper>
             </div>
           </>
+        ) 
+      }
+      {renderExtras ? (
+        <>
+          {' '}
+          {/* trick to keep the dropdown visible over an arc of the cursor, so users have some leeway if going diagonal to the actions dropdowns **/}
+          <div
+            className={`${diagonalHoverClasses} w-full transform translate-y-1`}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-9/12 transform translate-y-2 `}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-6/12 transform translate-y-3`}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-5/12 transform translate-y-4`}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-4/12 transform translate-y-5`}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-3/12 transform translate-y-6`}
+          />
+          <div
+            className={`${diagonalHoverClasses} w-2/12 transform translate-y-8`}
+          />
+          <div
+            className={`absolute z-40 
+              group-hover:z-50 
+              focus-within:z-50 
+              right-0 
+              top-0 
+              focus-within:opacity-100 
+              group-hover:opacity-100 
+              hover:opacity-100 
+              opacity-0 
+              cursor-auto transform 
+              focus-within:scale-100 
+              transition-all 
+              hover:scale-100 
+              ease-in-out 
+              duration-200 
+              hover:translate-x-0 
+              hover:scale-x-100`}
+          >
+            <Paper
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+              elevation={Elevations.overlays}
+              className="p-2"
+            >
+              <VerticalDynamicActions lazyResult={lazyResult} />
+            </Paper>
+          </div>
+        </>
         ) : null}
       </div>
     </button>

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/results-visual/result-item.tsx
@@ -192,8 +192,8 @@ const HorizontalFixedActions = ({
       wrap="nowrap"
       data-id="row-actions-container"
     >
-      <LinkButton lazyResult={lazyResult} />
       <DownloadButton lazyResult={lazyResult} />
+      <LinkButton lazyResult={lazyResult} />
       <Grid2 className="h-full">
         <Button
           component="div"
@@ -220,7 +220,7 @@ const HorizontalFixedActions = ({
  * Props:
  * - `lazyResult` (LazyQueryResult): The result object for which actions are displayed.
  */
-const VerticalDynamicActions = ({
+const HorizontalDynamicActions = ({
   lazyResult,
 }: {
   lazyResult: LazyQueryResult
@@ -229,11 +229,58 @@ const VerticalDynamicActions = ({
   return (
     <Grid2
       container
-      direction="column"
+      direction="row"
       wrap="nowrap"
       alignItems="center"
-      data-id="column-actions-container"
+      spacing={0.03}
+      data-id="row-dynamic-actions-container"
     >
+      <Grid2 className={dynamicActionClasses}>
+        {!lazyResult.hasErrors() && lazyResult.hasWarnings() ? (
+          <div
+            data-id="validation-warnings-icon"
+            className="h-full"
+            title="Has validation warnings."
+            data-help="Indicates the given result has a validation warning.
+                     See the 'Quality' tab of the result for more details."
+          >
+            <WarningIcon />
+          </div>
+        ) : (
+          ''
+        )}
+      </Grid2>
+      <Grid2 className={dynamicActionClasses}>
+        {lazyResult.hasErrors() ? (
+          <div
+            data-id="validation-errors-icon"
+            className="h-full"
+            title="Has validation errors."
+            data-help="Indicates the given result has a validation error.
+                     See the 'Quality' tab of the result for more details."
+          >
+            <WarningIcon />
+          </div>
+        ) : (
+          ''
+        )}
+      </Grid2>
+      <Grid2 className={dynamicActionClasses}>
+        {lazyResult.isSearch() ? (
+          <Button
+            component={Link}
+            data-id="edit-button"
+            to={`/search/${lazyResult.plain.id}`}
+            style={{ height: '100%' }}
+            size="small"
+          >
+            <EditIcon />
+          </Button>
+        ) : null}
+      </Grid2>
+      <Extensions.resultItemTitleAddOn lazyResult={lazyResult} />
+      <DownloadButton lazyResult={lazyResult} />
+      <LinkButton lazyResult={lazyResult} />
       <Grid2 className="h-full">
         <Button
           component="div"
@@ -259,52 +306,6 @@ const VerticalDynamicActions = ({
             />
           </Paper>
         </Popover>
-      </Grid2>
-      <Grid2 className={dynamicActionClasses}>
-        {lazyResult.hasErrors() ? (
-          <div
-            data-id="validation-errors-icon"
-            className="h-full"
-            title="Has validation errors."
-            data-help="Indicates the given result has a validation error.
-                     See the 'Quality' tab of the result for more details."
-          >
-            <WarningIcon />
-          </div>
-        ) : (
-          ''
-        )}
-      </Grid2>
-      <Grid2 className={dynamicActionClasses}>
-        {!lazyResult.hasErrors() && lazyResult.hasWarnings() ? (
-          <div
-            data-id="validation-warnings-icon"
-            className="h-full"
-            title="Has validation warnings."
-            data-help="Indicates the given result has a validation warning.
-                     See the 'Quality' tab of the result for more details."
-          >
-            <WarningIcon />
-          </div>
-        ) : (
-          ''
-        )}
-      </Grid2>
-      <LinkButton lazyResult={lazyResult} />
-      <DownloadButton lazyResult={lazyResult} />
-      <Extensions.resultItemTitleAddOn lazyResult={lazyResult} />
-      <Grid2 className={dynamicActionClasses}>
-        {lazyResult.isSearch() ? (
-          <Button
-            component={Link}
-            data-id="edit-button"
-            to={`/search/${lazyResult.plain.id}`}
-            style={{ height: '100%' }}
-            size="small"
-          >
-            <EditIcon />
-          </Button>
-        ) : null}
       </Grid2>
       {/** add inline editing later */}
       {/* <Grid item className="h-full">
@@ -891,7 +892,7 @@ export const ResultItem = ({
                 elevation={Elevations.overlays}
                 className="p-2"
               >
-                <VerticalDynamicActions lazyResult={lazyResult} />
+                <HorizontalDynamicActions lazyResult={lazyResult} />
               </Paper>
             </div>
           </>


### PR DESCRIPTION
Currently the Inspector and Results views only show the Artefact Download [Download Icon] and External Source Link [Chain Icon] buttons when they are available for a metacard.

For the Results view, the buttons only appear when hovering over the metacard. The Artefact Download and External Source Link buttons need to always be visible next to the three dot menu regardless of where the mouse is. For clarity it will also be good to have the three dot menu visible at all times as well.

For the Inspector view, the buttons are accessible via the three dot menu. The Artefact Download and External Source Link buttons need to always be visible next to the three dot menu.

For cases where either the Artefact Download or External Source Link is not applicable, both buttons will still be visible, but the unused button will be greyed out to show the link does not exist.


**More Details:**
**The changes to Source Link (SL), the Source Download (SD), Three Dot (TD) buttons are:**
1. They should be visible all the time, meaning even when the user does not hover over the search result item.
2. When not hovered, they will be positioned horizontally this order from left to right: Source Link, Download Link, then Three Dot.
3. When an item should not have those icons enabled, the icons should now be visible but greyed out.
4. When hovered, for an item that should not have those icons enabled, the icons should now be visible but greyed out and the direction of the icons will be kept as horizontal as well for consistency with the existing behavior.
 

**For example, for an item which currently has active SL, DL, and Star.  The changes are:**
1. When not hovered: SL, DL, and three-dot icons are displayed horizontally in the order as typed.
2. When hovered: TD, SL, DL, and Star icons are also displayed horizontally in the following order from right to left: TD, SL, DL, Star.

**Another example, for an item which currently has active Star only.  The changes are:**
1. When not hovered: SL, DL, and three-dot are displayed horizontally in the order as typed, but icons for SL and DL are greyed out.
2. When hovered: TD, SL, DL, and Star icons are also displayed horizontally in the following order from right to left: TD, SL, DL, Star.  But icons for SL and DL are greyed out.