### PR TITLE
Flatten getGeometries to handled multivalue geo attributes

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/LazyQueryResult/LazyQueryResult.tsx
@@ -367,7 +367,7 @@ export class LazyQueryResult {
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key] &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key].type ===
           'GEOMETRY'
-    )
+    ).flat()
   }
   getPoints(attribute?: any): any {
     try {

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/model/MetacardProperties.ts
@@ -66,6 +66,6 @@ export default Backbone.AssociatedModel.extend({
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key] &&
         StartupDataStore.MetacardDefinitions.getAttributeMap()[key].type ===
           'GEOMETRY'
-    )
+    ).flat()
   },
 })


### PR DESCRIPTION
Previously clustering would fail to include results that had multivalued geo attributes
<img width="424" height="126" alt="image" src="https://github.com/user-attachments/assets/86653c18-d4fb-4d63-8749-d94876814308" />


Now, all geometry attributes are used to calculate a center point for the result metacard. This center point is used to determine if the result belongs to a cluster.

Future improvement consideration: Instead of calculating a center point per result metacrd, treat each geometry on the metacard as its own geo when determining clusters