### PR TITLE
Use defaultValue for customInput

### DIFF
--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/customInputOrDefault.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/customInputOrDefault.tsx
@@ -73,7 +73,7 @@ export const CustomInputOrDefaultPostValidation = ({
   } else {
     return (
       <TextField
-        value={textValue}
+        defaultValue={textValue}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           onChange(e.target.value)
         }}


### PR DESCRIPTION
Value is not state in this component. When value is updated by a parent rerenders can cause the cursor to jump to end of input field. 