### PR TITLE
Update openlayers layer handling to properly handle wmts, and always wrapX

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
@@ -50,7 +50,9 @@ const WMS = (opts: any) => {
 
 const WMT = async (opts: any) => {
   const { proxyEnabled } = opts
-  const { result, layer, matrixSet, originalUrl } = await getWMTSCapabilities(opts)
+  const { result, layer, matrixSet, originalUrl } = await getWMTSCapabilities(
+    opts
+  )
 
   const options = optionsFromCapabilities(result, {
     ...opts,

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/openlayers.layers.tsx
@@ -11,10 +11,10 @@ import { Map } from 'ol'
 import Backbone from 'backbone'
 import { StartupDataStore } from '../model/Startup/startup'
 import { optionsFromCapabilities } from 'ol/source/WMTS'
-import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import { ProjectionLike } from 'ol/proj'
 import Layer from 'ol/layer/Layer'
 import { View } from 'ol'
+import { getWMTSCapabilities } from './wmts'
 const createTile = (
   { show, alpha, ...options }: any,
   Source: any,
@@ -47,30 +47,11 @@ const WMS = (opts: any) => {
   }
   return createTile({ ...opts, params }, TileWMS)
 }
+
 const WMT = async (opts: any) => {
-  const { url, withCredentials, proxyEnabled } = opts
-  const originalUrl = proxyEnabled
-    ? new URL(url, window.location.origin + window.location.pathname)
-    : new URL(url)
-  const getCapabilitiesUrl = new URL(originalUrl)
-  getCapabilitiesUrl.searchParams.set('request', 'GetCapabilities')
-  const res = await window.fetch(getCapabilitiesUrl, {
-    credentials: withCredentials ? 'include' : 'same-origin',
-  })
-  const text = await res.text()
-  const parser = new WMTSCapabilities()
-  const result = parser.read(text)
-  if ((result as any).Contents.Layer.length === 0) {
-    throw new Error('WMTS map layer source has no layers.')
-  }
-  let { layer, matrixSet } = opts
-  /* If tileMatrixSetID is present (Cesium WMTS keyword) set matrixSet (OpenLayers WMTS keyword) */
-  if (opts.tileMatrixSetID) {
-    matrixSet = opts.tileMatrixSetID
-  }
-  if (!layer) {
-    layer = (result as any).Contents.Layer[0].Identifier
-  }
+  const { proxyEnabled } = opts
+  const { result, layer, matrixSet, originalUrl } = await getWMTSCapabilities(opts)
+
   const options = optionsFromCapabilities(result, {
     ...opts,
     layer,
@@ -79,6 +60,9 @@ const WMT = async (opts: any) => {
   if (options === null) {
     throw new Error('WMTS map layer source could not be setup.')
   }
+  // always set to true, as optionsFromCapabilities is too strict in how it determines wrapX
+  options.wrapX = true
+
   if (proxyEnabled) {
     // Set this to the proxy URL. Otherwise, OpenLayers will use the URL provided by the
     // GetCapabilities response.

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/wmts.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/wmts.tsx
@@ -12,28 +12,47 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-import WMTSCapabilities from "ol/format/WMTSCapabilities"
+import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 
-function ensureValidLayer({layerIdentifier, result}: {layerIdentifier: string, result: any}) {
-  const layer = result.Contents.Layer.find((l: any) => l.Identifier === layerIdentifier)
+function ensureValidLayer({
+  layerIdentifier,
+  result,
+}: {
+  layerIdentifier: string
+  result: any
+}) {
+  const layer = result.Contents.Layer.find(
+    (l: any) => l.Identifier === layerIdentifier
+  )
   if (!layer) {
     const firstLayer = result.Contents.Layer[0]
-    console.error(`WMTS map layer source has no layer ${layerIdentifier}. Using first layer ${firstLayer.Identifier}.`)
+    console.error(
+      `WMTS map layer source has no layer ${layerIdentifier}. Using first layer ${firstLayer.Identifier}.`
+    )
     return firstLayer.Identifier
   }
   return layer.Identifier
 }
 
-function ensureValidMatrixSet({matrixSetIdentifier, result}: {matrixSetIdentifier: string, result: any}) {
-  const matrixSet = result.Contents.TileMatrixSet.find((m: any) => m.Identifier === matrixSetIdentifier)
+function ensureValidMatrixSet({
+  matrixSetIdentifier,
+  result,
+}: {
+  matrixSetIdentifier: string
+  result: any
+}) {
+  const matrixSet = result.Contents.TileMatrixSet.find(
+    (m: any) => m.Identifier === matrixSetIdentifier
+  )
   if (!matrixSet) {
     const firstMatrixSet = result.Contents.TileMatrixSet[0]
-    console.error(`WMTS map layer source has no matrix set ${matrixSetIdentifier}. Using first matrix set ${firstMatrixSet.Identifier}.`)
+    console.error(
+      `WMTS map layer source has no matrix set ${matrixSetIdentifier}. Using first matrix set ${firstMatrixSet.Identifier}.`
+    )
     return firstMatrixSet.Identifier
   }
-  return matrixSet.Identifier 
+  return matrixSet.Identifier
 }
-
 
 export async function getWMTSCapabilities(opts: any) {
   const { url, withCredentials, proxyEnabled } = opts
@@ -56,12 +75,12 @@ export async function getWMTSCapabilities(opts: any) {
   if (opts.tileMatrixSetID) {
     matrixSet = opts.tileMatrixSetID
   }
-  layer = ensureValidLayer({layerIdentifier: layer, result})
-  matrixSet = ensureValidMatrixSet({matrixSetIdentifier: matrixSet, result})
+  layer = ensureValidLayer({ layerIdentifier: layer, result })
+  matrixSet = ensureValidMatrixSet({ matrixSetIdentifier: matrixSet, result })
   return {
     layer,
     matrixSet,
     result,
-    originalUrl
+    originalUrl,
   }
 }

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/wmts.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/js/controllers/wmts.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import WMTSCapabilities from "ol/format/WMTSCapabilities"
+
+function ensureValidLayer({layerIdentifier, result}: {layerIdentifier: string, result: any}) {
+  const layer = result.Contents.Layer.find((l: any) => l.Identifier === layerIdentifier)
+  if (!layer) {
+    const firstLayer = result.Contents.Layer[0]
+    console.error(`WMTS map layer source has no layer ${layerIdentifier}. Using first layer ${firstLayer.Identifier}.`)
+    return firstLayer.Identifier
+  }
+  return layer.Identifier
+}
+
+function ensureValidMatrixSet({matrixSetIdentifier, result}: {matrixSetIdentifier: string, result: any}) {
+  const matrixSet = result.Contents.TileMatrixSet.find((m: any) => m.Identifier === matrixSetIdentifier)
+  if (!matrixSet) {
+    const firstMatrixSet = result.Contents.TileMatrixSet[0]
+    console.error(`WMTS map layer source has no matrix set ${matrixSetIdentifier}. Using first matrix set ${firstMatrixSet.Identifier}.`)
+    return firstMatrixSet.Identifier
+  }
+  return matrixSet.Identifier 
+}
+
+
+export async function getWMTSCapabilities(opts: any) {
+  const { url, withCredentials, proxyEnabled } = opts
+  const originalUrl = proxyEnabled
+    ? new URL(url, window.location.origin + window.location.pathname)
+    : new URL(url)
+  const getCapabilitiesUrl = new URL(originalUrl)
+  getCapabilitiesUrl.searchParams.set('request', 'GetCapabilities')
+  const res = await window.fetch(getCapabilitiesUrl, {
+    credentials: withCredentials ? 'include' : 'same-origin',
+  })
+  const text = await res.text()
+  const parser = new WMTSCapabilities()
+  const result = parser.read(text)
+  if ((result as any).Contents.Layer.length === 0) {
+    throw new Error('WMTS map layer source has no layers.')
+  }
+  let { layer, matrixSet } = opts
+  /* If tileMatrixSetID is present (Cesium WMTS keyword) set matrixSet (OpenLayers WMTS keyword) */
+  if (opts.tileMatrixSetID) {
+    matrixSet = opts.tileMatrixSetID
+  }
+  layer = ensureValidLayer({layerIdentifier: layer, result})
+  matrixSet = ensureValidMatrixSet({matrixSetIdentifier: matrixSet, result})
+  return {
+    layer,
+    matrixSet,
+    result,
+    originalUrl
+  }
+}


### PR DESCRIPTION
 - Updates openlayers layer handling to verify layer identity / matrix set identity to avoid errors being thrown.  If these are invalid, it will use the first of each.
 - Updates wmts layers for openlayers to always use wrapX, as the default openlayers behavior is too strict for this to be determined automatically.