### PR TITLE
Fix idle-timeout logout

### DIFF
--- a/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/session/SessionManagementApplicationTest.java
+++ b/ui-backend/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/session/SessionManagementApplicationTest.java
@@ -13,41 +13,36 @@
  */
 package org.codice.ddf.catalog.ui.session;
 
-import static spark.Spark.get;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import javax.servlet.http.HttpServletRequest;
 import org.codice.ddf.security.session.management.service.SessionManagementService;
-import spark.servlet.SparkApplication;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SessionManagementApplication implements SparkApplication {
+public class SessionManagementApplicationTest {
 
   private SessionManagementService sessionManagement;
+  private SessionManagementApplication app;
 
-  public SessionManagementApplication(SessionManagementService sessionManagementService) {
-    sessionManagement = sessionManagementService;
+  @Before
+  public void setup() {
+    sessionManagement = mock(SessionManagementService.class);
+    app = new SessionManagementApplication(sessionManagement);
   }
 
-  @Override
-  public void init() {
-    get(
-        "/session/expiry",
-        (req, res) -> {
-          String body = sessionManagement.getExpiry(req.raw());
-          res.status(200);
-          return body;
-        });
+  @Test
+  public void invalidateReturnsLogoutUri() throws Exception {
+    URI logoutUri = URI.create("https://localhost/logout?service=https://localhost/search");
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(sessionManagement.getInvalidate(request)).thenReturn(logoutUri);
 
-    get(
-        "/session/invalidate",
-        (req, res) -> {
-          res.status(200);
-          return handleInvalidate(req.raw());
-        });
-  }
+    String result = app.handleInvalidate(request);
 
-  String handleInvalidate(HttpServletRequest request) {
-    URI uri = sessionManagement.getInvalidate(request);
-    return uri.toString();
+    assertThat(result, is(logoutUri.toString()));
   }
 }

--- a/ui-frontend/package.json
+++ b/ui-frontend/package.json
@@ -31,7 +31,7 @@
     "node": "20.x.x"
   },
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e",
     "exitzero": "^1.0.1",
     "mkdirp": "3.0.1",
     "rimraf": "6.0.1"

--- a/ui-frontend/packages/admin/package.json
+++ b/ui-frontend/packages/admin/package.json
@@ -13,7 +13,7 @@
     "node": "20.x.x"
   },
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e",
     "@types/dropzone": "5.0.6",
     "@types/lodash": "4.17.16",
     "@types/react": "16.9.34",

--- a/ui-frontend/packages/admin/src/main/webapp/components/session-timeout/session-timeout.tsx
+++ b/ui-frontend/packages/admin/src/main/webapp/components/session-timeout/session-timeout.tsx
@@ -30,8 +30,19 @@ function isLocalStorageAvailable() {
 
 const localStorageAvailable = isLocalStorageAvailable()
 
-const logout = () => {
-  window.location.replace(URLS.SESSION.INVALIDATE + window.location.href)
+const navigate = (url: string) => {
+  window.location.href = url
+}
+
+const logout = async () => {
+  try {
+    const res = await fetch(
+      URLS.SESSION.INVALIDATE + encodeURIComponent(window.location.href)
+    )
+    navigate(await res.text())
+  } catch {
+    window.location.reload()
+  }
 }
 
 const handleLocalStorageChange = ({

--- a/ui-frontend/packages/admin/yarn.lock
+++ b/ui-frontend/packages/admin/yarn.lock
@@ -858,9 +858,9 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd":
+"@connexta/ace@git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd"
+  resolved "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e"
   dependencies:
     "@babel/core" "7.26.0"
     "@babel/preset-env" "7.26.0"

--- a/ui-frontend/packages/catalog-ui-search/package.json
+++ b/ui-frontend/packages/catalog-ui-search/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/dom": "10.4.0",
     "@testing-library/react": "16.0.1",

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.spec.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import sessionTimeoutModel from './session-timeout'
+import chai from 'chai'
+
+const expect = chai.expect
+
+describe('session-timeout', () => {
+  it('logout() navigates to the URL returned by the invalidate endpoint', async () => {
+    const navigated: string[] = []
+    const originalNavigate = (sessionTimeoutModel as any).navigate
+    ;(sessionTimeoutModel as any).navigate = (url: string) => {
+      navigated.push(url)
+    }
+    try {
+      await (sessionTimeoutModel as any).logout()
+      expect(navigated).to.deep.equal(['/logout?service=test-logout'])
+    } finally {
+      ;(sessionTimeoutModel as any).navigate = originalNavigate
+    }
+  })
+})

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.ts
@@ -105,15 +105,21 @@ const sessionTimeoutModel = new (Backbone.Model.extend({
   stopListeningForUserActivity() {
     $(document).off('keydown.sessionTimeout mousedown.sessionTimeout')
   },
-  logout() {
+  navigate(url: string) {
+    window.location.href = url
+  },
+  async logout(): Promise<void> {
     if (window.onbeforeunload != null) {
       window.onbeforeunload = null
     }
-    fetch(invalidateUrl + window.location.href, {
-      redirect: 'manual',
-    }).finally(() => {
+    try {
+      const res = await fetch(
+        invalidateUrl + encodeURIComponent(window.location.href)
+      )
+      this.navigate(await res.text())
+    } catch {
       window.location.reload()
-    })
+    }
   },
   renew() {
     this.hidePrompt()

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/fetch/fetch.tsx
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/react-component/utils/fetch/fetch.tsx
@@ -115,11 +115,19 @@ export default async function (
 ): Promise<Response> {
   if (Environment.isTest()) {
     const { default: MockApi } = await import('../../../test/mock-api')
-    return Promise.resolve({
-      json: await function () {
-        return MockApi(url)
+    const data = MockApi(url)
+    type MockResponse = Pick<Response, 'json' | 'text'>
+    const mockResponse: MockResponse = {
+      json(): Promise<any> {
+        return Promise.resolve(data)
       },
-    }) as Promise<Response>
+      text(): Promise<string> {
+        return Promise.resolve(
+          typeof data === 'string' ? data : JSON.stringify(data)
+        )
+      },
+    }
+    return Promise.resolve(mockResponse as Response)
   }
   return fetch(cacheBust(url), {
     credentials: 'same-origin',

--- a/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
+++ b/ui-frontend/packages/catalog-ui-search/src/main/webapp/test/mock-api/index.ts
@@ -323,6 +323,7 @@ const mockDataMap = {
 }
 const mockDataGlobs = {
   './internal/enumerations': Enumerations,
+  './internal/session/invalidate': '/logout?service=test-logout',
 }
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'url' implicitly has an 'any' type.
 export default (url) => {

--- a/ui-frontend/packages/catalog-ui-search/yarn.lock
+++ b/ui-frontend/packages/catalog-ui-search/yarn.lock
@@ -906,9 +906,9 @@
   dependencies:
     commander "^2.15.1"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd":
+"@connexta/ace@git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd"
+  resolved "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e"
   dependencies:
     "@babel/core" "7.26.0"
     "@babel/preset-env" "7.26.0"

--- a/ui-frontend/packages/cesium-assets/package.json
+++ b/ui-frontend/packages/cesium-assets/package.json
@@ -20,7 +20,7 @@
   ],
   "context-path": "/search/catalog/cesium/assets",
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e",
     "mkdirp": "3.0.1",
     "npm": "10.9.2"
   }

--- a/ui-frontend/packages/cesium-assets/yarn.lock
+++ b/ui-frontend/packages/cesium-assets/yarn.lock
@@ -851,9 +851,9 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd":
+"@connexta/ace@git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd"
+  resolved "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e"
   dependencies:
     "@babel/core" "7.26.0"
     "@babel/preset-env" "7.26.0"

--- a/ui-frontend/packages/logout/package.json
+++ b/ui-frontend/packages/logout/package.json
@@ -13,7 +13,7 @@
     "node": "20.x.x"
   },
   "devDependencies": {
-    "@connexta/ace": "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd",
+    "@connexta/ace": "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.04",
     "autoprefixer": "10.4.20",

--- a/ui-frontend/packages/logout/yarn.lock
+++ b/ui-frontend/packages/logout/yarn.lock
@@ -851,9 +851,9 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd":
+"@connexta/ace@git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd"
+  resolved "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e"
   dependencies:
     "@babel/core" "7.26.0"
     "@babel/preset-env" "7.26.0"

--- a/ui-frontend/yarn.lock
+++ b/ui-frontend/yarn.lock
@@ -851,9 +851,9 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@connexta/ace@git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd":
+"@connexta/ace@git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e":
   version "1.0.0"
-  resolved "git+https://github.com/connexta/ace.git#3ae3c5c8c2deff00ad9912dc47fbea19d12e30dd"
+  resolved "git+https://github.com/connexta/ace.git#9cae103d3e6c6f1942051cbddd86c84257b4261e"
   dependencies:
     "@babel/core" "7.26.0"
     "@babel/preset-env" "7.26.0"


### PR DESCRIPTION
The session-timeout components in catalog-ui-search and admin were navigating
directly to /session/invalidate (browser redirect), so the Keycloak logout URL
returned in the response body was never used. The browser reloaded the current
page, the OIDC profile was still present, and the session was never properly
torn down through Keycloak, leaving users on "Logout Failed!" after idle expiry.

Change both components to fetch /session/invalidate and navigate to the URL
returned as response text, matching the flow the manual logout button already
used. Encode the return-to URL before appending it. Extract the Spark handler
into a named method for testability and add a test.