### PR TITLE
Pan to the extent of all geometries on a result

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.ts
@@ -428,7 +428,7 @@ export default function CesiumMap(
           .filter((result: any) => result.hasGeometry())
           .map(
             (result: any) =>
-              _.map(result.getPoints('location'), (coordinate) =>
+              _.map(result.getPoints(), (coordinate) =>
                 Cesium.Cartographic.fromDegrees(
                   coordinate[0],
                   coordinate[1],

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.ts
@@ -312,7 +312,7 @@ export default function (
     },
     panToResults(results: any) {
       const coordinates = _.flatten(
-        results.map((result: any) => result.getPoints('location')),
+        results.map((result: any) => result.getPoints()),
         true
       )
       this.panToExtent(coordinates)
@@ -327,6 +327,7 @@ export default function (
           size: map.getSize(),
           maxZoom: map.getView().getZoom(),
           duration: 500,
+          padding: [50, 50, 50, 50],
         })
       }
     },


### PR DESCRIPTION
Instead of only panning to the location attribute, get all geometry attributes on the metacard