### PR TITLE
Deploy to codice Nexus + route CI Maven through codice-internal mirror

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>codice-internal</id>
+      <mirrorOf>codice</mirrorOf>
+      <url>https://repo.codice.org/repository/codice-internal/</url>
+    </mirror>
+  </mirrors>
+  <servers>
+    <server>
+      <id>releases</id>
+      <username>${env.NEXUS_USERNAME}</username>
+      <password>${env.NEXUS_PASSWORD}</password>
+    </server>
+    <server>
+      <id>snapshots</id>
+      <username>${env.NEXUS_USERNAME}</username>
+      <password>${env.NEXUS_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Configure Maven settings
+        run: mkdir -p ~/.m2 && cp .github/maven-settings.xml ~/.m2/settings.xml
+
       - name: Build
         run: mvn clean install $MAVEN_CLI_OPTS -DskipTests
 
@@ -66,6 +69,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Configure Maven settings
+        run: mkdir -p ~/.m2 && cp .github/maven-settings.xml ~/.m2/settings.xml
+
       - name: Build
         run: mvn clean install $MAVEN_CLI_OPTS -DskipTests
 
@@ -76,8 +82,6 @@ jobs:
       (github.ref == 'refs/heads/master' || contains(github.ref, '.x'))
     runs-on: ubuntu-latest
     environment: production
-    permissions:
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,24 +99,15 @@ jobs:
           node-version: '20'
 
       - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "releases",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            },
-            {
-              "id": "snapshots",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
+        run: mkdir -p ~/.m2 && cp .github/maven-settings.xml ~/.m2/settings.xml
 
       - name: Deploy
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           mvn deploy $MAVEN_CLI_OPTS \
             -DskipTests=true \
             -DretryFailedDeploymentCount=10 \
-            -Dreleases.repository.url=https://maven.pkg.github.com/codice/ddf-ui \
-            -Dsnapshots.repository.url=https://maven.pkg.github.com/codice/ddf-ui
+            -Dreleases.repository.url=https://repo.codice.org/repository/maven-releases/ \
+            -Dsnapshots.repository.url=https://repo.codice.org/repository/maven-snapshots/

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
     <repository>
       <id>codice</id>
       <name>Codice Repository</name>
-      <url>https://artifacts.codice.org/content/groups/public/</url>
+      <url>https://repo.codice.org/repository/maven-public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -409,7 +409,7 @@
     <pluginRepository>
       <id>codice</id>
       <name>Codice Repository</name>
-      <url>https://artifacts.codice.org/content/groups/public/</url>
+      <url>https://repo.codice.org/repository/maven-public/</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <!--Backend properties-->
     <ddf.version>2.29.32</ddf.version>
-    <ddf-jsonrpc.version>0.10.2</ddf-jsonrpc.version>
+    <ddf-jsonrpc.version>0.10.5</ddf-jsonrpc.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <antlr.version>4.3</antlr.version>
     <c3p0.version>0.9.5.5</c3p0.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <fmt.maven.plugin.version>2.3.0</fmt.maven.plugin.version>
 
     <!--Backend properties-->
-    <ddf.version>2.29.29</ddf.version>
+    <ddf.version>2.29.32</ddf.version>
     <ddf-jsonrpc.version>0.10.2</ddf-jsonrpc.version>
     <ddf.support.version>2.3.16</ddf.support.version>
     <antlr.version>4.3</antlr.version>
@@ -102,7 +102,7 @@
     <spark.version>2.9.4</spark.version>
     <spatial4j.version>0.8</spatial4j.version>
     <tika.version>3.2.2</tika.version>
-    <usng4j.version>0.4</usng4j.version>
+    <usng4j.version>0.5</usng4j.version>
     <org.slf4j.version>1.7.32</org.slf4j.version>
 
     <!-- Command line argument properties for the maven-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,11 @@
       </snapshots>
     </repository>
     <repository>
+      <id>osgeo</id>
+      <name>OSGeo Release Respository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+    </repository>
+    <repository>
       <id>codice</id>
       <name>Codice Repository</name>
       <url>https://repo.codice.org/repository/maven-public/</url>

--- a/ui-backend/catalog-ui-oauth/src/test/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplicationTest.java
+++ b/ui-backend/catalog-ui-oauth/src/test/java/org/codice/ddf/catalog/ui/oauth/app/OAuthApplicationTest.java
@@ -53,7 +53,6 @@ import java.util.Objects;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import org.apache.commons.io.IOUtils;
 import org.codice.ddf.security.handler.api.OidcHandlerConfiguration;
 import org.codice.ddf.security.token.storage.api.TokenInformation;
 import org.codice.ddf.security.token.storage.api.TokenInformationImpl;
@@ -120,9 +119,9 @@ public class OAuthApplicationTest {
     when(resourceRetriever.retrieveResource(eq(new URL(JWK_ENDPOINT)))).thenReturn(jwkResource);
 
     String content =
-        IOUtils.toString(
+        new String(
             Objects.requireNonNull(
-                getClass().getClassLoader().getResourceAsStream("metadata.json")),
+                getClass().getClassLoader().getResourceAsStream("metadata.json").readAllBytes()),
             StandardCharsets.UTF_8);
     Resource metadataResource = new Resource(content, APPLICATION_JSON);
     when(resourceRetriever.retrieveResource(eq(new URL(METADATA_ENDPOINT))))


### PR DESCRIPTION
Switches deploy from GitHub Packages (`maven.pkg.github.com/codice/ddf-ui`) to the codice Nexus (`repo.codice.org/repository/maven-{releases,snapshots}/`) and routes CI Maven resolution through the new `codice-internal` mirror. Also updates dead `artifacts.codice.org` URLs in pom.xml to the live Nexus.

Requires org-level `NEXUS_USERNAME` and `NEXUS_PASSWORD` secrets to be visible to this repo (already used by alliance/ddf workflows).